### PR TITLE
Unify common argument parsing for test/package commands

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Android/AndroidTestCommand.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Android
                 "usage: android test [OPTIONS]",
                 "",
                 "Executes tests on and Android device, waits up to a given timeout, then copies files off the device.",
-                { "app|a=", "Path to already-packaged app",  v => _arguments.AppPackagePath = v},
                 { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                     {
                         string[] argPair = v.Split('=');
@@ -38,12 +37,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Android
                     }
                 },
                 { "instrumentation|i=", "If specified, attempt to run instrumentation with this name instead of the default for the supplied APK.",  v => _arguments.InstrumentationName = v},
-                { "output-directory=", "Directory in which test results will be outputted", v => _arguments.OutputDirectory = v},
-                { "targets=", "Unused on Android",  v => { /* Ignore v but don't throw */ } },
-                { "timeout=", "Time span, in seconds, to wait for instrumentation to complete.", v => _arguments.Timeout = TimeSpan.FromSeconds(int.Parse(v)) },
-                { "working-directory=", "Directory in which other files (logs, etc) will be outputted", v => _arguments.WorkingDirectory = v},
-                { "help|h", "Show this message", v => ShowHelp = v != null }
             };
+
+            foreach (var option in CommonOptions)
+            {
+                Options.Add(option);
+            }
         }
 
         protected override Task<int> InvokeInternal()

--- a/src/Microsoft.DotNet.XHarness.CLI/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Android/AndroidTestCommandArguments.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.CLI.Common;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.XHarness.CLI.Android
+{
+    internal class AndroidTestCommandArguments : TestCommandArguments
+    {
+        /// <summary>
+        /// If specified, attempt to run instrumentation with this name instead of the default for the supplied APK
+        /// </summary>
+        public string InstrumentationName { get; set; }
+
+        public Dictionary<string, string> InstrumentationArguments { get; set; } = new Dictionary<string, string>();
+
+        public override bool TryValidate([NotNullWhen(true)] out IEnumerable<string> errors)
+        {
+            if (!base.TryValidate(out errors))
+            {
+                return false;
+            }
+
+            // TODO: Validate instrumentation
+
+            return true;
+        }
+
+        internal override IEnumerable<string> GetAvailableTargets()
+        {
+            return new[]
+            {
+                "TODO: To be filled in", // TODO
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/ICommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/ICommandArguments.cs
@@ -18,26 +18,26 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
         /// <summary>
         /// Path to packaged app
         /// </summary>
-        string AppPackagePath { get; }
+        string AppPackagePath { get; set; }
 
         /// <summary>
         /// List of targets to test
         /// </summary>
-        IReadOnlyCollection<string> Targets { get; }
+        IReadOnlyCollection<string> Targets { get; set; }
 
         /// <summary>
         /// How long XHarness should wait until a test execution completes before clean up (kill running apps, uninstall, etc)
         /// </summary>
-        TimeSpan Timeout { get; }
+        TimeSpan Timeout { get; set; }
 
         /// <summary>
         /// Path where the outputs of execution will be stored
         /// </summary>
-        string OutputDirectory { get; }
+        string OutputDirectory { get; set; }
 
         /// <summary>
         /// Path where run logs will hbe stored and projects
         /// </summary>
-        string WorkingDirectory { get; }
+        string WorkingDirectory { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/ICommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/ICommandArguments.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.DotNet.XHarness.CLI.Common
+{
+    internal interface ICommandArguments
+    {
+        bool TryValidate([NotNullWhen(true)]out IEnumerable<string> errors);
+    }
+
+    internal interface ITestCommandArguments : ICommandArguments
+    {
+        /// <summary>
+        /// Path to packaged app
+        /// </summary>
+        string AppPackagePath { get; }
+
+        /// <summary>
+        /// List of targets to test
+        /// </summary>
+        IReadOnlyCollection<string> Targets { get; }
+
+        /// <summary>
+        /// How long XHarness should wait until a test execution completes before clean up (kill running apps, uninstall, etc)
+        /// </summary>
+        TimeSpan Timeout { get; }
+
+        /// <summary>
+        /// Path where the outputs of execution will be stored
+        /// </summary>
+        string OutputDirectory { get; }
+
+        /// <summary>
+        /// Path where run logs will hbe stored and projects
+        /// </summary>
+        string WorkingDirectory { get; }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/PackageCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/PackageCommand.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Mono.Options;
+
+namespace Microsoft.DotNet.XHarness.CLI.Common
+{
+    internal abstract class PackageCommand : XHarnessCommand
+    {
+        protected override ICommandArguments Arguments => PackageArguments;
+        protected abstract IPackageCommandArguments PackageArguments { get; }
+
+        protected readonly OptionSet CommonOptions;
+
+        public PackageCommand() : base("package")
+        {
+            CommonOptions = new OptionSet
+            {
+                { "name=|n=", "Name of the test application",  v => PackageArguments.AppPackageName = v},
+                { "output-directory=|o=", "Directory in which the resulting package will be outputted", v => PackageArguments.OutputDirectory = v},
+                { "working-directory=|w=", "Directory in which the resulting package will be outputted", v => PackageArguments.WorkingDirectory = v},
+                { "help|h", "Show this message", v => ShowHelp = v != null }
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/PackageCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/PackageCommandArguments.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.XHarness.CLI.Common
+{
+    internal interface IPackageCommandArguments : ICommandArguments
+    {
+        /// <summary>
+        /// Name of the packaged app
+        /// </summary>
+        string AppPackageName { get; set; }
+
+        /// <summary>
+        /// Path where the outputs of execution will be stored
+        /// </summary>
+        string OutputDirectory { get; set; }
+
+        /// <summary>
+        /// Path where run logs will hbe stored and projects
+        /// </summary>
+        string WorkingDirectory { get; set; }
+    }
+
+    internal abstract class PackageCommandArguments : IPackageCommandArguments
+    {
+        public string AppPackageName { get; set; }
+        public string OutputDirectory { get; set; }
+        public string WorkingDirectory { get; set; }
+
+        public virtual bool TryValidate([NotNullWhen(true)] out IEnumerable<string> errors)
+        {
+            var errs = new List<string>();
+            errors = errs;
+
+            if (string.IsNullOrEmpty(AppPackageName))
+            {
+                errs.Add("You must provide a name for the application to be created.");
+            }
+
+            if (string.IsNullOrEmpty(OutputDirectory))
+            {
+                errs.Add("Output directory path missing.");
+            }
+            else
+            {
+                if (!Path.IsPathRooted(OutputDirectory))
+                {
+                    OutputDirectory = Path.Combine(Directory.GetCurrentDirectory(), OutputDirectory);
+                }
+
+                if (!Directory.Exists(OutputDirectory))
+                {
+                    Directory.CreateDirectory(OutputDirectory);
+                }
+            }
+
+            if (string.IsNullOrEmpty(WorkingDirectory))
+            {
+                errs.Add("Working directory path missing.");
+            }
+            else
+            {
+                if (!Path.IsPathRooted(WorkingDirectory))
+                {
+                    WorkingDirectory = Path.Combine(Directory.GetCurrentDirectory(), WorkingDirectory);
+                }
+
+                if (!Directory.Exists(WorkingDirectory))
+                {
+                    Directory.CreateDirectory(WorkingDirectory);
+                }
+            }
+
+            return !errors.Any();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommand.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Mono.Options;
-
 namespace Microsoft.DotNet.XHarness.CLI.Common
 {
-    public abstract class TestCommand : Command
+    internal abstract class TestCommand : XHarnessCommand
     {
+        protected override ICommandArguments Arguments => TestArguments;
+        protected abstract ITestCommandArguments TestArguments { get; }
+
         public TestCommand() : base("test")
         {
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommand.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Mono.Options;
+
 namespace Microsoft.DotNet.XHarness.CLI.Common
 {
     internal abstract class TestCommand : XHarnessCommand
@@ -9,8 +12,19 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
         protected override ICommandArguments Arguments => TestArguments;
         protected abstract ITestCommandArguments TestArguments { get; }
 
+        protected readonly OptionSet CommonOptions;
+
         public TestCommand() : base("test")
         {
+            CommonOptions = new OptionSet
+            {
+                { "app|a=", "Path to already-packaged app", v => TestArguments.AppPackagePath = v },
+                { "output-directory=|o=", "Directory in which the resulting package will be outputted", v => TestArguments.OutputDirectory = v},
+                { "targets=", "Comma-delineated list of targets to test for", v=> TestArguments.Targets = v.Split(',') },
+                { "timeout=|t=", "Time span, in seconds, to wait for instrumentation to complete.", v => TestArguments.Timeout = TimeSpan.FromSeconds(int.Parse(v))},
+                { "working-directory=|w=", "Directory in which the resulting package will be outputted", v => TestArguments.WorkingDirectory = v},
+                { "help|h", "Show this message", v => ShowHelp = v != null }
+            };
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
@@ -62,12 +62,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
                 }
             }
 
-            if (Targets.Count == 0)
+            if (Targets == null || Targets.Count == 0)
             {
                 errs.Add("0 targets specified. At least one target must be provided. " +
                     "Available targets are:" +
-                    Environment.NewLine +
-                    string.Join(Environment.NewLine, GetAvailableTargets()));
+                    Environment.NewLine + "\t" +
+                    string.Join(Environment.NewLine + "\t", GetAvailableTargets()));
             }
 
             return !errors.Any();

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.XHarness.CLI.Common
+{
+    internal abstract class TestCommandArguments : ITestCommandArguments
+    {
+        public string AppPackagePath { get; set; }
+        public IReadOnlyCollection<string> Targets { get; set; }
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(5);
+        public string OutputDirectory { get; set; }
+        public string WorkingDirectory { get; set; }
+
+        public virtual bool TryValidate([NotNullWhen(true)] out IEnumerable<string> errors)
+        {
+            var errs = new List<string>();
+            errors = errs;
+
+            if (string.IsNullOrEmpty(AppPackagePath))
+            {
+                errs.Add("You must provide a name for the application to be created.");
+            }
+
+            if (string.IsNullOrEmpty(OutputDirectory))
+            {
+                errs.Add("Output directory path missing.");
+            }
+            else
+            {
+                if (!Path.IsPathRooted(OutputDirectory))
+                {
+                    OutputDirectory = Path.Combine(Directory.GetCurrentDirectory(), OutputDirectory);
+                }
+
+                if (!Directory.Exists(OutputDirectory))
+                {
+                    Directory.CreateDirectory(OutputDirectory);
+                }
+            }
+
+            if (string.IsNullOrEmpty(WorkingDirectory))
+            {
+                errs.Add("Working directory path missing.");
+            }
+            else
+            {
+                if (!Path.IsPathRooted(WorkingDirectory))
+                {
+                    WorkingDirectory = Path.Combine(Directory.GetCurrentDirectory(), WorkingDirectory);
+                }
+
+                if (!Directory.Exists(WorkingDirectory))
+                {
+                    Directory.CreateDirectory(WorkingDirectory);
+                }
+            }
+
+            if (Targets.Count == 0)
+            {
+                errs.Add("0 targets specified. At least one target must be provided. " +
+                    "Available targets are:" +
+                    Environment.NewLine +
+                    string.Join(Environment.NewLine, GetAvailableTargets()));
+            }
+
+            return !errors.Any();
+        }
+
+        internal abstract IEnumerable<string> GetAvailableTargets();
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/TestCommandArguments.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
 
             if (string.IsNullOrEmpty(AppPackagePath))
             {
-                errs.Add("You must provide a name for the application to be created.");
+                errs.Add("You must provide a name for the application that will be tested.");
             }
 
             if (string.IsNullOrEmpty(OutputDirectory))

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
                 Console.Error.WriteLine("Invalid arguments:");
                 foreach (string error in errors)
                 {
-                    Console.Error.WriteLine(error);
+                    Console.Error.WriteLine("  - " + error);
                 }
 
                 return 1;

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mono.Options;
+
+namespace Microsoft.DotNet.XHarness.CLI.Common
+{
+    internal abstract class XHarnessCommand : Command
+    {
+        protected abstract ICommandArguments Arguments { get; }
+
+        protected bool ShowHelp = false;
+
+        protected XHarnessCommand(string name) : base(name)
+        {
+        }
+
+        public override sealed int Invoke(IEnumerable<string> arguments)
+        {
+            var extra = Options.Parse(arguments);
+
+            if (ShowHelp)
+            {
+                Options.WriteOptionDescriptions(Console.Out);
+                return 0;
+            }
+
+            if (extra.Count > 0)
+            {
+                Console.Error.WriteLine($"Unknown arguments{string.Join(" ", extra)}");
+                Options.WriteOptionDescriptions(Console.Out);
+                return 1;
+            }
+
+            if (!Arguments.TryValidate(out var errors))
+            {
+                Console.Error.WriteLine("Invalid arguments:");
+                foreach (string error in errors)
+                {
+                    Console.Error.WriteLine(error);
+                }
+
+                return 1;
+            }
+
+            return InvokeInternal().GetAwaiter().GetResult();
+        }
+
+        protected abstract Task<int> InvokeInternal();
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSPackageCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSPackageCommandArguments.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.DotNet.XHarness.CLI.Common;
+
+namespace Microsoft.DotNet.XHarness.CLI.iOS
+{
+    internal class iOSPackageCommandArguments : PackageCommandArguments
+    {
+        /// <summary>
+        /// A path that is the root of the .ignore files that will be used to skip tests if needed
+        /// </summary>
+        public string IgnoreFilesRootDirectory { get; set; }
+
+        /// <summary>
+        /// A path that is the root of the traits txt files that will be used to skip tests if needed
+        /// </summary>
+        public string TraitsRootDirectory { get; set; }
+
+        public string MtouchExtraArgs { get; set; }
+
+        public TemplateType SelectedTemplateType { get; set; }
+
+        public override bool TryValidate([NotNullWhen(true)] out IEnumerable<string> errors)
+        {
+            if (!base.TryValidate(out errors))
+            {
+                return false;
+            }
+
+            // TODO: Validate the above
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
@@ -5,30 +5,17 @@
 using Microsoft.DotNet.XHarness.CLI.Common;
 using Mono.Options;
 using System;
-using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.XHarness.CLI.iOS
 {
     /// <summary>
     /// Command which executes a given, already-packaged iOS application, waits on it and returns status based on the outcome.
     /// </summary>
-    public class iOSTestCommand : TestCommand
+    internal class iOSTestCommand : TestCommand
     {
-        // Path to packaged app
-        private string _applicationPath = "";
-
-        // List of targets to test.
-        private string[] _targets = Array.Empty<string>();
-
-        // Path where the outputs of execution will be stored.
-        private string _outputDirectory = "";
-
-        // Path where run logs will hbe stored and projects
-        private string _workingDirectory = "";
-
-        // How long XHarness should wait until a test execution completes before clean up (kill running apps, uninstall, etc)
-        private int _timeoutInSeconds = 300;
-        private bool _showHelp = false;
+        private readonly iOSTestCommandArguments _arguments = new iOSTestCommandArguments();
+        protected override ITestCommandArguments TestArguments => _arguments;
 
         public iOSTestCommand() : base()
         {
@@ -36,36 +23,25 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                 "usage: ios test [OPTIONS]",
                 "",
                 "Packaging command that will create a iOS/tvOS/watchOS or macOS application that can be used to run NUnit or XUnit-based test dlls",
-                { "app|a=", "Path to already-packaged app",  v => _applicationPath = v},
-                { "output-directory=|o=", "Directory in which the resulting package will be outputted", v => _outputDirectory = v},
-                { "targets=", "Comma-delineated list of targets to test for", v=> _targets = v.Split(',') },
-                { "timeout=|t=", "Time span, in seconds, to wait for instrumentation to complete.", v => _timeoutInSeconds = int.Parse(v)},
-                { "working-directory=|w=", "Directory in which the resulting package will be outputted", v => _workingDirectory = v},
-                { "help|h", "Show this message", v => _showHelp = v != null }
+                { "app|a=", "Path to already-packaged app",  v => _arguments.AppPackagePath = v},
+                { "output-directory=|o=", "Directory in which the resulting package will be outputted", v => _arguments.OutputDirectory = v},
+                { "targets=", "Comma-delineated list of targets to test for", v=> _arguments.Targets = v.Split(',') },
+                { "timeout=|t=", "Time span, in seconds, to wait for instrumentation to complete.", v => _arguments.Timeout = TimeSpan.FromSeconds(int.Parse(v))},
+                { "working-directory=|w=", "Directory in which the resulting package will be outputted", v => _arguments.WorkingDirectory = v},
+                { "help|h", "Show this message", v => ShowHelp = v != null }
             };
         }
 
-        public override int Invoke(IEnumerable<string> arguments)
+        protected override Task<int> InvokeInternal()
         {
-            // Deal with unknown options and print nicely
-            var extra = Options.Parse(arguments);
-            if (_showHelp)
-            {
-                Options.WriteOptionDescriptions(Console.Out);
-                return 1;
-            }
+            Console.WriteLine($"iOS Test command called:");
+            Console.WriteLine($"  App: {_arguments.AppPackagePath}");
+            Console.WriteLine($"  Targets: {string.Join(',', _arguments.Targets)}");
+            Console.WriteLine($"  Output Directory: {_arguments.OutputDirectory}");
+            Console.WriteLine($"  Working Directory: {_arguments.WorkingDirectory}");
+            Console.WriteLine($"  Timeout: {_arguments.Timeout.TotalSeconds}s");
 
-            if (extra.Count > 0)
-            {
-                Console.WriteLine($"Unknown arguments: {string.Join(" ", extra)}");
-                Options.WriteOptionDescriptions(Console.Out);
-                return 2;
-            }
-
-            Console.WriteLine($"iOS Test command called:{Environment.NewLine}App:{_applicationPath}{Environment.NewLine}Targets:{string.Join(',', _targets)}");
-            Console.WriteLine($"Output Directory:{_outputDirectory}{Environment.NewLine}Working Directory:{_workingDirectory}{Environment.NewLine}Timeout:{_timeoutInSeconds}s");
-
-            return 0;
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
@@ -23,13 +23,12 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                 "usage: ios test [OPTIONS]",
                 "",
                 "Packaging command that will create a iOS/tvOS/watchOS or macOS application that can be used to run NUnit or XUnit-based test dlls",
-                { "app|a=", "Path to already-packaged app",  v => _arguments.AppPackagePath = v},
-                { "output-directory=|o=", "Directory in which the resulting package will be outputted", v => _arguments.OutputDirectory = v},
-                { "targets=", "Comma-delineated list of targets to test for", v=> _arguments.Targets = v.Split(',') },
-                { "timeout=|t=", "Time span, in seconds, to wait for instrumentation to complete.", v => _arguments.Timeout = TimeSpan.FromSeconds(int.Parse(v))},
-                { "working-directory=|w=", "Directory in which the resulting package will be outputted", v => _arguments.WorkingDirectory = v},
-                { "help|h", "Show this message", v => ShowHelp = v != null }
             };
+
+            foreach (var option in CommonOptions)
+            {
+                Options.Add(option);
+            }
         }
 
         protected override Task<int> InvokeInternal()

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.CLI.Common;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.XHarness.CLI.iOS
+{
+    internal class iOSTestCommandArguments : TestCommandArguments
+    {
+        internal override IEnumerable<string> GetAvailableTargets()
+        {
+            return new[]
+            {
+                "None",
+                "Simulator_iOS",
+                "Simulator_iOS32",
+                "Simulator_iOS64",
+                "Simulator_tvOS",
+                "Simulator_watchOS",
+                "Device_iOS",
+                "Device_tvOS",
+                "Device_watchOS",
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.CLI.iOS
 {
+
     internal class iOSTestCommandArguments : TestCommandArguments
     {
         internal override IEnumerable<string> GetAvailableTargets()


### PR DESCRIPTION
Common arguments and their validation is now handled in one place for Android and iOS platforms.

This should help make sure our Android and iOS CLI won't digress much and should help reduce the need to write validation boilerplate twice. It also allows to write async implementation of the commands which was cumbersome to do before.