### PR TITLE
Force LF EOLs in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Apply LF to shell scripts automatically
+*.sh text eol=lf


### PR DESCRIPTION
Repo was initialized with arcade scripts having LF and they cannot be executed on Linux