### PR TITLE
Download and unzip ADB from android tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 # Local installations of .net core
 .dotnet/
 
+# Locally restored packages (when simulating AzDO build)
+.packages/
+

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.1.101",
+    "dotnet": "3.1.201",
     "runtimes": {
       "dotnet": [
         "2.1.11"

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.XHarness.Android
         #region Constructor and state variables
 
         // When packaged as a DotNet CLI tool, this should always be a minimal adb.exe
-        private const string DefaultAdbExePath = @"..\..\..\content\adb.exe";
+        private const string DefaultAdbExePath = @"..\..\..\content\adb\adb.exe";
         private const string AdbEnvironmentVariableName = "ADB_EXE_PATH";
 
         private readonly string _absoluteAdbExePath;

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -15,14 +15,14 @@ namespace Microsoft.DotNet.XHarness.Android
     {
         #region Constructor and state variables
 
-
-
+        // When packaged as a DotNet CLI tool, this should always be a minimal adb.exe
+        private const string DefaultAdbExePath = @"..\..\..\content\adb.exe";
         private const string AdbEnvironmentVariableName = "ADB_EXE_PATH";
 
         private readonly string _absoluteAdbExePath;
         private readonly ILogger _log;
 
-        public AdbRunner(ILogger log, string adbExePath = ".\\adb.exe")
+        public AdbRunner(ILogger log, string adbExePath = DefaultAdbExePath)
         {
             _log = log ?? throw new ArgumentNullException(nameof(log));
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -1,6 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- When updating, avoid using 'latest' url as this can make the same commit build differently on different days -->
+    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
+    <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
+  
+    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unsued. -->
+    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
+    <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
+  </PropertyGroup>
+
+  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" >
+    <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" />
+    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
+    <ItemGroup>
+      <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
+      <Content Include="@(WindowsAdbFiles)">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -28,7 +28,7 @@
     <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
     <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
   
-    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unsued. -->
+    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unused. -->
     <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
     <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -1,27 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- When updating, avoid using 'latest' url as this can make the same commit build differently on different days -->
-    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
-    <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
-  
-    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unsued. -->
-    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
-    <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
-  </PropertyGroup>
-
-  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" >
-    <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" />
-    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
-    <ItemGroup>
-      <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
-      <Content Include="@(WindowsAdbFiles)">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-  </Target>
-
-  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>true</IsPackable>
@@ -43,4 +22,28 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.XHarness.Android\Microsoft.DotNet.XHarness.Android.csproj" />
   </ItemGroup>
+  
+  <PropertyGroup>
+    <!-- When updating, avoid using 'latest' url as this can make the same commit build differently on different days -->
+    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
+    <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
+  
+    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unsued. -->
+    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
+    <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
+  </PropertyGroup>
+
+  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" >
+    <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
+    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
+    <ItemGroup>
+      <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
+      <Content Include="@(WindowsAdbFiles)">
+        <Pack>true</Pack>
+        <PackagePath>content/adb</PackagePath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+  </Target>
+  
 </Project>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -10,8 +10,9 @@
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>
 
+  <!-- Suppress NU5100 because there are ADB .DLLs we don't reference which we want as 'content' type -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>$(NoWarn);1701;1702;1705;1591;NU5105</NoWarn>
+    <NoWarn>$(NoWarn);1701;1702;1705;1591;NU5105;NU5100</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should probably be in Microsoft.DotNet.XHarness.Android but I couldn't get it to end up in the Nupkg without putting it in the CLI project

I asked a couple folks, also tagging @rainersigwald  in case he has ideas.  Basically I'd like to have this ADB stuff be in the referenced Android project and not the CLI, and I failed to make that happen so I just stuck it in the CLI project for now.  Is this fixable?