### PR TITLE
Fix case sensitivity issue (Xunit vs xUnit) in dotnet build

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
@@ -8,26 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Core\" />
-    <Folder Include="Xunit\" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Remove="xUnit\NUnit3Xml.xslt" />
-    <None Remove="xUnit\NUnitXml.xslt" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Xunit\NUnit3Xml.xslt">
+    <EmbeddedResource Include="xUnit\NUnit3Xml.xslt">
       <XlfSourceFormat></XlfSourceFormat>
       <XlfOutputItem></XlfOutputItem>
     </EmbeddedResource>
-    <EmbeddedResource Include="Xunit\NUnitXml.xslt">
+    <EmbeddedResource Include="xUnit\NUnitXml.xslt">
       <XlfSourceFormat></XlfSourceFormat>
       <XlfOutputItem></XlfOutputItem>
     </EmbeddedResource>


### PR DESCRIPTION
I was trying to build in Ubuntu and the build broke because of case conflict between the csproj and the folder name. Not sure how MacOS builds ok but fixing this.

Also removing unnecessary sections from csproj