### PR TITLE
Do not build Release for PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ stages:
       enablePublishUsingPipelines: true
       enablePublishBuildAssets: true
       helixRepo: dotnet/xharness
-      
+
       jobs:
       - job: Windows_NT
         pool:
@@ -57,8 +57,9 @@ stages:
             queue: BuildPool.Server.Amd64.VS2019.Open
         strategy:
           matrix:
-            release_configuration:
-              _BuildConfig: Release
+            ${{ if ne(variables._RunAsPublic, True) }}:
+              release_configuration:
+                _BuildConfig: Release
             ${{ if eq(variables._RunAsPublic, True) }}:
               debug_configuration:
                 _BuildConfig: Debug
@@ -84,11 +85,12 @@ stages:
           name: Hosted macOS
         strategy:
           matrix:
-            release_configuration:
-              _BuildConfig: Release
+            ${{ if ne(variables._RunAsPublic, True) }}:
+              release_configuration:
+                _BuildConfig: Release
             ${{ if eq(variables._RunAsPublic, True) }}:
               debug_configuration:
-                _BuildConfig: Debug            
+                _BuildConfig: Debug
         steps:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
@@ -105,7 +107,7 @@ stages:
             ArtifactName: $(Agent.Os)_$(Agent.JobName)
           continueOnError: true
           condition: always()
-        
+
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
@@ -128,4 +130,3 @@ stages:
         -TsaRepositoryName "Arcade"
         -TsaCodebaseName "Arcade"
         -TsaPublish $True'
-        


### PR DESCRIPTION
I was thinking we could only do Debug for PRs and in Debug skip things like downloading mlaunch and ADB which we don't really need?

@MattGal I don't have much experience in whether it will become hard for us to maintain green internal pipeline if we do what I propose here but maybe it is the right to do will the decreased capacity we are seeing these days? Let me know what you think.