### PR TITLE
Move ADB.exe to try to suppress NU5100

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -10,7 +10,6 @@
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>
 
-  <!-- Suppress NU5100 because there are ADB .DLLs we don't reference which we want as 'content' type -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>$(NoWarn);1701;1702;1705;1591;NU5105;NU5100</NoWarn>
   </PropertyGroup>
@@ -42,7 +41,7 @@
       <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
       <Content Include="@(WindowsAdbFiles)">
         <Pack>true</Pack>
-        <PackagePath>content/adb</PackagePath>
+        <PackagePath>runtimes/any/native/adb/windows</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>


### PR DESCRIPTION
Should fix build errors.  I locally verified that the lookup path behavior does not work on Windows too. 

Was meant to be part of https://github.com/dotnet/xharness/pull/27