### PR TITLE
[Runners] Add events to notify that a test run started and completed.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -36,10 +36,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             logger.MinimumLogLevel = MinimumLogLevel.Info;
             var testAssemblies = GetTestAssemblies();
 
-            var runner = await CreateRunner(logger);
-
-            // if we have ignore files, ignore those tests
-            await runner.Run(testAssemblies).ConfigureAwait(false);
+            var runner = await InternalRunAsync(logger);
 
             TestRunner.Jargon jargon = Core.TestRunner.Jargon.NUnitV3;
             switch (options.XmlVersion)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/TestRunResult.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/TestRunResult.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.DotNet.XHarness.Tests.Runners.Core;
+
+namespace Microsoft.DotNet.XHarness.Tests.Runners
+{
+    public struct TestRunResult 
+    {
+        /// <summary>
+        /// Retrieve the number of executed tests in a run.
+        /// </summary>
+        public long ExecutedTests { get; private set; }
+        
+        /// <summary>
+        /// Retrieve the number of failed tests in a run.
+        /// </summary>
+        public long FailedTests { get; private set; }
+
+        /// <summary>
+        /// Retrieve the number of not executed tests due to the filters in a
+        /// run.
+        /// </summary>
+        public long FilteredTests { get; private set; }
+
+        /// <summary>
+        /// Retrieve the number of inconclusive tests in a run.
+        /// </summary>
+        public long InconclusiveTests { get; private set; }
+
+        /// <summary>
+        /// Retrieve the number of passed tests in a run.
+        /// </summary>
+        public long PassedTests { get; private set; }
+
+        /// <summary>
+        /// Retrieve the number of skipped tests in a run.
+        /// </summary>
+        public long SkippedTests { get; private set; }
+
+        /// <summary>
+        /// Retrieve the total number of tests in a run. This value
+        /// includes all skipped and filtered tests and might no be equal
+        /// to the value returned by ExecutedTests.
+        /// </summary>
+        public long TotalTests { get; private set; }
+
+        internal TestRunResult(TestRunner runner) {
+            ExecutedTests = runner.ExecutedTests;
+            FailedTests = runner.FailedTests;
+            FilteredTests = runner.FilteredTests;
+            InconclusiveTests = runner.InconclusiveTests;
+            PassedTests = runner.PassedTests;
+            SkippedTests = runner.SkippedTests;
+            TotalTests = runner.TotalTests;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
@@ -31,11 +31,9 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
             // we will write the normal console output using the LogWriter
             var logger = (writer == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, writer);
             logger.MinimumLogLevel = MinimumLogLevel.Info;
-            var testAssemblies = GetTestAssemblies();
-            var runner = await CreateRunner(logger);
 
             // if we have ignore files, ignore those tests
-            await runner.Run(testAssemblies).ConfigureAwait(false);
+            var runner = await InternalRunAsync(logger);
 
             TestRunner.Jargon jargon = Core.TestRunner.Jargon.NUnitV3;
             switch (options.XmlVersion)


### PR DESCRIPTION
Add two events that notify when the runner started and when it
completed. The completed event will provide information of the results
of the run.

Later we can look at adding event for each of the tests starting and
completing, which is possible, but we are not going to add events that
we have not been asked to add. KISS

fixes: https://github.com/dotnet/xharness/issues/36