### PR TITLE
[Runners] Provide events to notify when a test has started or completed.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestResult.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestResult.cs
@@ -1,0 +1,22 @@
+﻿using System;
+namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
+{
+    /// <summary>
+    /// Enumeration used to state the result of a test.
+    /// </summary>
+    public enum TestResult
+    {
+        /// <summary>
+        /// Test was executed and passed.
+        /// </summary>
+        Passed,
+        /// <summary>
+        /// Test was executed and failed.
+        /// </summary>
+        Failed,
+        /// <summary>
+        /// Test was not executed but was skipped.
+        /// </summary>
+        Skipped,
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
@@ -22,6 +22,16 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         }
 
         /// <summary>
+        /// Event raised when a test has started.
+        /// </summary>
+        public event EventHandler<string> TestStarted;
+
+        /// <summary>
+        /// Event raised when a test has completed or has been skipped.
+        /// </summary>
+        public event EventHandler<(string TestName, TestResult TestResult)> TestCompleted;
+
+        /// <summary>
         /// Number of inconclusive tests.
         /// </summary>
         public long InconclusiveTests { get; protected set; } = 0;
@@ -179,5 +189,19 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                 Directory.CreateDirectory(resultsPath);
             return Path.Combine(resultsPath, ResultsFileName);
         }
+
+        protected virtual void OnTestStarted(string testName)
+        {
+            var hanlder = TestStarted;
+            if (hanlder != null)
+                hanlder(this, testName);
+        }
+
+        protected virtual void OnTestCompleted((string TestName, TestResult TestResult) result)
+        {
+            var handler = TestCompleted;
+            if (handler != null)
+                handler(this, result); 
+		}
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -262,6 +262,10 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             });
             OnInfo($"\t[FAIL] {args.Message.Test.TestCase.DisplayName}");
             OnInfo(sb.ToString());
+            OnTestCompleted((
+                TestName: args.Message.Test.DisplayName,
+                TestResult: TestResult.Failed
+            ));
         }
 
         void HandleTestCollectionStarting(MessageHandlerArgs<ITestCollectionStarting> args)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -141,6 +141,11 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             LogTestDetails(args.Message.Test, log: OnDebug);
             LogTestOutput(args.Message, log: OnDiagnostic);
             ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+            // notify that the test completed because it was skipped
+            OnTestCompleted((
+                TestName: args.Message.Test.DisplayName,
+                TestResult: TestResult.Skipped
+            ));
         }
 
         void HandleTestPassed(MessageHandlerArgs<ITestPassed> args)
@@ -153,6 +158,11 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             LogTestDetails(args.Message.Test, log: OnDebug);
             LogTestOutput(args.Message, log: OnDiagnostic);
             ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
+            // notify the completion of the test
+            OnTestCompleted((
+				TestName: args.Message.Test.DisplayName,
+                TestResult: TestResult.Passed
+            ));
         }
 
         void HandleTestOutput(MessageHandlerArgs<ITestOutput> args)
@@ -202,7 +212,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
         {
             if (args == null || args.Message == null)
                 return;
-
             ExecutedTests++;
             OnDiagnostic("Test finished");
             LogTestDetails(args.Message.Test, log: OnDiagnostic);
@@ -458,6 +467,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (args == null || args.Message == null)
                 return;
 
+            // notify that a method is starting
+            OnTestStarted(args.Message.Test.DisplayName);
             OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' starting");
         }
 
@@ -465,7 +476,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
         {
             if (args == null || args.Message == null)
                 return;
-
             OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' finished");
         }
 

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
             // notify the completion of the test
             OnTestCompleted((
-				TestName: args.Message.Test.DisplayName,
+                TestName: args.Message.Test.DisplayName,
                 TestResult: TestResult.Passed
             ));
         }


### PR DESCRIPTION
Add event to the base class and each of the runner implementations will
call it using the provided protected methods.

Expose the events via the ApplicationEntryPoint base class that will
connect to the runner and fwd the events.

fixes: https://github.com/dotnet/xharness/issues/50