### PR TITLE
[Runners] Add the default ActiveIssue category.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
     /// </summary>
     public abstract class ApplicationEntryPoint
     {
-
+        const string ActiveIssueCategory = "ActiveIssue";
         /// <summary>
         /// Event raised when the test run has started.
         /// </summary>
@@ -133,12 +133,12 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             // connect to the runner events so that we fwd them to the client
             runner.TestStarted += OnTestStarted;
             runner.TestCompleted += OnTestCompleted;
+            var categories = new List<string> { ActiveIssueCategory }; // default known category to ignore
 
             if (!string.IsNullOrEmpty(IgnoreFilesDirectory))
             {
-                var categories = await IgnoreFileParser.ParseTraitsContentFileAsync(IgnoreFilesDirectory, TestRunner == TestRunnerType.Xunit);
+                categories.AddRange (await IgnoreFileParser.ParseTraitsContentFileAsync(IgnoreFilesDirectory, TestRunner == TestRunnerType.Xunit));
                 // add category filters if they have been added
-                runner.SkipCategories(categories);
 
                 var skippedTests = await IgnoreFileParser.ParseContentFilesAsync(IgnoreFilesDirectory);
                 if (skippedTests.Any())
@@ -147,6 +147,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
                     runner.SkipTests(skippedTests);
                 }
             }
+
+            runner.SkipCategories(categories);
 
             var testAssemblies = GetTestAssemblies();
             // notify the clients we are starting

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -1172,7 +1172,12 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                 foreach (var c in categories)
                 {
                     var traitInfo = c.Split('=');
-                    filters.Add(XUnitFilter.CreateTraitFilter(traitInfo[0], traitInfo[1], true));
+                    if (traitInfo.Length == 2)
+                    {
+                        filters.Add(XUnitFilter.CreateTraitFilter(traitInfo[0], traitInfo[1], true));
+                    } else { 
+                        filters.Add(XUnitFilter.CreateTraitFilter(c, null, true));
+					}
                 }
             }
         }


### PR DESCRIPTION
Add a default category filter on [ActiveIssue] ignoring the url given in
the trait. This will ensure that ActiveIssues from netcore are not
executed.

fixes: https://github.com/dotnet/xharness/issues/53