### PR TITLE
[Runners] Raise the start event before the tests executes.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -455,6 +455,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (args == null || args.Message == null)
                 return;
 
+            // notify that a method is starting
+            OnTestStarted(args.Message.Test.DisplayName);
             OnDiagnostic($"'Before' method for test '{args.Message.Test.DisplayName}' starting");
         }
 
@@ -471,8 +473,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (args == null || args.Message == null)
                 return;
 
-            // notify that a method is starting
-            OnTestStarted(args.Message.Test.DisplayName);
             OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' starting");
         }
 


### PR DESCRIPTION
The OnTestStarted was being called in the HandleAfterTestStarting. That
means that the event might not be raised if there is an issue with the
test setup, making it hard to track. Moved the call to the
HandleBeforeTestStarting to notify the test is going to strat which will
execute before any issue occurs.

fixes: https://github.com/dotnet/xharness/issues/54