### PR TITLE
[iOS] Add basic classes to support the usage of tunnels.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
             var processManager = new ProcessManager(_arguments.XcodeRoot, _arguments.MlaunchPath);
             var deviceLoader = new HardwareDeviceLoader(processManager);
             var simulatorLoader = new SimulatorLoader(processManager);
+            var tunnelBore = new TunnelBore(processManager);
 
             var logs = new Logs(_arguments.OutputDirectory);
             var cancellationToken = new CancellationToken(); // TODO: Get cancellation from command line env? Set timeout through it?
@@ -59,7 +60,7 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
 
             foreach (TestTarget target in _arguments.TestTargets)
             {
-                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader, cancellationToken);
+                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader, tunnelBore, cancellationToken);
 
                 if (exitCodeForRun != ExitCode.SUCCESS)
                 {
@@ -75,6 +76,7 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
             ProcessManager processManager,
             IHardwareDeviceLoader deviceLoader,
             ISimulatorLoader simulatorLoader,
+            ITunnelBore tunnelBore,
             CancellationToken cancellationToken = default)
         {
             _log.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
@@ -141,7 +143,7 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                     processManager,
                     deviceLoader,
                     simulatorLoader,
-                    new SimpleListenerFactory(),
+                    new SimpleListenerFactory(tunnelBore),
                     new CrashSnapshotReporterFactory(processManager),
                     new CaptureLogFactory(),
                     new DeviceLogCapturerFactory(processManager),

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -455,6 +455,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (args == null || args.Message == null)
                 return;
 
+            // notify that a method is starting
+            OnTestStarted(args.Message.Test.DisplayName);
             OnDiagnostic($"'Before' method for test '{args.Message.Test.DisplayName}' starting");
         }
 
@@ -471,8 +473,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (args == null || args.Message == null)
                 return;
 
-            // notify that a method is starting
-            OnTestStarted(args.Message.Test.DisplayName);
             OnDiagnostic($"'After' method for test '{args.Message.Test.DisplayName}' starting");
         }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/Arguments.cs
@@ -318,4 +318,21 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch
 
         public override string AsCommandLineArgument() => "-v";
     }
+
+    /// <summary>
+    /// Create a tcp tunnel with the iOS device from the host.
+    /// </summary>
+    public sealed class TcpTunnelArgument : MlaunchArgument
+    {
+        readonly int port;
+
+        public TcpTunnelArgument(int port)
+        {
+            if (port <= 0)
+                throw new ArgumentOutOfRangeException(nameof(port));
+            this.port = port;
+        }
+
+        public override string AsCommandLineArgument() => $"--tcp-tunnel={port}:{port}";
+    }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -21,18 +21,27 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             ILog listenerLog,
             bool isSimulator,
             bool autoExit,
-            bool xmlOutput);
+            bool xmlOutput,
+            bool useTcpTunnel);
     }
 
     public class SimpleListenerFactory : ISimpleListenerFactory
     {
+
+        public ITunnelBore TunnelBore { get; private set; }
+
+        public SimpleListenerFactory(ITunnelBore tunnelBore)
+        {
+            TunnelBore = tunnelBore ?? throw new ArgumentNullException(nameof(tunnelBore));
+        }
 
         public (ListenerTransport transport, ISimpleListener listener, string listenerTempFile) Create(RunMode mode,
             ILog log,
             ILog listenerLog,
             bool isSimulator,
             bool autoExit,
-            bool xmlOutput)
+            bool xmlOutput,
+            bool useTcpTunnel)
         {
             string listenerTempFile = null;
             ISimpleListener listener;
@@ -57,7 +66,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     listener = new SimpleHttpListener(log, listenerLog, autoExit, xmlOutput);
                     break;
                 case ListenerTransport.Tcp:
-                    listener = new SimpleTcpListener(log, listenerLog, autoExit, xmlOutput);
+                    listener = new SimpleTcpListener(log, listenerLog, autoExit, xmlOutput, useTcpTunnel);
                     break;
                 default:
                     throw new NotImplementedException("Unknown type of listener");

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             {
                 var se = e as SocketException;
                 if (se == null || se.SocketErrorCode != SocketError.Interrupted)
-                    Console.WriteLine("[{0}] : {1}", DateTime.Now, e);
+                    Log.WriteLine("[{0}] : {1}", DateTime.Now, e);
             }
             finally
             {
@@ -131,6 +131,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                             // Give up after 2 minutes.
                             throw ex;
                         }
+                        Log.WriteLine($"Could not connet to tcp tunnel. Rerrying in {timeout} milliseconds.");
                         Thread.Sleep(timeout);
                     }
                 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -145,7 +145,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             {
                 var se = e as SocketException;
                 if (se == null || se.SocketErrorCode != SocketError.Interrupted)
-                    Console.WriteLine("[{0}] : {1}", DateTime.Now, e);
+                    Log.WriteLine("[{0}] : {1}", DateTime.Now, e);
             }
             finally
             {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -5,37 +5,62 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
-    public class SimpleTcpListener : SimpleListener
+    public class SimpleTcpListener : SimpleListener, ITunnelListener
     {
         readonly bool autoExit;
+        readonly bool useTcpTunnel = true;
 
         byte[] buffer = new byte[16 * 1024];
         TcpListener server;
+        TcpClient client;
 
-        public SimpleTcpListener(ILog log, ILog testLog, bool autoExit, bool xmlOutput) : base(log, testLog, xmlOutput)
+        public TaskCompletionSource<bool> TunnelHoleThrough { get; private set; } = new TaskCompletionSource<bool>();
+
+        public SimpleTcpListener(ILog log, ILog testLog, bool autoExit, bool xmlOutput, bool tunnel = false) : base(log, testLog, xmlOutput)
         {
             this.autoExit = autoExit;
+            this.useTcpTunnel = tunnel;
         }
+
+        public SimpleTcpListener(int port, ILog log, ILog testLog, bool autoExit, bool xmlOutput, bool tunnel = false) : this(log, testLog, autoExit, xmlOutput, tunnel)
+            => Port = port;
 
         protected override void Stop()
         {
-            server.Stop();
+            client?.Close();
+            client?.Dispose();
+            server?.Stop();
         }
 
         public override void Initialize()
         {
+            if (useTcpTunnel && Port != 0)
+                return;
+
             server = new TcpListener(Address, Port);
             server.Start();
 
             if (Port == 0)
                 Port = ((IPEndPoint)server.LocalEndpoint).Port;
+
+            if (useTcpTunnel)
+            {
+                // close the listener. We have a port. This is not the best
+                // way to find a free port, but there is nothing we can do
+                // better than this.
+
+                server.Stop();
+            }
         }
 
-        protected override void Start()
+        void StartNetworkTcp()
         {
             bool processed;
 
@@ -44,7 +69,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                 do
                 {
                     Log.WriteLine("Test log server listening on: {0}:{1}", Address, Port);
-                    using (TcpClient client = server.AcceptTcpClient())
+                    using (client = server.AcceptTcpClient())
                     {
                         client.ReceiveBufferSize = buffer.Length;
                         processed = Processing(client);
@@ -67,6 +92,75 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                 {
                     Finished();
                 }
+            }
+        }
+
+        void StartTcpTunnel()
+        {
+            if (!TunnelHoleThrough.Task.Result)
+            { // do nothing until the tunnel is ready
+                throw new InvalidOperationException("Tcp tunnel could not be initialized.");
+            }
+            bool processed;
+            try
+            {
+                int timeout = 100;
+                var watch = new System.Diagnostics.Stopwatch();
+                watch.Start();
+                while (true)
+                {
+                    try
+                    {
+                        client = new TcpClient("localhost", Port);
+                        Log.WriteLine("Test log server listening on: {0}:{1}", Address, Port);
+                        // let the device know we are ready!
+                        var stream = client.GetStream();
+                        var ping = Encoding.UTF8.GetBytes("ping");
+                        stream.Write(ping, 0, ping.Length);
+                        break;
+
+                    }
+                    catch (SocketException ex)
+                    {
+                        if (timeout == 100 && watch.ElapsedMilliseconds > 20000)
+                        {
+                            timeout = 250; // Switch to a 250ms timeout after 20 seconds
+                        }
+                        else if (timeout == 250 && watch.ElapsedMilliseconds > 120000)
+                        {
+                            // Give up after 2 minutes.
+                            throw ex;
+                        }
+                        Thread.Sleep(timeout);
+                    }
+                }
+                do
+                {
+                    client.ReceiveBufferSize = buffer.Length;
+                    processed = Processing(client);
+                } while (!autoExit || !processed);
+            }
+            catch (Exception e)
+            {
+                var se = e as SocketException;
+                if (se == null || se.SocketErrorCode != SocketError.Interrupted)
+                    Console.WriteLine("[{0}] : {1}", DateTime.Now, e);
+            }
+            finally
+            {
+                Finished();
+            }
+        }
+
+        protected override void Start()
+        {
+            if (useTcpTunnel)
+            {
+                StartTcpTunnel();
+            }
+            else
+            {
+                StartNetworkTcp();
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
+
+	// interface to be implemented by those listener that can use a tcp tunnel
+	public interface ITunnelListener : ISimpleListener { 
+		TaskCompletionSource<bool> TunnelHoleThrough { get; }
+	}
+
+	// interface implemented by a tcp tunnel between the host and the device.
+	public interface ITcpTunnel : IDisposable {
+		public void Open (string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog);
+		public Task Close ();
+		public Task<bool> Started { get; }
+	}
+
+	// represents a tunnel created between a device and a host. This tunnel allows the communication between
+	// the host and the device via the usb cable.
+	public class TcpTunnel : ITcpTunnel {
+		readonly object processExecutionLock = new object ();
+		readonly IProcessManager processManager;
+
+		bool disposed = false;
+		Task<ProcessExecutionResult> tcpTunnelExecutionTask = null; 
+		CancellationTokenSource cancellationToken;
+
+		public TaskCompletionSource<bool> startedCompletionSource { get; private set; } = new TaskCompletionSource<bool> ();
+		public Task<bool> Started => startedCompletionSource.Task;
+		public int Port { get; private set; }
+
+		public TcpTunnel (IProcessManager processManager)
+		{
+			this.processManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
+		}
+
+		public void Open (string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog)
+		{
+			if (device == null)
+				throw new ArgumentNullException (nameof (device));
+			if (simpleListener == null)
+				throw new ArgumentNullException (nameof (simpleListener));
+			if (mainLog == null)
+				throw new ArgumentNullException (nameof (mainLog));
+
+			lock (processExecutionLock) {
+				// launch app, but do not await for the result, since we need to create the tunnel
+				var tcpArgs = new MlaunchArguments {
+					new TcpTunnelArgument (simpleListener.Port),
+					new VerbosityArgument (),
+					new DeviceNameArgument (device),
+				};
+
+				// use a cancelation token, later will be used to kill the tcp tunnel proces
+				cancellationToken = new CancellationTokenSource ();
+				mainLog.WriteLine ($"Starting tcp tunnel between mac port: {simpleListener.Port} and devie port {simpleListener.Port}.");
+				Port = simpleListener.Port;
+				var tunnelbackLog = new CallbackLog ((line) => {
+					mainLog.WriteLine ($"The tcp tunnel output is {line}");
+					if (line.Contains ("Tcp tunnel started on device")) {
+						mainLog.Write ($"Tcp tunnel created on port {simpleListener.Port}");
+						startedCompletionSource.TrySetResult (true);
+						simpleListener.TunnelHoleThrough.TrySetResult (true);
+					}
+				});
+				// do not await since we are going to be running the process is parallel
+				tcpTunnelExecutionTask = processManager.ExecuteCommandAsync (tcpArgs, tunnelbackLog, timeout, cancellation_token: cancellationToken.Token);
+			}
+		}
+
+		public async Task Close ()
+		{
+			if (cancellationToken == null)
+				throw new InvalidOperationException ("Cannot close tunnel that was not opened.");
+			// cancel process and wait for it to terminate, else we might want to start a second tunnel to the same device
+			// which is going to give problems.
+			cancellationToken.Cancel ();
+			await tcpTunnelExecutionTask;
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose (bool disposing)
+		{
+			if (disposed)
+				return;
+
+			if (disposing) {
+				// cancel the process that started the tunnel, else we will leave processes alive
+				cancellationToken.Cancel ();
+			}
+
+			disposed = true;
+		}
+
+	}
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -5,101 +5,92 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
-namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
+{
 
-	// interface to be implemented by those listener that can use a tcp tunnel
-	public interface ITunnelListener : ISimpleListener { 
-		TaskCompletionSource<bool> TunnelHoleThrough { get; }
-	}
+    // interface to be implemented by those listener that can use a tcp tunnel
+    public interface ITunnelListener : ISimpleListener
+    {
+        TaskCompletionSource<bool> TunnelHoleThrough { get; }
+    }
 
-	// interface implemented by a tcp tunnel between the host and the device.
-	public interface ITcpTunnel : IDisposable {
-		public void Open (string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog);
-		public Task Close ();
-		public Task<bool> Started { get; }
-	}
+    // interface implemented by a tcp tunnel between the host and the device.
+    public interface ITcpTunnel : IAsyncDisposable 
+    {
+        public void Open(string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog);
+        public Task Close();
+        public Task<bool> Started { get; }
+    }
 
-	// represents a tunnel created between a device and a host. This tunnel allows the communication between
-	// the host and the device via the usb cable.
-	public class TcpTunnel : ITcpTunnel {
-		readonly object processExecutionLock = new object ();
-		readonly IProcessManager processManager;
+    // represents a tunnel created between a device and a host. This tunnel allows the communication between
+    // the host and the device via the usb cable.
+    public class TcpTunnel : ITcpTunnel
+    {
+        readonly object _processExecutionLock = new object();
+        readonly IProcessManager _processManager;
 
-		bool disposed = false;
-		Task<ProcessExecutionResult> tcpTunnelExecutionTask = null; 
-		CancellationTokenSource cancellationToken;
+        Task<ProcessExecutionResult> _tcpTunnelExecutionTask = null;
+        CancellationTokenSource _cancellationToken;
 
-		public TaskCompletionSource<bool> startedCompletionSource { get; private set; } = new TaskCompletionSource<bool> ();
-		public Task<bool> Started => startedCompletionSource.Task;
-		public int Port { get; private set; }
+        public TaskCompletionSource<bool> startedCompletionSource { get; private set; } = new TaskCompletionSource<bool>();
+        public Task<bool> Started => startedCompletionSource.Task;
+        public int Port { get; private set; }
 
-		public TcpTunnel (IProcessManager processManager)
-		{
-			this.processManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
-		}
+        public TcpTunnel(IProcessManager processManager)
+        {
+            _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
+        }
 
-		public void Open (string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog)
-		{
-			if (device == null)
-				throw new ArgumentNullException (nameof (device));
-			if (simpleListener == null)
-				throw new ArgumentNullException (nameof (simpleListener));
-			if (mainLog == null)
-				throw new ArgumentNullException (nameof (mainLog));
+        public void Open(string device, ITunnelListener simpleListener, TimeSpan timeout, ILog mainLog)
+        {
+            if (device == null)
+                throw new ArgumentNullException(nameof(device));
+            if (simpleListener == null)
+                throw new ArgumentNullException(nameof(simpleListener));
+            if (mainLog == null)
+                throw new ArgumentNullException(nameof(mainLog));
 
-			lock (processExecutionLock) {
-				// launch app, but do not await for the result, since we need to create the tunnel
-				var tcpArgs = new MlaunchArguments {
-					new TcpTunnelArgument (simpleListener.Port),
-					new VerbosityArgument (),
-					new DeviceNameArgument (device),
-				};
+            lock (_processExecutionLock)
+            {
+                // launch app, but do not await for the result, since we need to create the tunnel
+                var tcpArgs = new MlaunchArguments {
+                    new TcpTunnelArgument (simpleListener.Port),
+                    new VerbosityArgument (),
+                    new DeviceNameArgument (device),
+                };
 
-				// use a cancelation token, later will be used to kill the tcp tunnel proces
-				cancellationToken = new CancellationTokenSource ();
-				mainLog.WriteLine ($"Starting tcp tunnel between mac port: {simpleListener.Port} and devie port {simpleListener.Port}.");
-				Port = simpleListener.Port;
-				var tunnelbackLog = new CallbackLog ((line) => {
-					mainLog.WriteLine ($"The tcp tunnel output is {line}");
-					if (line.Contains ("Tcp tunnel started on device")) {
-						mainLog.Write ($"Tcp tunnel created on port {simpleListener.Port}");
-						startedCompletionSource.TrySetResult (true);
-						simpleListener.TunnelHoleThrough.TrySetResult (true);
-					}
-				});
-				// do not await since we are going to be running the process is parallel
-				tcpTunnelExecutionTask = processManager.ExecuteCommandAsync (tcpArgs, tunnelbackLog, timeout, cancellation_token: cancellationToken.Token);
-			}
-		}
+                // use a cancelation token, later will be used to kill the tcp tunnel proces
+                _cancellationToken = new CancellationTokenSource();
+                mainLog.WriteLine($"Starting tcp tunnel between mac port: {simpleListener.Port} and devie port {simpleListener.Port}.");
+                Port = simpleListener.Port;
+                var tunnelbackLog = new CallbackLog((line) =>
+                {
+                    mainLog.WriteLine($"The tcp tunnel output is {line}");
+                    if (line.Contains("Tcp tunnel started on device"))
+                    {
+                        mainLog.Write($"Tcp tunnel created on port {simpleListener.Port}");
+                        startedCompletionSource.TrySetResult(true);
+                        simpleListener.TunnelHoleThrough.TrySetResult(true);
+                    }
+                });
+                // do not await since we are going to be running the process is parallel
+                _tcpTunnelExecutionTask = _processManager.ExecuteCommandAsync(tcpArgs, tunnelbackLog, timeout, cancellation_token: _cancellationToken.Token);
+            }
+        }
 
-		public async Task Close ()
-		{
-			if (cancellationToken == null)
-				throw new InvalidOperationException ("Cannot close tunnel that was not opened.");
-			// cancel process and wait for it to terminate, else we might want to start a second tunnel to the same device
-			// which is going to give problems.
-			cancellationToken.Cancel ();
-			await tcpTunnelExecutionTask;
-		}
+        public async Task Close()
+        {
+            if (_cancellationToken == null)
+                throw new InvalidOperationException("Cannot close tunnel that was not opened.");
+            // cancel process and wait for it to terminate, else we might want to start a second tunnel to the same device
+            // which is going to give problems.
+            _cancellationToken.Cancel();
+            await _tcpTunnelExecutionTask;
+        }
 
-		public void Dispose ()
-		{
-			Dispose (true);
-			GC.SuppressFinalize (this);
-		}
-
-		protected virtual void Dispose (bool disposing)
-		{
-			if (disposed)
-				return;
-
-			if (disposing) {
-				// cancel the process that started the tunnel, else we will leave processes alive
-				cancellationToken.Cancel ();
-			}
-
-			disposed = true;
-		}
-
-	}
+        public async ValueTask DisposeAsync() 
+        {
+            await Close();
+        }
+    }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
 
-    // interface to be implemented by those listener that can use a tcp tunnel
+    // interface to be implemented by those listeners that can use a tcp tunnel
     public interface ITunnelListener : ISimpleListener
     {
         TaskCompletionSource<bool> TunnelHoleThrough { get; }
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         public Task<bool> Started { get; }
     }
 
-    // represents a tunnel created between a device and a host. This tunnel allows the communication between
+    // represents a tunnel created between a device and a host. This tunnel allows communication between
     // the host and the device via the usb cable.
     public class TcpTunnel : ITcpTunnel
     {
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     new DeviceNameArgument (device),
                 };
 
-                // use a cancelation token, later will be used to kill the tcp tunnel proces
+                // use a cancelation token, later will be used to kill the tcp tunnel process
                 _cancellationToken = new CancellationTokenSource();
                 mainLog.WriteLine($"Starting tcp tunnel between mac port: {simpleListener.Port} and devie port {simpleListener.Port}.");
                 Port = simpleListener.Port;
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         simpleListener.TunnelHoleThrough.TrySetResult(true);
                     }
                 });
-                // do not await since we are going to be running the process is parallel
+                // do not await since we are going to be running the process in parallel
                 _tcpTunnelExecutionTask = _processManager.ExecuteCommandAsync(tcpArgs, tunnelbackLog, timeout, cancellationToken: _cancellationToken.Token);
             }
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
@@ -1,69 +1,78 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
-namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
+{
 
-	// manages the tunnels that are used to communicate with the devices. We want to create a single tunnel per device
-	// since we can only run one app per device, this should not be a problem.
-	//
-	// definition: 
-	// A tunnel boring machine, also known as a "mole", is a machine used to excavate tunnels with a circular cross section
-	// through a variety of soil and rock strata. They may also be used for microtunneling. 
-	public interface ITunnelBore : IDisposable {
+    /// <summary>
+    /// manages the tunnels that are used to communicate with the devices. We want to create a single tunnel per device
+    /// since we can only run one app per device, this should not be a problem.
+    ///
+    /// definition: 
+    /// A tunnel boring machine, also known as a "mole", is a machine used to excavate tunnels with a circular cross section
+    /// through a variety of soil and rock strata. They may also be used for microtunneling. 
+    /// </summary>
+    public interface ITunnelBore : IAsyncDisposable
+    {
 
-		// create a new tunnel for the device with the given name.
-		ITcpTunnel Create (string device, ILog mainLog);
+        // create a new tunnel for the device with the given name.
+        ITcpTunnel Create(string device, ILog mainLog);
 
-		// close a given tunnel
-		Task Close (string device);
-	}
+        // close a given tunnel
+        Task Close(string device);
+    }
 
-	public class TunnelBore : ITunnelBore {
+    public class TunnelBore : ITunnelBore
+    {
 
-		readonly object tunnelsLock = new object ();
-		readonly IProcessManager processManager;
-		readonly Dictionary<string, TcpTunnel> tunnels = new Dictionary<string, TcpTunnel> ();
+        readonly object _tunnelsLock = new object();
+        readonly IProcessManager _processManager;
+        readonly ConcurrentDictionary<string, TcpTunnel> _tunnels = new ConcurrentDictionary<string, TcpTunnel>();
 
-		public TunnelBore (IProcessManager processManager)
-		{
-			this.processManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
-		}
+        public TunnelBore(IProcessManager processManager)
+        {
+            _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
+        }
 
-		// Creates a new tcp tunnel to the given device that will use the port from the passed listener. 
-		public ITcpTunnel Create (string device, ILog mainLog)
-		{
-			lock (tunnelsLock) {
-				if (tunnels.ContainsKey (device)) {
-					string msg = $"Cannot create more than one tunnel to device {device}";
-					mainLog.WriteLine (msg);
-					throw new InvalidOperationException (msg);
-				}
-				tunnels [device] = new TcpTunnel (processManager);
-				return tunnels [device];
-			}
-		}
+        // Creates a new tcp tunnel to the given device that will use the port from the passed listener. 
+        public ITcpTunnel Create(string device, ILog mainLog)
+        {
+            lock (_tunnelsLock)
+            {
+                if (_tunnels.ContainsKey(device))
+                {
+                    string msg = $"Cannot create more than one tunnel to device {device}";
+                    mainLog.WriteLine(msg);
+                    throw new InvalidOperationException(msg);
+                }
+                _tunnels[device] = new TcpTunnel(_processManager);
+                return _tunnels[device];
+            }
+        }
 
-		public async Task Close (string device)
-		{
-			// closes a tcp tunnel that was created for the given device.
-			if (tunnels.TryGetValue (device, out var tunnel)) {
-				await tunnel.Close ();
-				tunnel.Dispose ();
-				lock (tunnelsLock) {
-					tunnels.Remove (device);
-				}
-			}
-		}
+        public async Task Close(string device)
+        {
+            // closes a tcp tunnel that was created for the given device.
+            if (_tunnels.TryRemove(device, out var tunnel))
+            {
+                await tunnel.DisposeAsync(); // calls close already
+            }
+        }
 
-		public void Dispose ()
-		{
-			lock (tunnelsLock) {
-				foreach (var t in tunnels.Values)
-					t.Dispose ();
-			}
-		}
-	}
+        public async ValueTask DisposeAsync()
+        {
+            var devices = _tunnels.Keys.ToArray();
+            foreach (var d in devices) {
+                if (_tunnels.TryRemove(d, out var tunnel)) {
+                    // blocking, but we are disposing
+                    await tunnel.DisposeAsync(); // alls close already
+                }
+            }
+        }
+    }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners {
+
+	// manages the tunnels that are used to communicate with the devices. We want to create a single tunnel per device
+	// since we can only run one app per device, this should not be a problem.
+	//
+	// definition: 
+	// A tunnel boring machine, also known as a "mole", is a machine used to excavate tunnels with a circular cross section
+	// through a variety of soil and rock strata. They may also be used for microtunneling. 
+	public interface ITunnelBore : IDisposable {
+
+		// create a new tunnel for the device with the given name.
+		ITcpTunnel Create (string device, ILog mainLog);
+
+		// close a given tunnel
+		Task Close (string device);
+	}
+
+	public class TunnelBore : ITunnelBore {
+
+		readonly object tunnelsLock = new object ();
+		readonly IProcessManager processManager;
+		readonly Dictionary<string, TcpTunnel> tunnels = new Dictionary<string, TcpTunnel> ();
+
+		public TunnelBore (IProcessManager processManager)
+		{
+			this.processManager = processManager ?? throw new ArgumentNullException (nameof (processManager));
+		}
+
+		// Creates a new tcp tunnel to the given device that will use the port from the passed listener. 
+		public ITcpTunnel Create (string device, ILog mainLog)
+		{
+			lock (tunnelsLock) {
+				if (tunnels.ContainsKey (device)) {
+					string msg = $"Cannot create more than one tunnel to device {device}";
+					mainLog.WriteLine (msg);
+					throw new InvalidOperationException (msg);
+				}
+				tunnels [device] = new TcpTunnel (processManager);
+				return tunnels [device];
+			}
+		}
+
+		public async Task Close (string device)
+		{
+			// closes a tcp tunnel that was created for the given device.
+			if (tunnels.TryGetValue (device, out var tunnel)) {
+				await tunnel.Close ();
+				tunnel.Dispose ();
+				lock (tunnelsLock) {
+					tunnels.Remove (device);
+				}
+			}
+		}
+
+		public void Dispose ()
+		{
+			lock (tunnelsLock) {
+				foreach (var t in tunnels.Values)
+					t.Dispose ();
+			}
+		}
+	}
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/ApplicationOptions.cs
@@ -33,6 +33,7 @@ namespace BCLTests
             EnableXml = defaults.BoolForKey("xml.enabled");
             HostName = defaults.StringForKey("network.host.name");
             HostPort = (int)defaults.IntForKey("network.host.port");
+            UseTcpTunnel = defaults.BoolForKey("execution.usetcptunnel");
             Transport = defaults.StringForKey("network.transport");
             SortNames = defaults.BoolForKey("display.sort");
             LogFile = defaults.StringForKey("log.file");
@@ -45,6 +46,8 @@ namespace BCLTests
                 AutoStart = b;
             if (bool.TryParse(Environment.GetEnvironmentVariable("NUNIT_ENABLE_NETWORK"), out b))
                 EnableNetwork = b;
+            if (bool.TryParse(Environment.GetEnvironmentVariable("USE_TCP_TUNNEL"), out b))
+                UseTcpTunnel = b;
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NUNIT_HOSTNAME")))
                 HostName = Environment.GetEnvironmentVariable("NUNIT_HOSTNAME");
             int i;
@@ -70,6 +73,7 @@ namespace BCLTests
                 { "autostart", "If the app should automatically start running the tests.", v => AutoStart = true },
                 { "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
                 { "hostport=", "HTTP/TCP port to connect to.", v => HostPort = int.Parse (v) },
+                { "use_tcp_tunnel", "Use a tcp tunnel to connect to the host.", v => UseTcpTunnel = true },
                 { "enablenetwork", "Enable the network reporter.", v => EnableNetwork = true },
                 { "transport=", "Select transport method. Either TCP (default), HTTP or FILE.", v => Transport = v },
                 { "enablexml", "Enable the xml reported.", v => EnableXml = false },
@@ -100,6 +104,8 @@ namespace BCLTests
         public string HostName { get; private set; }
 
         public int HostPort { get; private set; }
+
+        public bool UseTcpTunnel { get; set; } = false;
 
         public bool AutoStart { get; set; }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/TestRunner/Core/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/common/TestRunner/Core/TcpTextWriter.cs
@@ -4,6 +4,7 @@
 // https://github.com/spouliot/Touch.Unit/blob/master/NUnitLite/TouchRunner/TcpTextWriter.cs
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -18,6 +19,7 @@ namespace BCLTests.TestRunner.Core
     {
 
         TcpClient client;
+        TcpListener server;
         StreamWriter writer;
 
         static string SelectHostName(string[] names, int port)
@@ -72,14 +74,15 @@ namespace BCLTests.TestRunner.Core
             return result;
         }
 
-        public TcpTextWriter(string hostName, int port)
+        public TcpTextWriter(string hostName, int port, bool isTunnel = false)
         {
             if ((port < 0) || (port > ushort.MaxValue))
                 throw new ArgumentOutOfRangeException(nameof(port), $"Port must be between 0 and {ushort.MaxValue}");
 
-            if (hostName == null)
+            if (!isTunnel && hostName == null)
                 throw new ArgumentNullException(nameof(hostName));
-            HostName = SelectHostName(hostName.Split(','), port);
+            if (!isTunnel)
+                HostName = SelectHostName(hostName.Split(','), port);
             Port = port;
 
 #if __IOS__
@@ -88,7 +91,27 @@ namespace BCLTests.TestRunner.Core
 
             try
             {
-                client = new TcpClient(HostName, port);
+                if (isTunnel)
+                {
+                    server = new TcpListener(IPAddress.Any, Port);
+                    server.Server.ReceiveTimeout = 5000;
+                    server.Start();
+                    client = server.AcceptTcpClient();
+                    // block until we have the ping from the client side
+                    int i;
+                    byte[] buffer = new byte[16 * 1024];
+                    var stream = client.GetStream();
+                    while ((i = stream.Read(buffer, 0, buffer.Length)) != 0)
+                    {
+                        var message = Encoding.UTF8.GetString(buffer);
+                        if (message.Contains("ping"))
+                            break;
+                    }
+                }
+                else
+                {
+                    client = new TcpClient(HostName, port);
+                }
                 writer = new StreamWriter(client.GetStream());
             }
             catch

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/iOSApp/ViewController.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/iOSApp/ViewController.cs
@@ -72,7 +72,7 @@ namespace BCLTests
             {
                 try
                 {
-                    writer = new TcpTextWriter(options.HostName, options.HostPort);
+                    writer = new TcpTextWriter(options.HostName, options.HostPort, options.UseTcpTunnel);
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/tvOSApp/ViewController.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/tvOSApp/ViewController.cs
@@ -72,7 +72,7 @@ namespace BCLTests
             {
                 try
                 {
-                    writer = new TcpTextWriter(options.HostName, options.HostPort);
+                    writer = new TcpTextWriter(options.HostName, options.HostPort, options.UseTcpTunnel);
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             }
 
             var listener_log = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: true);
-            var (transport, listener, listenerTmpFile) = _listenerFactory.Create(target.ToRunMode(), _mainLog, listener_log, isSimulator, true, false);
+            var (transport, listener, listenerTmpFile) = _listenerFactory.Create(target.ToRunMode(), _mainLog, listener_log, isSimulator, true, false, false);
 
             // Initialize has to be called before we try to get Port (internal implementation of the listener says so)
             // TODO: Improve this to not get into a broken state - it was really hard to debug when I moved this lower

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -12,13 +12,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
     public class SimpleListenerFactoryTest
     {
         private readonly Mock<ILog> _log;
-        private readonly Mock<ITunnelBore> _tunnelBore;
         private readonly SimpleListenerFactory _factory;
 
         public SimpleListenerFactoryTest()
         {
             _log = new Mock<ILog>();
-            _factory = new SimpleListenerFactory(_tunnelBore.Object);
+            _factory = new SimpleListenerFactory(Mock.Of<ITunnelBore> ());
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -12,18 +12,19 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
     public class SimpleListenerFactoryTest
     {
         private readonly Mock<ILog> _log;
+        private readonly Mock<ITunnelBore> _tunnelBore;
         private readonly SimpleListenerFactory _factory;
 
         public SimpleListenerFactoryTest()
         {
             _log = new Mock<ILog>();
-            _factory = new SimpleListenerFactory();
+            _factory = new SimpleListenerFactory(_tunnelBore.Object);
         }
 
         [Fact]
         public void CreateNotWatchListener()
         {
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true, false);
             Assert.Equal(ListenerTransport.Tcp, transport);
             Assert.IsType<SimpleTcpListener>(listener);
             Assert.Null(listenerTmpFile);
@@ -35,7 +36,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             var logFullPath = "myfullpath.txt";
             _ = _log.Setup(l => l.FullPath).Returns(logFullPath);
 
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true, false);
             Assert.Equal(ListenerTransport.File, transport);
             Assert.IsType<SimpleFileListener>(listener);
             Assert.NotNull(listenerTmpFile);
@@ -48,7 +49,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         [Fact]
         public void CreateWatchOSDevice()
         {
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true, false);
             Assert.Equal(ListenerTransport.Http, transport);
             Assert.IsType<SimpleHttpListener>(listener);
             Assert.Null(listenerTmpFile);


### PR DESCRIPTION
Add the basic classes that are needed to support the creation of tcp
tunnels to the devices. A following commit will provide the required CLI
option and integration to the runner to support this.