### PR TITLE
Prevent hang of XHarness when Listener doesn't initialize fully

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
@@ -53,13 +53,15 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
             var simulatorLoader = new SimulatorLoader(processManager);
 
             var logs = new Logs(_arguments.OutputDirectory);
-            var cancellationToken = new CancellationToken(); // TODO: Get cancellation from command line env? Set timeout through it?
+
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(_arguments.Timeout);
 
             var exitCode = ExitCode.SUCCESS;
 
             foreach (TestTarget target in _arguments.TestTargets)
             {
-                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader, cancellationToken);
+                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader, cts.Token);
 
                 if (exitCodeForRun != ExitCode.SUCCESS)
                 {
@@ -156,7 +158,8 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                     _arguments.LaunchTimeout,
                     deviceName,
                     verbosity: verbosity,
-                    xmlResultJargon: XmlResultJargon.xUnit);
+                    xmlResultJargon: XmlResultJargon.xUnit,
+                    cancellationToken: cancellationToken);
 
                 if (exitCode != 0)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/IProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/IProcessManager.cs
@@ -27,13 +27,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         string MlaunchPath { get; }
         Version XcodeVersion { get; }
 
-        Task<ProcessExecutionResult> ExecuteCommandAsync(string filename, IList<string> args, ILog log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellationToken = null);
-        Task<ProcessExecutionResult> ExecuteCommandAsync(string filename, IList<string> args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellationToken = null);
-        Task<ProcessExecutionResult> ExecuteCommandAsync(MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null);
+        Task<ProcessExecutionResult> ExecuteCommandAsync(string filename, IList<string> args, ILog log, TimeSpan timeout, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null);
+        Task<ProcessExecutionResult> ExecuteCommandAsync(string filename, IList<string> args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null);
+        Task<ProcessExecutionResult> ExecuteCommandAsync(MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null);
         Task<ProcessExecutionResult> ExecuteXcodeCommandAsync(string executable, IList<string> args, ILog log, TimeSpan timeout);
-        Task<ProcessExecutionResult> RunAsync(Process process, ILog log, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null);
-        Task<ProcessExecutionResult> RunAsync(Process process, MlaunchArguments args, ILog log, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null);
-        Task<ProcessExecutionResult> RunAsync(Process process, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan? timeout = null, Dictionary<string, string> environment_variables = null, CancellationToken? cancellation_token = null, bool? diagnostics = null);
+        Task<ProcessExecutionResult> RunAsync(Process process, ILog log, TimeSpan? timeout = null, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null, bool? diagnostics = null);
+        Task<ProcessExecutionResult> RunAsync(Process process, MlaunchArguments args, ILog log, TimeSpan? timeout = null, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null, bool? diagnostics = null);
+        Task<ProcessExecutionResult> RunAsync(Process process, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan? timeout = null, Dictionary<string, string> environmentVariables = null, CancellationToken? cancellationToken = null, bool? diagnostics = null);
         Task KillTreeAsync(Process process, ILog log, bool? diagnostics = true);
         Task KillTreeAsync(int pid, ILog log, bool? diagnostics = true);
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/ProcessManager.cs
@@ -94,11 +94,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         public Task<ProcessExecutionResult> RunAsync(Process process,
             ILog log,
             TimeSpan? timeout = null,
-            Dictionary<string, string> environment_variables = null,
+            Dictionary<string, string> environmentVariables = null,
             CancellationToken? cancellationToken = null,
             bool? diagnostics = null)
         {
-            return RunAsync(process, log, log, log, timeout, environment_variables, cancellationToken, diagnostics);
+            return RunAsync(process, log, log, log, timeout, environmentVariables, cancellationToken, diagnostics);
         }
 
         public Task<ProcessExecutionResult> RunAsync(Process process,

--- a/src/Microsoft.DotNet.XHarness.iOS/AppInstaller.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppInstaller.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             var totalSize = Directory.GetFiles(appPath, "*", SearchOption.AllDirectories).Select((v) => new FileInfo(v).Length).Sum();
             _mainLog.WriteLine($"Installing '{appPath}' to '{deviceName}' ({totalSize / 1024.0 / 1024.0:N2} MB)");
 
-            ProcessExecutionResult result = await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromHours(1), cancellation_token: cancellationToken);
+            ProcessExecutionResult result = await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromHours(1), cancellationToken: cancellationToken);
 
             return (deviceName, result);
         }

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -353,7 +353,8 @@ namespace Microsoft.DotNet.XHarness.iOS
                 }
             }
 
-            listener.Cancel();
+            // TODO: https://github.com/dotnet/xharness/issues/73
+            // listener.Cancel();
             listener.Dispose();
 
             // check the final status, copy all the required data

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
@@ -62,7 +63,8 @@ namespace Microsoft.DotNet.XHarness.iOS
             bool ensureCleanSimulatorState = false,
             string variation = null,
             int verbosity = 1,
-            XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit)
+            XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
+            CancellationToken cancellationToken = default)
         {
             var args = new MlaunchArguments
             {
@@ -169,6 +171,8 @@ namespace Microsoft.DotNet.XHarness.iOS
                     null,
                     (level, message) => _mainLog.WriteLine(message));
 
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(testReporter.CancellationToken, cancellationToken);
+
                 listener.ConnectedTask
                     .TimeoutAfter(testLaunchTimeout)
                     .ContinueWith(testReporter.LaunchCallback)
@@ -246,7 +250,7 @@ namespace Microsoft.DotNet.XHarness.iOS
 
                 _mainLog.WriteLine("Starting test run");
 
-                var result = _processManager.ExecuteCommandAsync(args, _mainLog, timeout, cancellation_token: testReporter.CancellationToken);
+                var result = _processManager.ExecuteCommandAsync(args, _mainLog, timeout, cancellationToken: linkedCts.Token);
 
                 await testReporter.CollectSimulatorResult(result);
 
@@ -296,6 +300,8 @@ namespace Microsoft.DotNet.XHarness.iOS
                     null,
                     (level, message) => _mainLog.WriteLine(message));
 
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(testReporter.CancellationToken, cancellationToken);
+
                 listener.ConnectedTask
                     .TimeoutAfter(testLaunchTimeout)
                     .ContinueWith(testReporter.LaunchCallback)
@@ -330,7 +336,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                         args,
                         aggregatedLog,
                         timeout,
-                        cancellation_token: testReporter.CancellationToken);
+                        cancellationToken: linkedCts.Token);
 
                     await testReporter.CollectDeviceResult(runTestTask);
                 }

--- a/src/Microsoft.DotNet.XHarness.iOS/AppUninstaller.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppUninstaller.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             args.Add(new UninstallAppFromDeviceArgument(appBundleId));
             args.Add(new DeviceNameArgument(deviceName));
 
-            return await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromMinutes(1), cancellation_token: cancellationToken);
+            return await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromMinutes(1), cancellationToken: cancellationToken);
         }
     }
 }


### PR DESCRIPTION
This is not a final fix but rather unblock for others.

More information about the hang here:
https://github.com/dotnet/xharness/issues/73
