### PR TITLE
[iOS] Add support for tunnels when running on devices.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommand.cs
@@ -19,12 +19,29 @@ using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.iOS
 {
+
+    /// <summary>
+    /// Specifies the channel that is used to comminicate with the device.
+    /// </summary>
+    public enum CommunicationChannel
+    {
+        /// <summary>
+        /// Connect to the device using the LAN or WAN.
+        /// </summary>
+        Network,
+        /// <summary>
+        /// Connect to the device using a tcp-tunnel
+        /// </summary>
+        UsbTunnel,
+    }
+
     /// <summary>
     /// Command which executes a given, already-packaged iOS application, waits on it and returns status based on the outcome.
     /// </summary>
     internal class iOSTestCommand : TestCommand
     {
         private readonly iOSTestCommandArguments _arguments = new iOSTestCommandArguments();
+        private CommunicationChannel _channel = CommunicationChannel.UsbTunnel; // use the tunnel as default since it is more reliable.
         protected override ITestCommandArguments TestArguments => _arguments;
 
         public iOSTestCommand() : base()
@@ -37,6 +54,7 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                 { "xcode=", "Path where Xcode is installed", v => _arguments.XcodeRoot = v},
                 { "mlaunch=", "Path to the mlaunch binary", v => _arguments.MlaunchPath = v},
                 { "device-name=", "Name of a specific device, if you wish to target one", v => _arguments.DeviceName = v},
+                { "communication-channel:", $"The communication channel to use to communicate with the default. Can be {CommunicationChannel.Network} and {CommunicationChannel.UsbTunnel}. Default is {CommunicationChannel.UsbTunnel}", v => Enum.TryParse (v, out _channel)},
                 { "launch-timeout=|lt=", "Time span, in seconds, to wait for the iOS app to start.", v => _arguments.LaunchTimeout = TimeSpan.FromSeconds(int.Parse(v))},
             };
 
@@ -152,7 +170,8 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                     new TestReporterFactory(processManager),
                     mainLog,
                     logs,
-                    new Helpers());
+                    new Helpers(),
+                    useTcpTunnel: _channel == CommunicationChannel.UsbTunnel);
 
                 (deviceName, exitCode) = await appRunner.RunApp(appBundleInfo,
                     target,

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -23,6 +23,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             bool autoExit,
             bool xmlOutput,
             bool useTcpTunnel);
+
+        ITunnelBore TunnelBore { get; }
     }
 
     public class SimpleListenerFactory : ISimpleListenerFactory


### PR DESCRIPTION
By default, use the tcp tunnel since it will be more reliable and easier
to setup in the CI. Nevertheless, allow user to state that they want to
use the network.

Updated tests both on sim runs, to make sure no tunnles are created and
on devices.