### PR TITLE
[iOS] Add a more useful message when a user gets the target wrong.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
@@ -62,7 +62,22 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
                     var message = new StringBuilder("Invalid arguments:");
                     foreach (string error in validationErrors)
                     {
-                        message.Append(Environment.NewLine + "  - " + error);
+                        // errors can have more than one line, if the do, add
+                        // some nice indentation
+                        var lines = error.Split(Environment.NewLine);
+                        if (lines.Length > 1)
+                        {
+                            // first line is in the same distance, rest have
+                            // and indentation
+                            message.Append(Environment.NewLine + "  - " + lines[0]);
+                            for(int index = 1; index < lines.Length; index++) {
+                                message.Append($"{Environment.NewLine}\t{lines[index]}");
+							}
+                        }
+						else
+                        { 
+                            message.Append(Environment.NewLine + "  - " + error);
+						} 
                     }
 
                     _log.LogError(message.ToString());

--- a/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Common/XHarnessCommand.cs
@@ -70,14 +70,15 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
                             // first line is in the same distance, rest have
                             // and indentation
                             message.Append(Environment.NewLine + "  - " + lines[0]);
-                            for(int index = 1; index < lines.Length; index++) {
+                            for (int index = 1; index < lines.Length; index++)
+                            {
                                 message.Append($"{Environment.NewLine}\t{lines[index]}");
-							}
+                            }
                         }
-						else
-                        { 
+                        else
+                        {
                             message.Append(Environment.NewLine + "  - " + error);
-						} 
+                        }
                     }
 
                     _log.LogError(message.ToString());
@@ -85,7 +86,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Common
                     return 1;
                 }
 
-                return (int) InvokeInternal().GetAwaiter().GetResult();
+                return (int)InvokeInternal().GetAwaiter().GetResult();
             }
             finally
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.DotNet.XHarness.CLI.Common;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -61,7 +62,17 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                     }
                     catch (ArgumentOutOfRangeException)
                     {
-                        errors.Add($"Failed to parse test target '{targetName}'");
+                        // let the user know that the target is not known
+                        // and all the available ones.
+                        var sb = new StringBuilder();
+						sb.AppendLine($"Failed to parse test target '{targetName}'. Avaliable targets are:");
+                        sb.AppendLine();
+                        foreach (var val in Enum.GetValues(typeof(TestTarget))) {
+                            var enumString = ((TestTarget)val).AsString();
+                            if (!string.IsNullOrEmpty(enumString))
+                                sb.AppendLine($"\t* {enumString}");
+                        }
+                        errors.Add(sb.ToString());
                     }
                 }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/iOS/iOSTestCommandArguments.cs
@@ -65,9 +65,10 @@ namespace Microsoft.DotNet.XHarness.CLI.iOS
                         // let the user know that the target is not known
                         // and all the available ones.
                         var sb = new StringBuilder();
-						sb.AppendLine($"Failed to parse test target '{targetName}'. Avaliable targets are:");
+                        sb.AppendLine($"Failed to parse test target '{targetName}'. Avaliable targets are:");
                         sb.AppendLine();
-                        foreach (var val in Enum.GetValues(typeof(TestTarget))) {
+                        foreach (var val in Enum.GetValues(typeof(TestTarget)))
+                        {
                             var enumString = ((TestTarget)val).AsString();
                             if (!string.IsNullOrEmpty(enumString))
                                 sb.AppendLine($"\t* {enumString}");


### PR DESCRIPTION
Add a more verbose error when the user does not provide the correct
target to the command.

fixes: https://github.com/dotnet/xharness/issues/82