### PR TITLE
[iOS] Ensure that we do generate xml when we call the CLI.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
@@ -37,6 +37,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
         /// </summary>
         public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
+        /// <summary>
+        /// Allows to specify the xml format to be used in the result files.
+        /// </summary>
+        public XmlResultJargon XmlResultJargon { get; set; } = XmlResultJargon.xUnit; // default by mono
+
         public IReadOnlyCollection<TestTarget> TestTargets { get; set; }
 
         public override IList<string> GetValidationErrors()
@@ -64,7 +69,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
                         // let the user know that the target is not known
                         // and all the available ones.
                         var sb = new StringBuilder();
-                        sb.AppendLine($"Failed to parse test target '{targetName}'. Avaliable targets are:");
+                        sb.AppendLine($"Failed to parse test target '{targetName}'. Available targets are:");
                         sb.AppendLine();
                         foreach (var val in Enum.GetValues(typeof(TestTarget)))
                         {
@@ -99,6 +104,17 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
                 errors.Add($"Failed to find Xcode root at {XcodeRoot}");
             }
 
+            if (XmlResultJargon == XmlResultJargon.Missing)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine($"Failed to parse xml jargon. Available targets are:");
+                sb.AppendLine();
+                foreach (var val in new [] {XmlResultJargon.NUnitV2, XmlResultJargon.NUnitV3, XmlResultJargon.TouchUnit, XmlResultJargon.xUnit})
+                {
+                    sb.AppendLine($"\t* {val.ToString()}");
+                }
+                errors.Add(sb.ToString());
+            }
             return errors;
         }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -178,7 +178,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     mainLog,
                     logs,
                     new Helpers(),
-                    true, // the cli ALWAYS will get the output as xml
+                    useXmlOutput: true, // the cli ALWAYS will get the output as xml
                     useTcpTunnel: _channel == CommunicationChannel.UsbTunnel);
 
                 (deviceName, success) = await appRunner.RunApp(appBundleInfo,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -57,6 +57,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 { "device-name=", "Name of a specific device, if you wish to target one", v => _arguments.DeviceName = v},
                 { "communication-channel:", $"The communication channel to use to communicate with the default. Can be {CommunicationChannel.Network} and {CommunicationChannel.UsbTunnel}. Default is {CommunicationChannel.UsbTunnel}", v => Enum.TryParse (v, out _channel)},
                 { "launch-timeout=|lt=", "Time span, in seconds, to wait for the iOS app to start.", v => _arguments.LaunchTimeout = TimeSpan.FromSeconds(int.Parse(v))},
+                { "xml-jargon:|xj:", $"The xml format to be used in the unit test results. Can be {XmlResultJargon.TouchUnit} {XmlResultJargon.NUnitV2} {XmlResultJargon.NUnitV3} and {XmlResultJargon.xUnit}", v =>
+                    {
+                        // if we cannot parse it, set it as missing and the error will notify the issue
+                        _arguments.XmlResultJargon = Enum.TryParse(v, out XmlResultJargon jargon) ? jargon : XmlResultJargon.Missing;
+                    }
+                },
             };
 
             foreach (var option in CommonOptions)
@@ -172,6 +178,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     mainLog,
                     logs,
                     new Helpers(),
+                    true, // the cli ALWAYS will get the output as xml
                     useTcpTunnel: _channel == CommunicationChannel.UsbTunnel);
 
                 (deviceName, success) = await appRunner.RunApp(appBundleInfo,
@@ -180,7 +187,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     _arguments.LaunchTimeout,
                     deviceName,
                     verbosity: verbosity,
-                    xmlResultJargon: XmlResultJargon.xUnit,
+                    xmlResultJargon: _arguments.XmlResultJargon,
                     cancellationToken: cancellationToken);
 
                 if (success)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
         public abstract TextWriter Logger { get; }
 
         /// <summary>
-        /// Implementors should provide a full path in which the final 
+        /// Implementors should provide a full path in which the final
         /// results of the test run will be written. This property must not
         /// return null.
         /// </summary>
@@ -38,15 +38,17 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
 
             var runner = await InternalRunAsync(logger);
 
-            TestRunner.Jargon jargon = Core.TestRunner.Jargon.NUnitV3;
+            TestRunner.Jargon jargon;
             switch (options.XmlVersion)
             {
                 case XmlVersion.NUnitV2:
                     jargon = Core.TestRunner.Jargon.NUnitV2;
                     break;
-                case XmlVersion.NUnitV3:
-                default: // nunitv3 gives os the most amount of possible details
+                case XmlVersion.NUnitV3: // nunitv3 gives os the most amount of possible details
                     jargon = Core.TestRunner.Jargon.NUnitV3;
+                    break;
+                default:
+                    jargon = Core.TestRunner.Jargon.xUnit;
                     break;
             }
             if (options.EnableXml)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
     {
         NUnitV2 = 0,
         NUnitV3 = 1,
+        xUnit = 2,
     }
 
     internal class ApplicationOptions
@@ -119,7 +120,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         /// <summary>
         /// The transport to be used to communicate with the host. The default
         /// value is TCP.
-        /// 
+        ///
         /// Supported values are:
         ///
         /// * TCP

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/iOSApp/ViewController.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/iOSApp/ViewController.cs
@@ -113,6 +113,9 @@ namespace BCLTests
                 case XmlVersion.NUnitV3:
                     jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV3;
                     break;
+                case XmlVersion.xUnit:
+                    jargon = Core.TestRunner.Jargon.xUnit;
+                    break;
             }
 
             if (options.EnableXml)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/tvOSApp/ViewController.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/tvOSApp/ViewController.cs
@@ -105,13 +105,14 @@ namespace BCLTests
             Xamarin.iOS.UnitTests.TestRunner.Jargon jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV3;
             switch (options.XmlVersion)
             {
+                case XmlVersion.NUnitV2:
+                    jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV2;
+                    break;
                 case XmlVersion.NUnitV3:
                     jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV3;
                     break;
-
-                default:
-                case XmlVersion.NUnitV2:
-                    jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV2;
+                case XmlVersion.xUnit:
+                    jargon = Core.TestRunner.Jargon.xUnit;
                     break;
             }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/watchOS/Extension/InterfaceController.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestImporter/Templates/Managed/Resources/src/watchOS/Extension/InterfaceController.cs
@@ -89,7 +89,7 @@ namespace monotouchtestWatchKitExtension
 				yield return new TestAssemblyInfo (a, name);
 			}
  		}
- 		
+
 		void RunTests ()
 		{
 			var options = ApplicationOptions.Current;
@@ -139,6 +139,9 @@ namespace monotouchtestWatchKitExtension
 						break;
 					case XmlVersion.NUnitV3:
 						jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.NUnitV3;
+						break;
+					case XmlVersion.xUnit:
+						jargon = Xamarin.iOS.UnitTests.TestRunner.Jargon.xUnit;
 						break;
 					}
 					if (options.EnableXml) {
@@ -208,7 +211,7 @@ class NameStartsWithFilter : NUnit.Framework.Internal.TestFilter
 		var method = test as NUnit.Framework.Internal.TestMethod;
 		if (method != null)
 			return Match (method.Parent);
-		
+
 		var name = !string.IsNullOrEmpty (test.Name) ? test.Name : test.FullName;
 		bool rv;
 		if (string.IsNullOrEmpty (name)) {

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -391,7 +391,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             Assert.Equal("Test iPhone", deviceName);
             Assert.True(success);
 
-            var ips = string.Join(",", System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.Select(ip => ip.ToString()));
+            var ipAddresses = System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.Select(ip => ip.ToString());
+            var ips = string.Join(",", ipAddresses);
 
             var tunnelParam = useTunnel ? "-setenv=USE_TCP_TUNNEL=true " : "";
             var xmlParam = useXml ? "-setenv=NUNIT_ENABLE_XML_OUTPUT=true -setenv=NUNIT_ENABLE_XML_MODE=wrapped -setenv=NUNIT_XML_VERSION=xUnit " : "";

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -125,9 +125,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task RunOnSimulatorWithNoAvailableSimulatorTest(bool useTcpTunnel)
+        [InlineData(false, false)] // no tunnel, no xml
+        [InlineData(false, true)] // no tunnel, xml
+        [InlineData(true, false)] // tunnel, no xml
+        [InlineData(true, true)] // tunnel and xml
+        public async Task RunOnSimulatorWithNoAvailableSimulatorTest(bool useTcpTunnel, bool useXmlOutput)
         {
             // Mock finding simulators
             string simulatorLogPath = Path.Combine(Path.GetTempPath(), "simulator-logs");
@@ -168,6 +170,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
+                useXmlOutput,
                 useTcpTunnel);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
@@ -191,8 +194,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             _tunnelBore.Verify(t => t.Create(It.IsAny<string>(), It.IsAny<ILog>()), Times.Never); // never create tunnels on simulators
         }
 
-        [Fact]
-        public async Task RunOnSimulatorSuccessfullyTest()
+        [Theory]
+        [InlineData(false, false)] // no tunnel, no xml
+        [InlineData(false, true)] // no tunnel, xml
+        [InlineData(true, false)] // tunnel, no xml
+        [InlineData(true, true)] // tunnel and xml
+        public async Task RunOnSimulatorSuccessfullyTest(bool useTunnel, bool useXml)
         {
             string simulatorLogPath = Path.Combine(Path.GetTempPath(), "simulator-logs");
 
@@ -238,7 +245,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
-                false);
+                useXml,
+                useTunnel);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
 
@@ -253,12 +261,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             Assert.Equal("Test iPhone simulator", deviceName);
             Assert.True(success);
 
+            var xmlParam = useXml ? "-setenv=NUNIT_ENABLE_XML_OUTPUT=true -setenv=NUNIT_ENABLE_XML_MODE=wrapped -setenv=NUNIT_XML_VERSION=xUnit " : "";
+
             var expectedArgs = $"-argument=-connection-mode -argument=none -argument=-app-arg:-autostart " +
                 $"-setenv=NUNIT_AUTOSTART=true -argument=-app-arg:-autoexit -setenv=NUNIT_AUTOEXIT=true " +
                 $"-argument=-app-arg:-enablenetwork -setenv=NUNIT_ENABLE_NETWORK=true -setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1 -v -v " +
                 $"-argument=-app-arg:-hostname:127.0.0.1 -setenv=NUNIT_HOSTNAME=127.0.0.1 -argument=-app-arg:-transport:Tcp " +
                 $"-setenv=NUNIT_TRANSPORT=TCP -argument=-app-arg:-hostport:{_listener.Object.Port} " +
-                $"-setenv=NUNIT_HOSTPORT={_listener.Object.Port} --launchsim {StringUtils.FormatArguments(s_appPath)} " +
+                $"-setenv=NUNIT_HOSTPORT={_listener.Object.Port} {xmlParam}--launchsim {StringUtils.FormatArguments(s_appPath)} " +
                 $"--stdout=tty1 --stderr=tty1 --device=:v2:udid={simulator.Object.UDID}";
 
             _processManager
@@ -306,6 +316,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
+                true,
                 false);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
@@ -320,9 +331,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task RunOnDeviceSuccessfullyTest(bool useTunnel)
+        [InlineData(false, false)] // no tunnel, no xml
+        [InlineData(false, true)] // no tunnel, xml
+        [InlineData(true, false)] // tunnel, no xml
+        [InlineData(true, true)] // tunnel and xml
+        public async Task RunOnDeviceSuccessfullyTest(bool useTunnel, bool useXml)
         {
             var deviceSystemLog = new Mock<ILog>();
             deviceSystemLog.SetupGet(x => x.FullPath).Returns(Path.GetTempFileName());
@@ -363,6 +376,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
+                useXml,
                 useTunnel);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
@@ -380,13 +394,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var ips = string.Join(",", System.Net.Dns.GetHostEntry(System.Net.Dns.GetHostName()).AddressList.Select(ip => ip.ToString()));
 
             var tunnelParam = useTunnel ? "-setenv=USE_TCP_TUNNEL=true " : "";
+            var xmlParam = useXml ? "-setenv=NUNIT_ENABLE_XML_OUTPUT=true -setenv=NUNIT_ENABLE_XML_MODE=wrapped -setenv=NUNIT_XML_VERSION=xUnit " : "";
 
             var expectedArgs = $"-argument=-connection-mode -argument=none -argument=-app-arg:-autostart " +
                 $"-setenv=NUNIT_AUTOSTART=true -argument=-app-arg:-autoexit -setenv=NUNIT_AUTOEXIT=true " +
                 $"-argument=-app-arg:-enablenetwork -setenv=NUNIT_ENABLE_NETWORK=true -setenv=DISABLE_SYSTEM_PERMISSION_TESTS=1 -v -v " +
                 $"-argument=-app-arg:-hostname:{ips} -setenv=NUNIT_HOSTNAME={ips} -argument=-app-arg:-transport:Tcp " +
                 $"-setenv=NUNIT_TRANSPORT=TCP -argument=-app-arg:-hostport:{_listener.Object.Port} " +
-                $"-setenv=NUNIT_HOSTPORT={_listener.Object.Port} {tunnelParam}--launchdev {StringUtils.FormatArguments(s_appPath)} " +
+                $"-setenv=NUNIT_HOSTPORT={_listener.Object.Port} {tunnelParam}{xmlParam}--launchdev {StringUtils.FormatArguments(s_appPath)} " +
                 $"--disable-memory-limits --wait-for-exit --devname \"Test iPhone\"";
 
             _processManager


### PR DESCRIPTION
During the refactor we removed the env vars that are passed to the
runners to decide if xml is used and the jargon to use. The env
paramenters have been added and tests updated. Now the runners will get
notified that xml is used (always) and the jargon (default to xunit).

fixes: https://github.com/dotnet/xharness/issues/98
fixes: https://github.com/dotnet/xharness/issues/77