### PR TITLE
[iOS] Improve the TunnelBore API.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
@@ -76,7 +77,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             var processManager = new ProcessManager(_arguments.XcodeRoot, _arguments.MlaunchPath);
             var deviceLoader = new HardwareDeviceLoader(processManager);
             var simulatorLoader = new SimulatorLoader(processManager);
-            var tunnelBore = new TunnelBore(processManager);
+            var tunnelBore = (_channel == CommunicationChannel.UsbTunnel) ? new TunnelBore(processManager) : null;
 
             var logs = new Logs(_arguments.OutputDirectory);
 
@@ -178,8 +179,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     mainLog,
                     logs,
                     new Helpers(),
-                    useXmlOutput: true, // the cli ALWAYS will get the output as xml
-                    useTcpTunnel: _channel == CommunicationChannel.UsbTunnel);
+                    useXmlOutput: true); // the cli ALWAYS will get the output as xml
 
                 (deviceName, success) = await appRunner.RunApp(appBundleInfo,
                     target,

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             bool useTcpTunnel);
 
         ITunnelBore TunnelBore { get; }
+        bool UseTunnel { get; }
     }
 
     public class SimpleListenerFactory : ISimpleListenerFactory
@@ -33,10 +34,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public ITunnelBore TunnelBore { get; private set; }
 
-        public SimpleListenerFactory(ITunnelBore tunnelBore)
-        {
-            TunnelBore = tunnelBore ?? throw new ArgumentNullException(nameof(tunnelBore));
-        }
+        public bool UseTunnel => TunnelBore != null;
+
+        public SimpleListenerFactory(ITunnelBore tunnelBore) =>
+            TunnelBore = tunnelBore; // allow it to be null in case we are working with a sim
 
         public (ListenerTransport transport, ISimpleListener listener, string listenerTempFile) Create(
             RunMode mode,

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -22,8 +22,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             ILog testLog,
             bool isSimulator,
             bool autoExit,
-            bool xmlOutput,
-            bool useTcpTunnel);
+            bool xmlOutput);
 
         ITunnelBore TunnelBore { get; }
         bool UseTunnel { get; }
@@ -45,8 +44,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             ILog testLog,
             bool isSimulator,
             bool autoExit,
-            bool xmlOutput,
-            bool useTcpTunnel)
+            bool xmlOutput)
         {
             string listenerTempFile = null;
             ISimpleListener listener;
@@ -71,7 +69,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     listener = new SimpleHttpListener(log, testLog, autoExit);
                     break;
                 case ListenerTransport.Tcp:
-                    listener = new SimpleTcpListener(log, testLog, autoExit, useTcpTunnel);
+                    listener = new SimpleTcpListener(log, testLog, autoExit, UseTunnel);
                     break;
                 default:
                     throw new NotImplementedException("Unknown type of listener");

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public bool UseTunnel => TunnelBore != null;
 
-        public SimpleListenerFactory(ITunnelBore tunnelBore) =>
+        public SimpleListenerFactory(ITunnelBore tunnelBore = null) =>
             TunnelBore = tunnelBore; // allow it to be null in case we are working with a sim
 
         public (ListenerTransport transport, ISimpleListener listener, string listenerTempFile) Create(

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -31,7 +31,6 @@ namespace Microsoft.DotNet.XHarness.iOS
         private readonly ILogs _logs;
         private readonly ILog _mainLog;
         private readonly IHelpers _helpers;
-        private readonly bool _useTcpTunnel;
         private readonly bool _useXmlOutput;
 
         public AppRunner(IProcessManager processManager,
@@ -45,8 +44,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             ILog mainLog,
             ILogs logs,
             IHelpers helpers,
-            bool useXmlOutput,
-            bool useTcpTunnel)
+            bool useXmlOutput)
         {
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
             _hardwareDeviceLoader = hardwareDeviceLoader ?? throw new ArgumentNullException(nameof(hardwareDeviceLoader));
@@ -60,7 +58,6 @@ namespace Microsoft.DotNet.XHarness.iOS
             _logs = logs ?? throw new ArgumentNullException(nameof(logs));
             _helpers = helpers ?? throw new ArgumentNullException(nameof(helpers));
             _useXmlOutput = useXmlOutput;
-            _useTcpTunnel = useTcpTunnel;
         }
 
         public async Task<(string deviceName, bool success)> RunApp(
@@ -131,7 +128,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             args.Add(new SetAppArgumentArgument($"-hostport:{listener.Port}", true));
             args.Add(new SetEnvVariableArgument("NUNIT_HOSTPORT", listener.Port));
 
-            if (_useTcpTunnel && !isSimulator) // simulators do not support tunnels
+            if (_listenerFactory.UseTunnel && !isSimulator) // simulators do not support tunnels
             {
                 args.Add(new SetEnvVariableArgument("USE_TCP_TUNNEL", true));
             }
@@ -350,7 +347,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     await crashReporter.StartCaptureAsync();
 
                     // create a tunnel to communicate with the device
-                    if (transport == ListenerTransport.Tcp && _useTcpTunnel && listener is SimpleTcpListener tcpListener)
+                    if (transport == ListenerTransport.Tcp && _listenerFactory.UseTunnel && listener is SimpleTcpListener tcpListener)
                     {
                         // create a new tunnel using the listener
                         var tunnel = _listenerFactory.TunnelBore.Create(deviceName, _mainLog);
@@ -377,7 +374,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     deviceSystemLog.Dispose();
 
                     // close a tunnel if it was created
-                    if (!isSimulator)
+                    if (!isSimulator && _listenerFactory.UseTunnel)
                         await _listenerFactory.TunnelBore.Close(deviceName);
                 }
 

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             }
 
             var listenerLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: true);
-            var (transport, listener, listenerTmpFile) = _listenerFactory.Create(target.ToRunMode(), _mainLog, listenerLog, isSimulator, true, false, false);
+            var (transport, listener, listenerTmpFile) = _listenerFactory.Create(target.ToRunMode(), _mainLog, listenerLog, isSimulator, true, false);
 
             // Initialize has to be called before we try to get Port (internal implementation of the listener says so)
             // TODO: Improve this to not get into a broken state - it was really hard to debug when I moved this lower

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         public SimpleListenerFactoryTest()
         {
             _log = new Mock<ILog>();
-            _factory = new SimpleListenerFactory(Mock.Of<ITunnelBore> ());
+            _factory = new SimpleListenerFactory();
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         [Fact]
         public void CreateNotWatchListener()
         {
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true, false);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true);
             Assert.Equal(ListenerTransport.Tcp, transport);
             Assert.IsType<SimpleTcpListener>(listener);
             Assert.Null(listenerTmpFile);
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             var logFullPath = "myfullpath.txt";
             _ = _log.Setup(l => l.FullPath).Returns(logFullPath);
 
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true, false);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true);
             Assert.Equal(ListenerTransport.File, transport);
             Assert.IsType<SimpleFileListener>(listener);
             Assert.NotNull(listenerTmpFile);
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         [Fact]
         public void CreateWatchOSDevice()
         {
-            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true, false);
+            var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true);
             Assert.Equal(ListenerTransport.Http, transport);
             Assert.IsType<SimpleHttpListener>(listener);
             Assert.Null(listenerTmpFile);

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -21,6 +21,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         }
 
         [Fact]
+        public void ConstructorAllowsNullTunnelBore()
+        {
+            var f = new SimpleListenerFactory(null); // if it throws, test fails ;)
+        }
+
+        [Fact]
         public void CreateNotWatchListener()
         {
             var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true, false);
@@ -52,6 +58,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             Assert.Equal(ListenerTransport.Http, transport);
             Assert.IsType<SimpleHttpListener>(listener);
             Assert.Null(listenerTmpFile);
+        }
+
+        [Fact]
+        public void UseTcpTunnel()
+        {
+            var f = new SimpleListenerFactory(null);
+            Assert.False(f.UseTunnel, "Do not use tunnel.");
+            f = new SimpleListenerFactory(Mock.Of<ITunnelBore>());
+            Assert.True(f.UseTunnel, "Use tunnel.");
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -43,8 +43,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
         private readonly Mock<ITestReporter> _testReporter;
         private readonly Mock<IHelpers> _helpers;
         private readonly Mock<ITunnelBore> _tunnelBore;
+        private readonly Mock<ISimpleListenerFactory> _listenerFactory;
 
-        private readonly ISimpleListenerFactory _listenerFactory;
         private readonly ICrashSnapshotReporterFactory _snapshotReporterFactory;
         private readonly ITestReporterFactory _testReporterFactory;
 
@@ -91,10 +91,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             _tunnelBore = new Mock<ITunnelBore>();
             _tunnelBore.Setup(t => t.Close(It.IsAny<string>()));
 
-            var factory = new Mock<ISimpleListenerFactory>();
-            factory.SetReturnsDefault((ListenerTransport.Tcp, _listener.Object, "listener-temp-file"));
-            factory.Setup(f => f.TunnelBore).Returns(_tunnelBore.Object);
-            _listenerFactory = factory.Object;
+            _listenerFactory = new Mock<ISimpleListenerFactory>();
+            _listenerFactory.SetReturnsDefault((ListenerTransport.Tcp, _listener.Object, "listener-temp-file"));
+            _listenerFactory.Setup(f => f.TunnelBore).Returns(_tunnelBore.Object);
             _listener.SetupGet(x => x.Port).Returns(1020);
 
             var factory2 = new Mock<ICrashSnapshotReporterFactory>();
@@ -158,11 +157,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                    It.IsAny<string>()))
                 .Returns(captureLog.Object);
 
+            _listenerFactory.Setup(f => f.UseTunnel).Returns(useTcpTunnel);
             // Act
             var appRunner = new AppRunner(_processManager.Object,
                 _hardwareDeviceLoader.Object,
                 _simulatorLoader.Object,
-                _listenerFactory,
+                _listenerFactory.Object,
                 _snapshotReporterFactory,
                 captureLogFactory.Object,
                 Mock.Of<IDeviceLogCapturerFactory>(),
@@ -170,8 +170,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
-                useXmlOutput,
-                useTcpTunnel);
+                useXmlOutput);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
 
@@ -233,11 +232,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                    It.IsAny<string>()))
                 .Returns(captureLog.Object);
 
+            _listenerFactory.Setup(f => f.UseTunnel).Returns((useTunnel));
             // Act
             var appRunner = new AppRunner(_processManager.Object,
                 _hardwareDeviceLoader.Object,
                 _simulatorLoader.Object,
-                _listenerFactory,
+                _listenerFactory.Object,
                 _snapshotReporterFactory,
                 captureLogFactory.Object,
                 Mock.Of<IDeviceLogCapturerFactory>(),
@@ -245,8 +245,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
-                useXml,
-                useTunnel);
+                useXml);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
 
@@ -304,11 +303,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 .Setup(x => x.FindDevice(RunMode.iOS, _mainLog.Object, false, false))
                 .ThrowsAsync(new NoDeviceFoundException());
 
+            _listenerFactory.Setup(f => f.UseTunnel).Returns(false);
             // Act
             var appRunner = new AppRunner(_processManager.Object,
                 _hardwareDeviceLoader.Object,
                 _simulatorLoader.Object,
-                _listenerFactory,
+                _listenerFactory.Object,
                 _snapshotReporterFactory,
                 Mock.Of<ICaptureLogFactory>(),
                 Mock.Of<IDeviceLogCapturerFactory>(),
@@ -316,8 +316,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
-                true,
-                false);
+                true);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
 
@@ -364,11 +363,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _tunnelBore.Setup(t => t.Create("Test iPhone", It.IsAny<ILog>()));
             }
 
+            _listenerFactory.Setup(f => f.UseTunnel).Returns((useTunnel));
             // Act
             var appRunner = new AppRunner(_processManager.Object,
                 _hardwareDeviceLoader.Object,
                 _simulatorLoader.Object,
-                _listenerFactory,
+                _listenerFactory.Object,
                 _snapshotReporterFactory,
                 Mock.Of<ICaptureLogFactory>(),
                 deviceLogCapturerFactory.Object,
@@ -376,8 +376,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _mainLog.Object,
                 _logs.Object,
                 _helpers.Object,
-                useXml,
-                useTunnel);
+                useXml);
 
             var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
 


### PR DESCRIPTION
Remove the need to use a bool. Allow the factory to take a null tunnel
bore (less memory used) and add a property that will tell use if the
factory will use a tunnel bore.