### PR TITLE
[Runners] Respect the usage of xunit.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -38,19 +38,9 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
 
             var runner = await InternalRunAsync(logger);
 
-            TestRunner.Jargon jargon;
-            switch (options.XmlVersion)
-            {
-                case XmlVersion.NUnitV2:
-                    jargon = Core.TestRunner.Jargon.NUnitV2;
-                    break;
-                case XmlVersion.NUnitV3: // nunitv3 gives os the most amount of possible details
-                    jargon = Core.TestRunner.Jargon.NUnitV3;
-                    break;
-                default:
-                    jargon = Core.TestRunner.Jargon.xUnit;
-                    break;
-            }
+
+            TestRunner.Jargon jargon = options.XmlVersion.ToTestRunnerJargon();
+
             if (options.EnableXml)
             {
                 if (TestsResultsFinalPath == null)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -21,6 +21,20 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         xUnit = 2,
     }
 
+    internal static class XmlVersionExtensions {
+
+        public static TestRunner.Jargon ToTestRunnerJargon(this XmlVersion version)
+        {
+            return version switch
+            {
+                XmlVersion.NUnitV2 => TestRunner.Jargon.NUnitV2,
+                XmlVersion.NUnitV3 => TestRunner.Jargon.NUnitV3,
+                XmlVersion.xUnit => TestRunner.Jargon.xUnit,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+
     internal class ApplicationOptions
     {
 

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
@@ -35,17 +35,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
             // if we have ignore files, ignore those tests
             var runner = await InternalRunAsync(logger);
 
-            TestRunner.Jargon jargon = Core.TestRunner.Jargon.NUnitV3;
-            switch (options.XmlVersion)
-            {
-                case XmlVersion.NUnitV2:
-                    jargon = Core.TestRunner.Jargon.NUnitV2;
-                    break;
-                case XmlVersion.NUnitV3:
-                default: // nunitv3 gives os the most amount of possible details
-                    jargon = Core.TestRunner.Jargon.NUnitV3;
-                    break;
-            }
+            TestRunner.Jargon jargon = options.XmlVersion.ToTestRunnerJargon();
 
             if (options.EnableXml)
             {


### PR DESCRIPTION
We forgot to update the applicaiton entry points to consider the usage
of xunit.

fixes: https://github.com/dotnet/xharness/issues/111