### PR TITLE
[iOS] If the user tries to install the app in the wrong arch, let him know.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
@@ -1,0 +1,35 @@
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared
+{
+    /// <summary>
+    /// Interface to be implemented to determine if error in the installation, build and execution of the tests
+    /// are known. This class will help users understand better why an error ocurred.
+    /// </summary>
+    public interface IErrorKnowledgeBase
+    {
+        /// <summary>
+        /// Identifies via the logs if the installation failure is due to a known issue that the user can act upon.
+        /// </summary>
+        /// <param name="installLog">The installation log.</param>
+        /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
+        /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
+        bool IsKnownInstallIssue(ILog installLog, out string knownFailureMessage);
+
+        /// <summary>
+        /// Identifies via the logs if the build failure is due to a known issue that the user can act upon.
+        /// </summary>
+        /// <param name="buildLog">The build log.</param>
+        /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
+        /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
+        bool IsKnownBuildIssue(ILog buildLog, out string knownFailureMessage);
+
+        /// <summary>
+        /// Identifies via the logs if the run failure is due to a known issue that the user can act upon.
+        /// </summary>
+        /// <param name="runLog">The run log.</param>
+        /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
+        /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
+        bool IsKnownTestIssue(ILog runLog, out string knownFailureMessage);
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS/ErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/ErrorKnowledgeBase.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+
+namespace Microsoft.DotNet.XHarness.iOS
+{
+    public class ErrorKnowledgeBase : IErrorKnowledgeBase
+    {
+        const string IncorrectArchPrefix = "IncorrectArchitecture";
+
+        public bool IsKnownInstallIssue(ILog installLog, out string knownFailureMessage)
+        {
+            knownFailureMessage = null;
+            if (installLog == null)
+            {
+                return false;
+            }
+
+            if (File.Exists(installLog.FullPath) && new FileInfo(installLog.FullPath).Length > 0)
+            {
+                using StreamReader reader = installLog.GetReader();
+                while (!reader.EndOfStream)
+                {
+                    string line = reader.ReadLine();
+                    if (line == null)
+                    {
+                        continue;
+                    }
+
+                    var index = line.IndexOf("IncorrectArchitecture", StringComparison.Ordinal);
+                    if (index >= 0)
+                    {
+                        // add the information from the line, which is good enough
+                        knownFailureMessage = line.Substring(index); // remove the timestamp if any
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsKnownBuildIssue(ILog buildLog, out string knownFailureMessage)
+        {
+            knownFailureMessage = null;
+            return false;
+        }
+
+        public bool IsKnownTestIssue(ILog runLog, out string knownFailureMessage)
+        {
+            knownFailureMessage = null;
+            return false;
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/ErrorKnowledgeBaseTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/ErrorKnowledgeBaseTests.cs
@@ -16,42 +16,51 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
         [Fact]
         public void WrongArchPresentTest()
         {
+            var logPath = Path.GetTempFileName();
             var expectedFailureMessage =
                 "IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Ic8Ank/extracted/monotouchtest.app/monotouchtest";
-            using var log = new LogFile("test", Path.GetTempFileName());
-            // write some data in it
-            log.WriteLine("InstallingEmbeddedProfile: 65%");
-            log.WriteLine("PercentComplete: 30");
-            log.WriteLine("Status: InstallingEmbeddedProfile");
-            log.WriteLine("VerifyingApplication: 70%");
-            log.WriteLine("PercentComplete: 40");
-            log.WriteLine("Status: VerifyingApplication");
-            log.WriteLine("IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Ic8Ank/extracted/monotouchtest.app/monotouchtest");
-            log.Flush();
+            using (var log = new LogFile("test", logPath))
+            {
+                // write some data in it
+                log.WriteLine("InstallingEmbeddedProfile: 65%");
+                log.WriteLine("PercentComplete: 30");
+                log.WriteLine("Status: InstallingEmbeddedProfile");
+                log.WriteLine("VerifyingApplication: 70%");
+                log.WriteLine("PercentComplete: 40");
+                log.WriteLine("Status: VerifyingApplication");
+                log.WriteLine(
+                    "IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Ic8Ank/extracted/monotouchtest.app/monotouchtest");
+                log.Flush();
 
-            Assert.True(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
-            Assert.Equal(expectedFailureMessage, failureMessage);
-            if (File.Exists(log.FullPath))
-                File.Delete(log.FullPath);
+                Assert.True(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
+                Assert.Equal(expectedFailureMessage, failureMessage);
+            }
+
+            if (File.Exists(logPath))
+                File.Delete(logPath);
         }
 
         [Fact]
         public void WrongArchNotPresentTest()
         {
-            using var log = new LogFile("test", Path.GetTempFileName());
-            // write some data in it
-            log.WriteLine("InstallingEmbeddedProfile: 65%");
-            log.WriteLine("PercentComplete: 30");
-            log.WriteLine("Status: InstallingEmbeddedProfile");
-            log.WriteLine("VerifyingApplication: 70%");
-            log.WriteLine("PercentComplete: 40");
-            log.WriteLine("Status: VerifyingApplication");
-            log.Flush();
+            var logPath = Path.GetTempFileName();
+            using (var log = new LogFile("test", logPath))
+            {
+                // write some data in it
+                log.WriteLine("InstallingEmbeddedProfile: 65%");
+                log.WriteLine("PercentComplete: 30");
+                log.WriteLine("Status: InstallingEmbeddedProfile");
+                log.WriteLine("VerifyingApplication: 70%");
+                log.WriteLine("PercentComplete: 40");
+                log.WriteLine("Status: VerifyingApplication");
+                log.Flush();
 
-            Assert.False(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
-            Assert.Null(failureMessage);
-            if (File.Exists(log.FullPath))
-                File.Delete(log.FullPath);
+                Assert.False(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
+                Assert.Null(failureMessage);
+            }
+
+            if (File.Exists(logPath))
+                File.Delete(logPath);
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/ErrorKnowledgeBaseTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/ErrorKnowledgeBaseTests.cs
@@ -1,0 +1,57 @@
+using System.IO;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.iOS.Tests
+{
+    public class ErrorKnowledgeBaseTests
+    {
+        readonly ErrorKnowledgeBase _errorKnowledgeBase;
+
+        public ErrorKnowledgeBaseTests()
+        {
+            _errorKnowledgeBase = new ErrorKnowledgeBase();
+        }
+
+        [Fact]
+        public void WrongArchPresentTest()
+        {
+            var expectedFailureMessage =
+                "IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Ic8Ank/extracted/monotouchtest.app/monotouchtest";
+            using var log = new LogFile("test", Path.GetTempFileName());
+            // write some data in it
+            log.WriteLine("InstallingEmbeddedProfile: 65%");
+            log.WriteLine("PercentComplete: 30");
+            log.WriteLine("Status: InstallingEmbeddedProfile");
+            log.WriteLine("VerifyingApplication: 70%");
+            log.WriteLine("PercentComplete: 40");
+            log.WriteLine("Status: VerifyingApplication");
+            log.WriteLine("IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Ic8Ank/extracted/monotouchtest.app/monotouchtest");
+            log.Flush();
+
+            Assert.True(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
+            Assert.Equal(expectedFailureMessage, failureMessage);
+            if (File.Exists(log.FullPath))
+                File.Delete(log.FullPath);
+        }
+
+        [Fact]
+        public void WrongArchNotPresentTest()
+        {
+            using var log = new LogFile("test", Path.GetTempFileName());
+            // write some data in it
+            log.WriteLine("InstallingEmbeddedProfile: 65%");
+            log.WriteLine("PercentComplete: 30");
+            log.WriteLine("Status: InstallingEmbeddedProfile");
+            log.WriteLine("VerifyingApplication: 70%");
+            log.WriteLine("PercentComplete: 40");
+            log.WriteLine("Status: VerifyingApplication");
+            log.Flush();
+
+            Assert.False(_errorKnowledgeBase.IsKnownInstallIssue(log, out var failureMessage));
+            Assert.Null(failureMessage);
+            if (File.Exists(log.FullPath))
+                File.Delete(log.FullPath);
+        }
+    }
+}


### PR DESCRIPTION
If a user tries to execute the test command with an application and
the wrong device arch, do notify him since we do know is an expected
error.

Sample output:
```
info: test[0]
      Starting test for ios-device targeting XQAiPodTouch5f..
info: test[0]
      Installing application 'MonoTouchTest' on  on device 'XQAiPodTouch5f'
fail: test[0]
      Failed to install the app bundle (exit code=1): IncorrectArchitecture: Failed to find matching arch for 64-bit Mach-O input file /private/var/installd/Library/Caches/com.apple.mobile.installd.staging/temp.Z91Igw/extracted/monotouchtest.app/monotouchtest
XHarness exit code: -43
```

fixes: https://github.com/dotnet/xharness/issues/88