### PR TITLE
[iOS] If we use simulators do not use a tunnel.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -78,8 +78,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             var processManager = new ProcessManager(_arguments.XcodeRoot, _arguments.MlaunchPath);
             var deviceLoader = new HardwareDeviceLoader(processManager);
             var simulatorLoader = new SimulatorLoader(processManager);
-            var hasSimulators = _arguments.TestTargets.Where(t => t.IsSimulator()).Any();
-            var tunnelBore = (_channel == CommunicationChannel.UsbTunnel && !hasSimulators) ? new TunnelBore(processManager) : null;
 
             var logs = new Logs(_arguments.OutputDirectory);
 
@@ -90,7 +88,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             foreach (TestTarget target in _arguments.TestTargets)
             {
-                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader, tunnelBore, cts.Token);
+                var tunnelBore = (_channel == CommunicationChannel.UsbTunnel && !target.IsSimulator())
+                    ? new TunnelBore(processManager)
+                    : null;
+                var exitCodeForRun = await RunTest(target, logs, processManager, deviceLoader, simulatorLoader,
+                    tunnelBore, cts.Token);
 
                 if (exitCodeForRun != ExitCode.SUCCESS)
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -78,7 +78,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             var processManager = new ProcessManager(_arguments.XcodeRoot, _arguments.MlaunchPath);
             var deviceLoader = new HardwareDeviceLoader(processManager);
             var simulatorLoader = new SimulatorLoader(processManager);
-            var tunnelBore = (_channel == CommunicationChannel.UsbTunnel) ? new TunnelBore(processManager) : null;
+            var hasSimulators = _arguments.TestTargets.Where(t => t.IsSimulator()).Any();
+            var tunnelBore = (_channel == CommunicationChannel.UsbTunnel && !hasSimulators) ? new TunnelBore(processManager) : null;
 
             var logs = new Logs(_arguments.OutputDirectory);
 


### PR DESCRIPTION
Check what targets are passed to the CLI and do not use tunnels in that
case.

fixes: https://github.com/dotnet/xharness/issues/126