### PR TITLE
[Common] Add version command.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessVersionCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessVersionCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Mono.Options;
+
+namespace Microsoft.DotNet.XHarness.CLI.Commands
+{
+    internal class XHarnessVersionCommand : Command
+    {
+        public XHarnessVersionCommand() : base("version") { }
+
+        public override int Invoke(IEnumerable<string> arguments)
+        {
+            // ignore arguments, print the name of the tool and the version number unix style, for example
+            // man --version
+            // man, version 1.6g
+            // gcc --version
+            // Apple clang version 11.0.3 (clang-1103.0.32.29)
+            // Target: x86_64-apple-darwin19.4.0
+            // Thread model: posix
+            // InstalledDir: /Applications/Xcode114.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+            var assembly = Assembly.GetExecutingAssembly();
+            var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+            Console.WriteLine($"xharness version {fvi.ProductVersion} ({fvi.OriginalFilename})");
+            Console.WriteLine($"InstalledDir: {fvi.FileName}");
+            return 0;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Program.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Program.cs
@@ -21,12 +21,13 @@ namespace Microsoft.DotNet.XHarness.CLI
             // Root command: will use the platform specific commands to perform the appropriate action.
             var commands = new CommandSet("xharness")
             {
-                // Add per-platform CommandSets - If adding  a new supported set, that goes here. 
+                // Add per-platform CommandSets - If adding  a new supported set, that goes here.
                 new iOSCommandSet(),
                 new AndroidCommandSet(),
 
                 // add shared commands, for example, help and so on. --version, --help, --verbosity and so on
-                new XHarnessHelpCommand()
+                new XHarnessHelpCommand(),
+                new XHarnessVersionCommand(),
             };
 
             int result = commands.Run(args);


### PR DESCRIPTION
Add a version command that via reflection will get the xharness version.
More data can be added, currently the version printed is:

```bash
dotnet tool xharness version
xharness version 1.0.0-dev (Microsoft.DotNet.XHarness.CLI.exe)
InstalledDir:
/Users/mandel/Xamarin/xharness/artifacts/bin/Microsoft.DotNet.XHarness.CLI/Debug/netcoreapp3.1/Microsoft.DotNet.XHarness.CLI.dll
```

fixes: https://github.com/dotnet/xharness/issues/110