### PR TITLE
[Runners] Do not filter per Attr, make client use traits.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
@@ -58,8 +58,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         public long ExecutedTests { get; protected set; } = 0;
 
         /// <summary>
-        /// Total number of tests. This icludes, executed, ignored, filtered 
-		/// and skipped tests.
+        /// Total number of tests. This icludes, executed, ignored, filtered
+        /// and skipped tests.
         /// </summary>
         public long TotalTests { get; protected set; } = 0;
 
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
 
         /// <summary>
         /// Specify if the runner should log those tests that have been excluded
-        /// due to a filter. Default is false. 
+        /// due to a filter. Default is false.
         /// </summary>
         public bool LogExcludedTests { get; set; }
 
@@ -122,8 +122,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         public abstract void WriteResultsToFile(TextWriter writer, Jargon jargon);
         public abstract void SkipTests(IEnumerable<string> tests);
         public abstract void SkipCategories(IEnumerable<string> categories);
-
-        public abstract void SkipAttributes(IEnumerable<string> attributes);
 
         protected void OnError(string message)
         {
@@ -203,7 +201,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         {
             var handler = TestCompleted;
             if (handler != null)
-                handler(this, result); 
+                handler(this, result);
 		}
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitFilter.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitFilter.cs
@@ -86,23 +86,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             };
         }
 
-        public static XUnitFilter CreateAttributeFilter(string attributeName, bool exclude)
-        {
-            if (string.IsNullOrEmpty((attributeName)))
-            {
-                throw new ArgumentException("must not be null or empty", nameof(attributeName));
-            }
-
-            return new XUnitFilter
-            {
-                AssemblyName = null,
-                SelectorName = attributeName,
-                SelectorValue = null,
-                FilterType = XUnitFilterType.Attribute,
-                Exclude = exclude
-            };
-        }
-
         public override string ToString()
         {
             var sb = new StringBuilder("XUnitFilter [");
@@ -135,10 +118,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                     AppendDesc("Class", SelectorValue);
                     break;
 
-                case XUnitFilterType.Attribute:
-                    AppendDesc("Attribute", SelectorValue);
-                    break;
-                
                 default:
                     sb.Append("; Unknown filter type");
                     break;

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitFilterType.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitFilterType.cs
@@ -11,6 +11,5 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
         Assembly,
         Single,
         Namespace,
-        Attribute,
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -1101,13 +1101,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                     continue;
                 }
 
-                if (filter.FilterType == XUnitFilterType.Attribute)
-                {
-                    if (testCase.TestMethod.Method.GetCustomAttributes(filter.SelectorName).Any())
-                        return ReportFilteredTest(filter);
-                    continue;
-                }
-
                 if (filter.FilterType == XUnitFilterType.Assembly)
                 {
                     continue; // Ignored: handled elsewhere
@@ -1176,7 +1169,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
         {
             if (categories == null)
                 throw new ArgumentNullException(nameof(categories));
-            
+
             foreach (var c in categories)
             {
                 var traitInfo = c.Split('=');
@@ -1186,17 +1179,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                 } else {
                     filters.Add(XUnitFilter.CreateTraitFilter(c, null, true));
                 }
-            }
-        }
-
-        public override void SkipAttributes(IEnumerable<string> attributes)
-        {
-            if (attributes == null)
-                throw new ArgumentNullException(nameof(attributes));
-
-            foreach (var attr in attributes)
-            {
-                filters.Add(XUnitFilter.CreateAttributeFilter(attr, true));
             }
         }
     }

--- a/tests/Microsoft.DotNet.XHarness.Tests.Runners.Tests/xUnit/XUnitFilterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Tests.Runners.Tests/xUnit/XUnitFilterTests.cs
@@ -119,24 +119,5 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests
             Assert.Equal(XUnitFilterType.Trait, filter.FilterType);
         }
 
-        [Fact]
-        public void CreateAttributeFilterNullName()
-        {
-            Assert.Throws<ArgumentException>(() => XUnitFilter.CreateAttributeFilter(null, true));
-            Assert.Throws<ArgumentException>(() => XUnitFilter.CreateAttributeFilter("", true));
-        }
-
-        [Theory]
-        [InlineData("MyAttribute", true)]
-        [InlineData("MyAttribute", false)]
-        public void CreateAttributeFilter(string attributeName, bool excluded)
-        {
-            var filter = XUnitFilter.CreateAttributeFilter(attributeName, excluded);
-            Assert.Equal(attributeName, filter.SelectorName);
-            Assert.Null(filter.AssemblyName);
-            Assert.Null(filter.SelectorValue);
-            Assert.Equal(excluded, filter.Exclude);
-            Assert.Equal(XUnitFilterType.Attribute, filter.FilterType);
-        }
     }
 }


### PR DESCRIPTION
We support traits from the very first release, those have to be passed in
a file that is provided by the child of the entry point:

IgnoreFilesDirectory.

That directory can contain two diff files:

* xunit-excludes.txt
* nunit-excludes.txt

I have updated the docs to describe what should be done since is the
root of the misscommunication.

fixes: https://github.com/dotnet/xharness/issues/137