### PR TITLE
[iOS] Add support to parse the arch of a csproj or a plist.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformation.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformation.cs
@@ -11,14 +11,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         public string AppPath { get; }
         public string Variation { get; set; }
         public string LaunchAppPath { get; }
+        public bool Supports32Bit { get; }
         public Extension? Extension { get; }
 
-        public AppBundleInformation(string appName, string bundleIdentifier, string appPath, string launchAppPath, Extension? extension)
+        public AppBundleInformation(string appName, string bundleIdentifier, string appPath, string launchAppPath, bool supports32b, Extension? extension)
         {
             AppName = appName;
             BundleIdentifier = bundleIdentifier;
             AppPath = appPath;
             LaunchAppPath = launchAppPath;
+            Supports32Bit = supports32b;
             Extension = extension;
         }
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 ? Directory.GetDirectories(Path.Combine(appPackagePath, "Watch"), "*.app")[0]
                 : appPackagePath;
 
-            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, supports32.Contains(Armv7), extension: null);
+            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, supports32.Contains(Armv7, StringComparison.InvariantCultureIgnoreCase), extension: null);
         }
 
         private async Task<string> GetPlistProperty(string plistPath, string propertyName, ILog log, CancellationToken cancellationToken = default)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
     public class AppBundleInformationParser : IAppBundleInformationParser
     {
         private const string PlistBuddyPath = "/usr/libexec/PlistBuddy";
+        private const string Armv7 = "armv7";
 
         private readonly IProcessManager _processManager;
 
@@ -56,6 +57,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 csproj.GetOutputPath(platform, buildConfiguration).Replace('\\', Path.DirectorySeparatorChar),
                 appName + (extension != null ? ".appex" : ".app"));
 
+            string arch = csproj.GetMtouchArch(platform, buildConfiguration);
+            bool supports32 = arch.Contains("ARMv7") || arch.Contains("i386");
+
             if (!Directory.Exists(appPath))
                 throw new DirectoryNotFoundException($"The app bundle directory `{appPath}` does not exist");
 
@@ -63,7 +67,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 ? Directory.GetDirectories(Path.Combine(appPath, "Watch"), "*.app")[0]
                 : appPath;
 
-            return new AppBundleInformation(appName, bundleIdentifier, appPath, launchAppPath, extension);
+            return new AppBundleInformation(appName, bundleIdentifier, appPath, launchAppPath, supports32, extension);
         }
 
         public async Task<AppBundleInformation> ParseFromAppBundle(string appPackagePath, TestTarget target, ILog log, CancellationToken cancellationToken = default)
@@ -77,12 +81,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
 
             var appName = await GetPlistProperty(plistPath, PListExtensions.BundleNamePropertyName, log, cancellationToken);
             var bundleIdentifier = await GetPlistProperty(plistPath, PListExtensions.BundleIdentifierPropertyName, log, cancellationToken);
+            var supports32 = await GetPlistProperty(plistPath, PListExtensions.RequiredDeviceCapabilities, log, cancellationToken);
 
             string launchAppPath = target.ToRunMode() == RunMode.WatchOS
                 ? Directory.GetDirectories(Path.Combine(appPackagePath, "Watch"), "*.app")[0]
                 : appPackagePath;
 
-            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, extension: null);
+            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, supports32.Contains(Armv7), extension: null);
         }
 
         private async Task<string> GetPlistProperty(string plistPath, string propertyName, ILog log, CancellationToken cancellationToken = default)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 appName + (extension != null ? ".appex" : ".app"));
 
             string arch = csproj.GetMtouchArch(platform, buildConfiguration);
-            bool supports32 = arch.Contains("ARMv7") || arch.Contains("i386");
+            bool supports32 = arch.Contains("ARMv7", StringComparison.InvariantCultureIgnoreCase) || arch.Contains("i386", StringComparison.InvariantCultureIgnoreCase);
 
             if (!Directory.Exists(appPath))
                 throw new DirectoryNotFoundException($"The app bundle directory `{appPath}` does not exist");

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Xml;
 
@@ -11,6 +12,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
     {
         public const string BundleIdentifierPropertyName = "CFBundleIdentifier";
         public const string BundleNamePropertyName = "CFBundleName";
+        public const string RequiredDeviceCapabilities = "UIRequiredDeviceCapabilities";
 
         public static void LoadWithoutNetworkAccess(this XmlDocument doc, string filename)
         {
@@ -54,43 +56,44 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             plist.SetPListStringValue("LSMinimumSystemVersion", value);
         }
 
-        public static void SetCFBundleDisplayName(this XmlDocument plist, string value)
-        {
+        public static void SetCFBundleDisplayName(this XmlDocument plist, string value) =>
             plist.SetPListStringValue("CFBundleDisplayName", value);
-        }
 
-        public static string GetMinimumOSVersion(this XmlDocument plist)
-        {
-            return plist.GetPListStringValue("MinimumOSVersion");
-        }
+        public static string GetCFBundleDisplayName(this XmlDocument plist) =>
+            plist.GetPListStringValue("CFBundleDisplayName");
 
-        public static void SetCFBundleIdentifier(this XmlDocument plist, string value)
-        {
+        public static string GetMinimumOSVersion(this XmlDocument plist) =>
+            plist.GetPListStringValue("MinimumOSVersion");
+
+        public static string GetMinimummacOSVersion(this XmlDocument plist) =>
+            plist.GetPListStringValue("LSMinimumSystemVersion");
+
+        public static void SetCFBundleIdentifier(this XmlDocument plist, string value) =>
             plist.SetPListStringValue(BundleIdentifierPropertyName, value);
-        }
 
-        public static void SetCFBundleName(this XmlDocument plist, string value)
-        {
+        public static void SetCFBundleName(this XmlDocument plist, string value) =>
             plist.SetPListStringValue(BundleNamePropertyName, value);
-        }
 
-        public static void SetUIDeviceFamily(this XmlDocument plist, params int[] families)
-        {
+        public static void SetUIDeviceFamily(this XmlDocument plist, params int[] families) =>
             plist.SetPListArrayOfIntegerValues("UIDeviceFamily", families);
-        }
 
-        public static string GetCFBundleIdentifier(this XmlDocument plist)
-        {
-            return plist.GetPListStringValue(BundleIdentifierPropertyName);
-        }
+        public static string GetCFBundleIdentifier(this XmlDocument plist) =>
+            plist.GetPListStringValue(BundleIdentifierPropertyName);
 
-        public static string GetNSExtensionPointIdentifier(this XmlDocument plist)
-        {
-            return plist.SelectSingleNode("//dict/key[text()='NSExtensionPointIdentifier']")?.NextSibling?.InnerText;
-        }
+        public static string GetCFBundleName(this XmlDocument plist) =>
+            plist.GetPListStringValue(BundleNamePropertyName);
+
+        public static string GetNSExtensionPointIdentifier(this XmlDocument plist) =>
+            plist.SelectSingleNode("//dict/key[text()='NSExtensionPointIdentifier']")?.NextSibling?.InnerText;
 
         public static void SetPListStringValue(this XmlDocument plist, string node, string value)
         {
+            if (node == null)
+                throw new ArgumentNullException(nameof(node));
+
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
             var element = plist.SelectSingleNode("//dict/key[text()='" + node + "']");
             if (element == null)
             {
@@ -124,10 +127,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             root.AppendChild(valueElement);
         }
 
-        public static bool ContainsKey(this XmlDocument plist, string key)
-        {
-            return plist.SelectSingleNode("//dict/key[text()='" + key + "']") != null;
-        }
+        public static bool ContainsKey(this XmlDocument plist, string key) =>
+            plist.SelectSingleNode("//dict/key[text()='" + key + "']") != null;
 
         private static void SetPListArrayOfIntegerValues(this XmlDocument plist, string node, params int[] values)
         {
@@ -143,9 +144,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             key.ParentNode.InsertAfter(array, key);
         }
 
-        private static string GetPListStringValue(this XmlDocument plist, string node)
-        {
-            return plist.SelectSingleNode("//dict/key[text()='" + node + "']").NextSibling.InnerText;
-        }
+        private static string GetPListStringValue(this XmlDocument plist, string node) =>
+            plist.SelectSingleNode("//dict/key[text()='" + node + "']").NextSibling.InnerText;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -166,6 +166,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             return GetElementValue(csproj, platform, configuration, "OutputPath");
         }
 
+        public static string GetMtouchArch(this XmlDocument csproj, string platform, string configuration)
+        { 
+            return GetElementValue(csproj, platform, configuration, "MtouchArch");
+		}
+
         static string GetElementValue(this XmlDocument csproj, string platform, string configuration, string elementName)
         {
             var nodes = csproj.SelectNodes($"/*/*/*[local-name() = '{elementName}']");

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -37,7 +37,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             _mainLog = new Mock<ILog>();
             _logs = new Mock<ILogs>();
             _listener = new Mock<ISimpleListener>();
-            _appInformation = new AppBundleInformation("test app", "my.id.com", "/path/to/app", "/launch/app/path", null) { Variation = "Debug" };
+            _appInformation = new AppBundleInformation(
+                appName: "test app",
+                bundleIdentifier: "my.id.com",
+                appPath:"/path/to/app",
+                launchAppPath: "/launch/app/path",
+                supports32b:false,
+                extension: null)
+            {
+                Variation = "Debug"
+            };
             _logsDirectory = Path.GetTempFileName();
             File.Delete(_logsDirectory);
             Directory.CreateDirectory(_logsDirectory);

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Utilities/PListExtensionsTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Utilities/PListExtensionsTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Utilities
+{
+    public class PListExtensionsTests
+    {
+        private XmlDocument _plist;
+
+        public PListExtensionsTests() =>
+            _plist = CreateResultSample();
+
+        /// <summary>
+        /// Creates a sample pList to be used with the tests and returns the temp file in which it was stored.
+        /// </summary>
+        /// <returns>The path where the sample plist can be found.</returns>
+        private XmlDocument CreateResultSample()
+        {
+            var name = GetType().Assembly.GetManifestResourceNames()
+                .FirstOrDefault(a => a.EndsWith("Info.plist", StringComparison.Ordinal));
+            var tempPath = Path.GetTempFileName();
+            var byteOrderMarkUtf8 = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble()); // I hate BOM
+            using var sampleStream = new StreamReader(GetType().Assembly.GetManifestResourceStream(name));
+
+            // create the document with the plist and return it
+            var doc = new XmlDocument();
+            var settings = new XmlReaderSettings()
+            {
+                XmlResolver = null,
+                DtdProcessing = DtdProcessing.Parse,
+            };
+            using var reader = XmlReader.Create(sampleStream, settings);
+            doc.Load(reader);
+            return doc;
+        }
+
+        [Fact]
+        public void SetMinimumOSVersion()
+        {
+            var version = "MyMinVersion";
+            _plist.SetMinimumOSVersion(version);
+            Assert.Equal(version, _plist.GetMinimumOSVersion());
+        }
+
+        [Fact]
+        public void SetNullMinimumOSVersion()
+        {
+            Assert.Throws<ArgumentNullException>(() => _plist.SetMinimumOSVersion(null));
+        }
+
+        [Fact]
+        public void SetMinimummacOSVersion()
+        {
+            var version = "MyMaccMinVersion";
+            _plist.SetMinimummacOSVersion(version);
+            Assert.Equal(version, _plist.GetMinimummacOSVersion());
+        }
+
+        [Fact]
+        public void SetNullMinimummacOSVersion()
+        {
+            Assert.Throws<ArgumentNullException>(() => _plist.SetMinimummacOSVersion(null));
+        }
+
+        [Fact]
+        public void SetCFBundleDisplayName()
+        {
+            var displayName = "MySuperApp";
+            _plist.SetCFBundleDisplayName(displayName);
+            Assert.Equal(displayName, _plist.GetCFBundleDisplayName());
+        }
+
+        [Fact]
+        public void SetNullCFBundleDisplayName()
+        {
+            Assert.Throws<ArgumentNullException>(() => _plist.SetCFBundleDisplayName(null));
+        }
+
+        [Fact]
+        public void SetCFBundleIdentifier()
+        {
+            var bundleIdentifier = "my.company.super.app";
+            _plist.SetCFBundleIdentifier(bundleIdentifier);
+            Assert.Equal(bundleIdentifier, _plist.GetCFBundleIdentifier());
+        }
+
+        [Fact]
+        public void SetNullCFBundleIdentifier()
+        {
+            Assert.Throws<ArgumentNullException>(() => _plist.SetCFBundleIdentifier(null));
+        }
+
+        [Fact]
+        public void SetCFBundleName()
+        {
+            var bundleName = "MySuper.app";
+            _plist.SetCFBundleName(bundleName);
+            Assert.Equal(bundleName, _plist.GetCFBundleName());
+        }
+
+        [Fact]
+        public void SetNullCFBundleName()
+        {
+            Assert.Throws<ArgumentNullException>(() => _plist.SetCFBundleName(null));
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -172,7 +172,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _helpers.Object,
                 useXmlOutput);
 
-            var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
+            var appInformation = new AppBundleInformation(
+                appName: AppName,
+                bundleIdentifier: AppBundleIdentifier,
+                appPath: s_appPath,
+                launchAppPath: s_appPath,
+                supports32b: false,
+                extension:null);
 
             await Assert.ThrowsAsync<NoDeviceFoundException>(
                 async () => await appRunner.RunApp(
@@ -247,7 +253,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _helpers.Object,
                 useXml);
 
-            var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
+            var appInformation = new AppBundleInformation(
+                appName: AppName,
+                bundleIdentifier: AppBundleIdentifier,
+                appPath: s_appPath,
+                launchAppPath: s_appPath,
+                supports32b: false,
+                extension: null);
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,
@@ -319,7 +331,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _helpers.Object,
                 true);
 
-            var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
+            var appInformation = new AppBundleInformation(
+                appName: AppName,
+                bundleIdentifier: AppBundleIdentifier,
+                appPath:s_appPath,
+                launchAppPath:s_appPath,
+                supports32b: false,
+                extension:null);
 
             await Assert.ThrowsAsync<NoDeviceFoundException>(
                 async () => await appRunner.RunApp(
@@ -379,7 +397,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 _helpers.Object,
                 useXml);
 
-            var appInformation = new AppBundleInformation(AppName, AppBundleIdentifier, s_appPath, s_appPath, null);
+            var appInformation = new AppBundleInformation(
+                appName: AppName,
+                bundleIdentifier: AppBundleIdentifier,
+                appPath: s_appPath,
+                launchAppPath:s_appPath,
+                supports32b: false,
+                extension: null);
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,


### PR DESCRIPTION
Add code that will allow to parse the arch of a bundled app and a
project this will later help to use the correct device when the device
name is not provided.

We yet do not select the correct arch, this is the first step to do so.