### PR TITLE
MacOS Support - include native adb binary

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -57,10 +57,15 @@ namespace Microsoft.DotNet.XHarness.Android
             {
                 return Path.Join(currentAssemblyDirectory, @"..\..\..\runtimes\any\native\adb\windows\adb.exe");
             }
-            else
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 return Path.Join(currentAssemblyDirectory, @"../../../runtimes/any/native/adb/linux/adb");
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return Path.Join(currentAssemblyDirectory, @"../../../runtimes/any/native/adb/macos/adb");
+            }
+            throw new NotSupportedException("Cannot determine OS platform being used, thus we can not select ADB executable.");
         }
 
         #endregion

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -13,13 +13,15 @@
          If you change the version, please run /eng/download-mlaunch.sh to get this version into your environment -->
     <MlaunchVersion>3fbdcdb97459ca2c699d47e33028a106b95a7f1f</MlaunchVersion>
 
-    <!-- When updating, avoid using 'latest' url as this can make the same commit build differently on different days -->
+    <!-- When updating these URLs, avoid using 'latest' url as these are redirects and can make the same commit build differently on different days -->
     <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
     <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
 
-    <!-- TODO: Figure out minimal set of binaries for linux, then copy them.  Until then this is unsued. -->
     <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
     <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
+
+    <MacOsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-darwin.zip</MacOsAndroidSdkUrl>
+    <MacOsAndroidSdkFileName>macos-android-platform-tools.zip</MacOsAndroidSdkFileName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -43,12 +45,15 @@
 
   <Target Name="DownloadAndroidSdks" BeforeTargets="Build">
     <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
-    <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)"   DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)" SkipUnchangedFiles="True" />
+    <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)"   DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)"   SkipUnchangedFiles="True" />
+    <DownloadFile SourceUrl="$(MacOsAndroidSdkUrl)"   DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(MacOsAndroidSdkFileName)"   SkipUnchangedFiles="True" />
     <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
-    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(LinuxAndroidSdkFileName)"   DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/linux" OverwriteReadOnlyFiles="true" />
+    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(LinuxAndroidSdkFileName)"   DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/linux"   OverwriteReadOnlyFiles="true" />
+    <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(MacOsAndroidSdkFileName)"   DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/macos"   OverwriteReadOnlyFiles="true" />
     <ItemGroup>
       <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
       <LinuxAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/linux/platform-tools/adb" />
+      <MacOsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/macos/platform-tools/adb" />
       <Content Include="@(WindowsAdbFiles)">
         <Pack>true</Pack>
         <PackagePath>runtimes/any/native/adb/windows</PackagePath>
@@ -59,6 +64,11 @@
         <PackagePath>runtimes/any/native/adb/linux</PackagePath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <Content Include="@(MacOsAdbFiles)">
+        <Pack>true</Pack>
+        <PackagePath>runtimes/any/native/adb/macos</PackagePath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>      
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
A parallel change was all that linux needed.  I'm still working on getting this to a mac to try it. 