### PR TITLE
[Runners] Workaround to discover all the active issues.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Microsoft.DotNet.XHarness.Tests.Runners.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="5.0.0-beta.20254.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/TestCaseExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/TestCaseExtensions.cs
@@ -24,12 +24,14 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
             if (testCase.Traits == null)
                 return;
 
-            // the following is a hack to work around an issue in the extensions that
+            // the following code is a work around an issue in the extensions that
             // was fixed in https://github.com/dotnet/arcade/pull/5425 but until we get the
-            // arcade update, we do the following, check for the discoverer and the add
+            // arcade update, we do the following, check for the discoverer and then add
             // the expected category for the ActiveIssue
             var nullMessageSink = new NullMessageSink();
-            var traitAttributes =  testCase.TestMethod.Method.GetCustomAttributes(typeof (ITraitAttribute));
+            var traitAttributes =  testCase.TestMethod?.Method?.GetCustomAttributes(typeof (ITraitAttribute));
+            if (traitAttributes == null)
+                return;
             foreach (var traitAttribute in traitAttributes)
             {
                 var discovererAttribute = traitAttribute.GetCustomAttributes(typeof(TraitDiscovererAttribute)).FirstOrDefault();

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/TestCaseExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/TestCaseExtensions.cs
@@ -6,7 +6,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Xunit.Abstractions;
+using Xunit.Sdk;
+using Microsoft.DotNet.XUnitExtensions;
+using NullMessageSink = Xunit.Sdk.NullMessageSink;
 
 namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
 {
@@ -15,13 +19,49 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
     /// </summary>
     public static class TestCaseExtensions
     {
+        static void DiscoverAllTraits(this ITestCase testCase)
+        {
+            if (testCase.Traits == null)
+                return;
+
+            // the following is a hack to work around an issue in the extensions that
+            // was fixed in https://github.com/dotnet/arcade/pull/5425 but until we get the
+            // arcade update, we do the following, check for the discoverer and the add
+            // the expected category for the ActiveIssue
+            var nullMessageSink = new NullMessageSink();
+            var traitAttributes =  testCase.TestMethod.Method.GetCustomAttributes(typeof (ITraitAttribute));
+            foreach (var traitAttribute in traitAttributes)
+            {
+                var discovererAttribute = traitAttribute.GetCustomAttributes(typeof(TraitDiscovererAttribute)).FirstOrDefault();
+                if (discovererAttribute == null)  continue;
+
+                var discoverer = ExtensibilityPointFactory.GetTraitDiscoverer(nullMessageSink, discovererAttribute);
+
+                if (discoverer == null || !(discoverer is ActiveIssueDiscoverer)) continue;
+
+                // add the missing trait
+                if (testCase.Traits.ContainsKey(XunitConstants.Category))
+                {
+                    if (!testCase.Traits[XunitConstants.Category].Contains("failing"))
+                        testCase.Traits[XunitConstants.Category].Add("failing");
+                }
+                else
+                {
+                    testCase.Traits.Add(XunitConstants.Category, new List<string> {"failing"});
+                }
+            }
+        }
+
         /// <summary>
         /// Returns boolean indicating whether the test case does have traits.
         /// </summary>
         /// <param name="testCase">The test case under test.</param>
         /// <returns>true if the test case has traits, false otherwise.</returns>
-        public static bool HasTraits(this ITestCase testCase) =>
-            testCase.Traits != null && testCase.Traits.Count > 0;
+        public static bool HasTraits(this ITestCase testCase)
+        {
+            testCase.DiscoverAllTraits();
+            return testCase.Traits != null && testCase.Traits.Count > 0;
+        }
 
         public static bool TryGetTrait(this ITestCase testCase,
                                        string trait,

--- a/tests/Microsoft.DotNet.XHarness.Tests.Runners.Tests/xUnit/XUnitFilterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Tests.Runners.Tests/xUnit/XUnitFilterTests.cs
@@ -32,7 +32,10 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                         traitValue:null,
                         exclude:true);
                     var testCase = new Mock<ITestCase>();
+                    var method = new Mock<ITestMethod>();
                     testCase.Setup(t => t.Traits).Returns(new Dictionary<string, List<string>>());
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,
@@ -47,6 +50,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                         exclude:false);
                     testCase = new Mock<ITestCase>();
                     testCase.Setup(t => t.Traits).Returns(new Dictionary<string, List<string>>());
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,
@@ -64,6 +69,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = null!,
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,
@@ -81,6 +88,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = null!,
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
 
                     yield return new object[]
                     {
@@ -99,6 +108,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = new List<string> {traitValue},
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
 
                     yield return new object[]
                     {
@@ -117,6 +128,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = new List<string>{traitValue},
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,
@@ -134,6 +147,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = new List<string>{new string('$', 4)},
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,
@@ -151,6 +166,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Tests.xUnit
                     {
                         [traitName] = new List<string>{new string('$', 4)},
                     });
+                    testCase.Setup(t => t.TestMethod).Returns(method.Object);
+                    method.Setup(m => m.Method).Returns((IMethodInfo)null!);
                     yield return new object[]
                     {
                         filter,


### PR DESCRIPTION
The ActiveIssue discoverer does have a bug in which it does not add the
traits on Android or iOS. The fix was landed here:
https://github.com/dotnet/arcade/pull/5425 but this commit adds a
workaround. Issue https://github.com/dotnet/xharness/issues/156 to
track the workaround and make sure it is removed.

fixes: https://github.com/dotnet/xharness/issues/53

PS: This time it really fixes the issue ;)