### PR TITLE
Changes needed to deal with arch issues

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbExitCodes.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbExitCodes.cs
@@ -13,5 +13,6 @@ namespace Microsoft.DotNet.XHarness.Android
         INSTRUMENTATION_SUCCESS = -1,
         INSTRUMENTATION_TIMEOUT = -2,
         ADB_UNINSTALL_APP_NOT_ON_DEVICE = 255,
+        ADB_UNINSTALL_APP_NOT_ON_EMULATOR = 1,
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -307,7 +307,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
         public Dictionary<string, string?> GetAttachedDevicesAndArchitectures()
         {
-            Dictionary<string, string?> devicesAndArchitectures = new Dictionary<string, string>();
+            Dictionary<string, string?> devicesAndArchitectures = new Dictionary<string, string?>();
 
             var result = RunAdbCommand("devices -l");
             string standardOutput = result.StandardOutput;

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
         private readonly string _absoluteAdbExePath;
         private readonly ILogger _log;
+        private string? _currentDevice;
 
         public AdbRunner(ILogger log, string adbExePath = "")
         {
@@ -50,6 +51,11 @@ namespace Microsoft.DotNet.XHarness.Android
             }
         }
 
+        public void SetActiveDevice(string deviceSerialNumber)
+        {
+            _currentDevice = deviceSerialNumber;
+        }
+
         private static string GetCliAdbExePath()
         {
             var currentAssemblyDirectory = Path.GetDirectoryName(typeof(AdbRunner).Assembly.Location);
@@ -65,7 +71,7 @@ namespace Microsoft.DotNet.XHarness.Android
             {
                 return Path.Join(currentAssemblyDirectory, @"../../../runtimes/any/native/adb/macos/adb");
             }
-            throw new NotSupportedException("Cannot determine OS platform being used, thus we can not select ADB executable.");
+            throw new NotSupportedException("Cannot determine OS platform being used, thus we can not select an ADB executable.");
         }
 
         #endregion
@@ -164,7 +170,8 @@ namespace Microsoft.DotNet.XHarness.Android
             {
                 _log.LogInformation($"Successfully uninstalled {apkName}.");
             }
-            else if (result.ExitCode == (int)AdbExitCodes.ADB_UNINSTALL_APP_NOT_ON_DEVICE)
+            else if (result.ExitCode == (int)AdbExitCodes.ADB_UNINSTALL_APP_NOT_ON_DEVICE ||
+                     result.ExitCode == (int)AdbExitCodes.ADB_UNINSTALL_APP_NOT_ON_EMULATOR)
             {
                 _log.LogInformation($"APK '{apkName}' not on device.");
             }
@@ -298,19 +305,62 @@ namespace Microsoft.DotNet.XHarness.Android
             _log.LogDebug($"Copied {filesToCopy.Length} files");
         }
 
-        public (string StandardOutput, string StandardError, int ExitCode) RunApkInstrumentation(string apkName, TimeSpan timeout)
+        public Dictionary<string, string> GetAttachedDevicesAndArchitectures()
         {
-            return RunApkInstrumentation(apkName, "", new Dictionary<string, string>(), timeout);
+            Dictionary<string, string> devicesAndArchitectures = new Dictionary<string, string>();
+
+            var result = RunAdbCommand("devices -l");
+            string standardOutput = result.StandardOutput;
+
+            // If the adb server is dead, this can return 0 exit code and no output; retry a few times if so)
+            int retriesLeft = 5;
+            while (retriesLeft-- > 0 && result.ExitCode == (int)AdbExitCodes.SUCCESS && standardOutput == "")
+            {
+                result = RunAdbCommand("devices -l");
+                standardOutput = result.StandardOutput;
+            }
+
+            if (result.ExitCode == (int)AdbExitCodes.SUCCESS)
+            {
+                string[] lines = standardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+                
+                for (int lineNumber = 1; lineNumber < lines.Length; lineNumber++)
+                {
+                    _log.LogDebug($"Evaluating line: {lines[lineNumber]}");
+                    var lineParts = lines[lineNumber].Split(' ');
+                    if (lineParts.Length > 0)
+                    {
+                        var shellArchitecture = RunAdbCommand($"-s {lineParts[0]} shell getprop ro.product.cpu.abi");
+                        var deviceSerial = lineParts[0];
+
+                        if (shellArchitecture.ExitCode == (int)AdbExitCodes.SUCCESS)
+                        {
+                            devicesAndArchitectures.Add(deviceSerial, shellArchitecture.StandardOutput.Trim());
+                        }
+                        else
+                        {
+                            _log.LogError($"Error trying to get device architecture: {shellArchitecture.StandardError}");
+                            devicesAndArchitectures.Add(deviceSerial, "unknown");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                _log.LogError($"Error: {result.StandardError}");
+            }
+            return devicesAndArchitectures;
         }
+
+        public (string StandardOutput, string StandardError, int ExitCode) RunApkInstrumentation(string apkName, TimeSpan timeout) =>
+            RunApkInstrumentation(apkName, "", new Dictionary<string, string>(), timeout);
 
         public (string StandardOutput, string StandardError, int ExitCode) RunApkInstrumentation(string apkName, Dictionary<string, string> args, TimeSpan timeout) =>
             RunApkInstrumentation(apkName, "", args, timeout);
 
-
         public (string StandardOutput, string StandardError, int ExitCode) RunApkInstrumentation(string apkName, string? instrumentationClassName, Dictionary<string, string> args, TimeSpan timeout)
         {
             string displayName = string.IsNullOrEmpty(instrumentationClassName) ? "{default}" : instrumentationClassName;
-
             string appArguments = "";
             if (args.Count > 0)
             {
@@ -323,7 +373,7 @@ namespace Microsoft.DotNet.XHarness.Android
             string command = $"shell am instrument {appArguments} -w {apkName}";
             if (string.IsNullOrEmpty(instrumentationClassName))
             {
-                _log.LogInformation($"Starting default instrumentation class on {apkName} (exit code -1 == success)");
+                _log.LogInformation($"Starting default instrumentation class on {apkName} (exit code 0 == success)");
             }
             else
             {
@@ -377,7 +427,9 @@ namespace Microsoft.DotNet.XHarness.Android
                 throw new FileNotFoundException($"Provided path for adb.exe was not valid ('{_absoluteAdbExePath}')");
             }
 
-            _log.LogDebug($"Executing command: '{_absoluteAdbExePath} {command}'");
+            string deviceSerialArgs = string.IsNullOrEmpty(_currentDevice) ? "" : $"-s {_currentDevice}";
+
+            _log.LogDebug($"Executing command: '{_absoluteAdbExePath} {deviceSerialArgs} {command}'");
 
             ProcessStartInfo processStartInfo = new ProcessStartInfo
             {
@@ -387,11 +439,11 @@ namespace Microsoft.DotNet.XHarness.Android
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 FileName = _absoluteAdbExePath,
-                Arguments = command,
+                Arguments = $"{deviceSerialArgs} {command}",
             };
-            Process p = new Process() { StartInfo = processStartInfo };
-            StringBuilder standardOut = new StringBuilder();
-            StringBuilder standardErr = new StringBuilder();
+            var p = new Process() { StartInfo = processStartInfo };
+            var standardOut = new StringBuilder();
+            var standardErr = new StringBuilder();
 
             p.OutputDataReceived += delegate (object sender, DataReceivedEventArgs e)
             {

--- a/src/Microsoft.DotNet.XHarness.Android/ApkHelper.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/ApkHelper.cs
@@ -10,6 +10,10 @@ namespace Microsoft.DotNet.XHarness.Android
     {
         public static List<string> GetApkSupportedArchitectures(string apkPath)
         {
+            if (string.IsNullOrEmpty(apkPath))
+            {
+                throw new ArgumentException("Please supply a value for apkPath");
+            }
             if (!File.Exists(apkPath))
             {
                 throw new FileNotFoundException($"Invalid APK Path: '{apkPath}'");

--- a/src/Microsoft.DotNet.XHarness.Android/ApkHelper.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/ApkHelper.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Microsoft.DotNet.XHarness.Android
+{
+    public static class ApkHelper
+    {
+        public static List<string> GetApkSupportedArchitectures(string apkPath)
+        {
+            if (!File.Exists(apkPath))
+            {
+                throw new FileNotFoundException($"Invalid APK Path: '{apkPath}'");
+            }
+            if (!Path.GetExtension(apkPath).Equals(".apk", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Only know how to open APK files.");
+            }
+
+            using (ZipArchive archive = ZipFile.Open(apkPath, ZipArchiveMode.Read))
+            {
+                // Enumerate all folders under /lib inside the zip
+                var allLibFolders = archive.Entries.Where(e => e.FullName.StartsWith("lib/"))
+                                                   .Select(e => e.FullName[4..e.FullName.IndexOf('/', 4)])
+                                                   .Distinct().ToList();
+
+                return allLibFolders;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -28,6 +28,12 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         }
 
         /// <summary>
+        /// If specified, attempt to run on a compatible attached device, failing if unavailable.
+        /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
+        /// </summary>
+        public string? DeviceArchitecture { get; set; }
+
+        /// <summary>
         /// Folder to copy off for output of executing the specified APK
         /// </summary>
         public string? DeviceOutputFolder { get; set; }
@@ -36,6 +42,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         protected override OptionSet GetTestCommandOptions() => new OptionSet
         {
+            { "device-arch=", "If specified, only run on a device with the listed architecture (x86, x86-64, or arm64-v8a).  Otherwise infer from supplied APK",
+                v => DeviceArchitecture = v
+            },
             { "device-out-folder=|dev-out=", "If specified, copy this folder recursively off the device to the path specified by the output directory",
                 v => DeviceOutputFolder = RootPath(v)
             },

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -30,6 +30,14 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
                 }
                 logger.LogInformation($"ADB Version info:{Environment.NewLine}{runner.GetAdbVersion()}");
                 logger.LogInformation($"ADB State ('device' if physically attached):{Environment.NewLine}{state}");
+
+                logger.LogInformation($"List of devices:");
+                var deviceAndArchList = runner.GetAttachedDevicesAndArchitectures();
+                foreach (string device in deviceAndArchList.Keys)
+                {
+                    logger.LogInformation($"Device: '{device}' - Architecture: {deviceAndArchList[device]}");
+                }
+
                 return Task.FromResult(ExitCode.SUCCESS);
             }
             catch (Exception toLog)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
 
         protected override string CommandUsage { get; } = "android test [OPTIONS]";
 
-        protected override string CommandDescription { get; } = "Executes tests on and Android device, waits up to a given timeout, then copies files off the device.";
+        protected override string CommandDescription { get; } = "Executes test .apk on an Android device, waits up to a given timeout, then copies files off the device and uninstalls the test app";
 
         protected override Task<ExitCode> InvokeInternal(ILogger logger)
         {
@@ -38,6 +39,20 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
             }
             var runner = new AdbRunner(logger);
 
+            // Assumption: APKs we test will only have one arch for now
+            string apkRequiredArchitecture = string.IsNullOrEmpty(_arguments.DeviceArchitecture) ?
+                ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath).FirstOrDefault() :
+                _arguments.DeviceArchitecture;
+
+            if (!string.IsNullOrEmpty(_arguments.DeviceArchitecture))
+            {
+                logger.LogInformation($"Will attempt to run device on specified architecture: '{apkRequiredArchitecture}'");
+            }
+            else
+            {
+                logger.LogInformation($"Will attempt to run device on detected architecture: '{apkRequiredArchitecture}'");
+            }
+
             // Package Name is not guaranteed to match file name, so it needs to be mandatory.
             string apkPackageName = _arguments.PackageName;
 
@@ -47,8 +62,15 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
             {
                 using (logger.BeginScope("Initialization and setup of APK on device"))
                 {
+                    // Make sure the adb server is freshly started
                     runner.KillAdbServer();
                     runner.StartAdbServer();
+
+                    // enumerate the devices attached and their architectures
+                    // Tell ADB to only use that one (will always use the present one for systems w/ only 1 machine)
+                    runner.SetActiveDevice(GetDeviceToUse(logger, runner, apkRequiredArchitecture));
+
+                    // Wait til the device is ready then empty its log
                     runner.WaitForDevice();
                     runner.ClearAdbLog();
 
@@ -56,6 +78,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
 
                     // If anything changed about the app, Install will fail; uninstall it first.
                     // (we'll ignore if it's not present)
+                    // This is where mismatched architecture APKs fail.
                     runner.UninstallApk(apkPackageName);
                     if (runner.InstallApk(_arguments.AppPackagePath) != 0)
                     {
@@ -92,7 +115,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
                         var logs = runner.PullFiles(_arguments.DeviceOutputFolder, _arguments.OutputDirectory);
                         foreach (string log in logs)
                         {
-                            logger.LogDebug($"Detected output file: {log}");
+                            logger.LogDebug($"Found output file: {log}");
                         }
                     }
                     runner.DumpAdbLog(Path.Combine(_arguments.OutputDirectory, $"adb-logcat-{_arguments.PackageName}.log"));
@@ -118,6 +141,36 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
             }
 
             return Task.FromResult(ExitCode.GENERAL_FAILURE);
+        }
+
+        private string GetDeviceToUse(ILogger logger, AdbRunner runner, string apkRequiredArchitecture)
+        {
+            var allDevicesAndTheirArchitectures = runner.GetAttachedDevicesAndArchitectures();
+            if (allDevicesAndTheirArchitectures.Count == 1)
+            {
+                // There's only one device, so -s argument isn't needed but still check
+                if (!allDevicesAndTheirArchitectures.Values.Contains(apkRequiredArchitecture, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    logger.LogError($"Single device available has architecture '{allDevicesAndTheirArchitectures.Values.First()}', != '{apkRequiredArchitecture}'. Package installation will likely fail, but we'll try anyways."); 
+                }
+                return ""; // Empty = Use default device
+            }
+            else if (allDevicesAndTheirArchitectures.Count > 1)
+            {
+                if (allDevicesAndTheirArchitectures.Any(kvp => kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)))
+                { 
+                    var firstAvailableCompatible = allDevicesAndTheirArchitectures.Where(kvp => kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    logger.LogDebug($"Using first-found compatible device - serial: '{firstAvailableCompatible.Key}' - Arch: {firstAvailableCompatible.Value}");
+                    return firstAvailableCompatible.Key;
+                }
+                else
+                {
+                    logger.LogError($"No devices found with architecture '{apkRequiredArchitecture}'.  Just returning first available device; installation will likely fail, but we'll try anyways.");
+                    return allDevicesAndTheirArchitectures.Keys.First();
+                }
+            }
+            logger.LogError("Unable to detect an attached device.");
+            return "";
         }
 
         private (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(ILogger logger, string stdOut)


### PR DESCRIPTION
Today I learned that our emulators are set up x86 only while Runtime team has been primarily been building for x86-x64.  Once we start using real devices we'll need arm64-v8a apps to match.

This change makes it so either the user can specify the arch to run on (--device-arch) and get an error if no such device is available, _or_ leave this out and have it be guessed from the contents of the /lib/ folder of the apk itself.  

Also handles the slightly different non-error failure message from uninstalling an app that isn't there on an emulator versus real device. 