### PR TITLE
[iOS] Show run log in stdout in verbose mode

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -74,7 +74,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             logger.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
 
             string mainLogFile = Path.Join(_arguments.OutputDirectory, $"run-{target}{(_arguments.DeviceName != null ? "-" + _arguments.DeviceName : null)}.log");
-            ILog mainLog = logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true);
+            ILog mainLog = Log.CreateAggregatedLog(
+                logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true),
+                new CallbackLog(message => logger.LogDebug(message)));
+
             int verbosity = GetMlaunchVerbosity(_arguments.Verbosity);
 
             string? deviceName = _arguments.DeviceName;

--- a/tests/integration-tests/helix-payload/osx-helix-payload.sh
+++ b/tests/integration-tests/helix-payload/osx-helix-payload.sh
@@ -42,13 +42,14 @@ export XHARNESS_LOG_WITH_TIMESTAMPS=true
 open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
 
 dotnet tool restore --no-cache
-dotnet xharness ios test           \
-    --app="$here/$app_name"        \
-    --output-directory="$1"        \
-    --targets=ios-simulator-64     \
-    --timeout=600                  \
-    --launch-timeout=360           \
-    --communication-channel=Network
+dotnet xharness ios test            \
+    --app="$here/$app_name"         \
+    --output-directory="$1"         \
+    --targets=ios-simulator-64      \
+    --timeout=600                   \
+    --launch-timeout=360            \
+    --communication-channel=Network \
+    -v
 
 set +e
 


### PR DESCRIPTION
This will start logging whatever is in the run log (`run-Simulator_iOS64.log`) to the stdout to get more details upfront.

Egor was asking for this behavior and it is a good point that this would be expected.