### PR TITLE
Adds support for skipping tests when SkipTestException is raised

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -142,18 +142,6 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                 return;
 
             RaiseTestSkippedCase(args.Message, args.Message.TestCases, args.Message.TestCase);
-            /*
-            SkippedTests++;
-            OnInfo($"\t[IGNORED] {args.Message.TestCase.DisplayName}");
-            LogTestDetails(args.Message.Test, log: OnDebug);
-            LogTestOutput(args.Message, log: OnDiagnostic);
-            ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
-            // notify that the test completed because it was skipped
-            OnTestCompleted((
-                TestName: args.Message.Test.DisplayName,
-                TestResult: TestResult.Skipped
-            ));
-            */
         }
 
         void HandleTestPassed(MessageHandlerArgs<ITestPassed> args)


### PR DESCRIPTION
If a test fails and the exception type is SkipTestException, then the runner will flag that as a skipped test.  This is to support tests that depend on something in the xunit pipeline that may not be supported on mobile.  We don't want to have to go into every test and mark ConditionalFact/Theory.