### PR TITLE
[iOS] Ensure we do select devices according to their architecture.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
                 try
                 {
-                    (deviceName, result) = await appInstaller.InstallApp(_arguments.AppPackagePath, target, cancellationToken: cancellationToken);
+                    (deviceName, result) = await appInstaller.InstallApp(appBundleInfo, target, cancellationToken: cancellationToken);
                 }
                 catch (NoDeviceFoundException)
                 {

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.iOS;
@@ -10,6 +12,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Moq;
+using Moq.Language.Flow;
 using Xunit;
 
 namespace Microsoft.DotNet.XHarness.iOS.Tests
@@ -17,6 +20,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
     public class AppInstallerTests : IDisposable
     {
         private static readonly string s_appPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        static readonly string s_appIdentifier = Guid.NewGuid().ToString();
         private static readonly IHardwareDevice s_mockDevice = new Device(
             buildVersion: "17A577",
             deviceClass: DeviceClass.iPhone,
@@ -29,6 +33,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
         readonly Mock<IProcessManager> _processManager;
         readonly Mock<ILog> _mainLog;
+        readonly AppBundleInformation _appBundleInformation;
         private Mock<IHardwareDeviceLoader> _hardwareDeviceLoader;
 
         public AppInstallerTests()
@@ -40,10 +45,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             _hardwareDeviceLoader = new Mock<IHardwareDeviceLoader>();
             _hardwareDeviceLoader
-                .Setup(x => x.FindDevice(RunMode.iOS, _mainLog.Object, false, false))
-                .ReturnsAsync(s_mockDevice);
+                .Setup(x => x.Connected64BitIOS).Returns(new List<IHardwareDevice> {s_mockDevice});
 
             Directory.CreateDirectory(s_appPath);
+            _appBundleInformation = new AppBundleInformation(
+                appName: "AppName",
+                bundleIdentifier: s_appIdentifier,
+                appPath: s_appPath,
+                launchAppPath:s_appPath,
+                supports32b: false,
+                extension: null);
         }
 
         public void Dispose()
@@ -57,7 +68,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await appInstaller.InstallApp(s_appPath, TestTarget.Simulator_iOS64));
+                async () => await appInstaller.InstallApp(_appBundleInformation, TestTarget.Simulator_iOS64));
         }
 
         [Fact]
@@ -71,7 +82,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
 
             await Assert.ThrowsAsync<NoDeviceFoundException>(
-                async () => await appInstaller.InstallApp(s_appPath, TestTarget.Device_iOS));
+                async () => await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS));
         }
 
         [Fact]
@@ -80,7 +91,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             // Act
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 2);
 
-            var (deviceName, result) = await appInstaller.InstallApp(s_appPath, TestTarget.Device_iOS);
+            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS);
 
             // Verify
             Assert.Equal(0, result.ExitCode);
@@ -102,7 +113,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             // Act
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 2);
 
-            var (deviceName, result) = await appInstaller.InstallApp(s_appPath, TestTarget.Device_iOS, deviceName: "OtherDevice");
+            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS, deviceName: "OtherDevice");
 
             // Verify
             Assert.Equal(0, result.ExitCode);
@@ -116,6 +127,23 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                It.IsAny<TimeSpan>(),
                null,
                It.IsAny<CancellationToken>()));
+        }
+
+        [Fact]
+        public async Task InstallOn32bMissingDevice()
+        {
+            var appBundle32b = new AppBundleInformation(
+                appName: "AppName",
+                bundleIdentifier: s_appIdentifier,
+                appPath: s_appPath,
+                launchAppPath:s_appPath,
+                supports32b: true,
+                extension: null);
+
+            var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
+
+            await Assert.ThrowsAsync<NoDeviceFoundException>(
+                async () => await appInstaller.InstallApp(appBundle32b, TestTarget.Device_iOS));
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.XHarness.iOS;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
@@ -12,7 +10,6 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Moq;
-using Moq.Language.Flow;
 using Xunit;
 
 namespace Microsoft.DotNet.XHarness.iOS.Tests


### PR DESCRIPTION
The FindDevice method returns the first device found, but will not
filter over the architecture. Move to use LoadDevices and then use the
collections to use the first device that matches the desired arch.

With this commit, xharness will pick the **correct** device if two different
devices are present in the host.

fixes: https://github.com/dotnet/xharness/issues/86