### PR TITLE
Make XmlVersion.xUnit default

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         /// <summary>
         /// Specify the version of Xml to be used for the results.
         /// </summary>
-        public XmlVersion XmlVersion { get; set; } = XmlVersion.NUnitV2;
+        public XmlVersion XmlVersion { get; set; } = XmlVersion.xUnit;
 
         /// <summary>
         /// Return the test results as xml.


### PR DESCRIPTION
Currently Runtime teams and ADO reporting all uses XUnit, so make this a default.  Eventually we'll clean the duplicated enums up and support this from cmd line