### PR TITLE
[Runners] Allow to specify to the test app not to run all tests.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿#nullable enable
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             var runner = await InternalRunAsync(logger);
             ConfigureRunner(runner, options);
 
-            TextWriter writer = null;
+            TextWriter? writer = null;
 
             if (options.EnableXml)
             {

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             else
             {
                 resultsFilePath = runner.WriteResultsToFile(jargon);
-                logger.Info($"Xml result can be found {resultsFilePath}");
+                logger.Info($"XML results can be found in '{resultsFilePath}'");
             }
 
             return resultsFilePath;

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 using Microsoft.DotNet.XHarness.Tests.Runners.Core;
 using Microsoft.DotNet.XHarness.Tests.Runners.Xunit;
 
@@ -161,6 +163,30 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             }
 
             return categories;
+        }
+
+        internal static void ConfigureRunner(TestRunner runner, ApplicationOptions options)
+        {
+            runner.RunAllTestsByDefault = options.RunAllTestsByDefault;
+        }
+
+        internal static string WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer = null)
+        {
+            TestRunner.Jargon jargon = options.XmlVersion.ToTestRunnerJargon();
+            string resultsFilePath = null;
+
+            if (options.EnableXml)
+            {
+                runner.WriteResultsToFile(writer ?? Console.Out, jargon);
+                logger.Info("Xml file was written to the tcp listener.");
+            }
+            else
+            {
+                resultsFilePath = runner.WriteResultsToFile(jargon);
+                logger.Info($"Xml result can be found {resultsFilePath}");
+            }
+
+            return resultsFilePath;
         }
 
         protected async Task<TestRunner> InternalRunAsync (LogWriter logger)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -69,6 +69,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                 XmlVersion = (XmlVersion)Enum.Parse(typeof(XmlVersion), xml_version, true);
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.LogFilePath)))
                 LogFile = Environment.GetEnvironmentVariable(EnviromentVariables.LogFilePath);
+            if (bool.TryParse(Environment.GetEnvironmentVariable(EnviromentVariables.RunAllTestsByDefault), out b))
+                RunAllTestsByDefault = b;
 
             var os = new OptionSet() {
                 { "autoexit", "Exit application once the test run has completed.", v => TerminateAfterExecution = true },
@@ -82,6 +84,12 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                 { "xmlversion", "The xml version.", v => XmlVersion = (XmlVersion) Enum.Parse (typeof (XmlVersion), v, false) },
                 { "logfile=", "A path where output will be saved.", v => LogFile = v },
                 { "result=", "The path to be used to store the result", v => ResultFile = v},
+                { "run-all-tests:", "Run all the tests fund in the assembly. Defaults to true.", v =>
+                {
+                    // if cannot parse, use default
+                    if (Boolean.TryParse(v, out var runAll))
+                        RunAllTestsByDefault = runAll;
+                }}
             };
 
             try
@@ -162,6 +170,11 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         /// Specify if test results should be sorted by name.
         /// </summary>
         public bool SortNames { get; set; }
+
+        /// <summary>
+        /// Specify if all the tests should be run by default or not. Defaults to true.
+        /// </summary>
+        public bool RunAllTestsByDefault { get; set; } = true;
 
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                 { "xmlversion", "The xml version.", v => XmlVersion = (XmlVersion) Enum.Parse (typeof (XmlVersion), v, false) },
                 { "logfile=", "A path where output will be saved.", v => LogFile = v },
                 { "result=", "The path to be used to store the result", v => ResultFile = v},
-                { "run-all-tests:", "Run all the tests fund in the assembly. Defaults to true.", v =>
+                { "run-all-tests:", "Run all the tests found in the assembly. Defaults to true.", v =>
                 {
                     // if cannot parse, use default
                     if (Boolean.TryParse(v, out var runAll))

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
@@ -35,18 +35,9 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
             // if we have ignore files, ignore those tests
             var runner = await InternalRunAsync(logger);
 
-            TestRunner.Jargon jargon = options.XmlVersion.ToTestRunnerJargon();
+            ConfigureRunner(runner, options);
 
-            if (options.EnableXml)
-            {
-                runner.WriteResultsToFile(writer ?? Console.Out, jargon);
-                logger.Info("Xml file was written to the tcp listener.");
-            }
-            else
-            {
-                string resultsFilePath = runner.WriteResultsToFile(jargon);
-                logger.Info($"Xml result can be found {resultsFilePath}");
-            }
+            WriteResults(runner, options, logger, writer);
 
             logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/EnviromentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/EnviromentVariables.cs
@@ -69,5 +69,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch
         /// Env var used to notify the test application that the test should be sorted by name.
         /// </summary>
         public const string SortByName = "NUNIT_SORTNAMES";
+
+        /// <summary>
+        /// Env var used to notify the test application if all the tests should be ran by default.
+        /// </summary>
+        public const string RunAllTestsByDefault = "NUNIT_RUN_ALL";
     }
 }


### PR DESCRIPTION
This is a step fwd allowing user to run just those tests that match a
filter or filters. To support that we first want to be able to ignore
all tests and later provide the inclusion filters.

This is related to issue https://github.com/dotnet/xharness/issues/144