### PR TITLE
Remove hard coded sleep and set_BuildConfig 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,16 +181,12 @@ stages:
       displayName: iOS Integration Tests
       pool:
         name: Hosted macOS
+      variables:
+        _BuildConfig: debug
       steps:
       - download: current
         artifact: Microsoft.DotNet.XHarness.CLI.OSX.IntegrationTests.Debug
-        
-      # Work around https://github.com/dotnet/core-eng/issues/9824
-      # AzDO API does not like to be called too soon relative to the beginning of the pipeline
-      - task: CmdLine@2
-        inputs:
-          script: 'echo Sleeping to work around ADO API issue && sleep 20s' 
-          
+         
       - template: /eng/common/templates/steps/send-to-helix.yml
         parameters:
           DisplayNamePrefix: Run Tests


### PR DESCRIPTION
… so if this comes back we'll have a binlog.

The problem was in the GH repo itself, along with AzDO changing their response for when giving secrets to forks is turned off