### PR TITLE
Fix file permissions for uploads of integration tests

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -140,9 +140,9 @@ namespace Microsoft.DotNet.XHarness.iOS
             if (_useXmlOutput)
             {
                 // let the runner now via envars that we want to get a xml output, else the runner will default to plain text
-                args.Add (new SetEnvVariableArgument (EnviromentVariables.EnableXmlOutput, true));
-                args.Add (new SetEnvVariableArgument (EnviromentVariables.XmlMode, "wrapped"));
-                args.Add (new SetEnvVariableArgument (EnviromentVariables.XmlVersion, $"{xmlResultJargon}"));
+                args.Add(new SetEnvVariableArgument(EnviromentVariables.EnableXmlOutput, true));
+                args.Add(new SetEnvVariableArgument(EnviromentVariables.XmlMode, "wrapped"));
+                args.Add(new SetEnvVariableArgument(EnviromentVariables.XmlVersion, $"{xmlResultJargon}"));
             }
 
             listener.StartAsync();
@@ -253,35 +253,46 @@ namespace Microsoft.DotNet.XHarness.iOS
                     systemLogs.Add(log);
                 }
 
-                _mainLog.WriteLine("*** Executing {0}/{1} in the simulator ***", appInformation.AppName, target);
-
-                if (ensureCleanSimulatorState)
+                try
                 {
-                    foreach (var sim in simulators)
+                    _mainLog.WriteLine("*** Executing {0}/{1} in the simulator ***", appInformation.AppName, target);
+
+                    if (ensureCleanSimulatorState)
                     {
-                        await sim.PrepareSimulator(_mainLog, appInformation.BundleIdentifier);
+                        foreach (var sim in simulators)
+                        {
+                            await sim.PrepareSimulator(_mainLog, appInformation.BundleIdentifier);
+                        }
+                    }
+
+                    args.Add(new SimulatorUDIDArgument(simulator.UDID));
+
+                    await crashReporter.StartCaptureAsync();
+
+                    _mainLog.WriteLine("Starting test run");
+
+                    var result = _processManager.ExecuteCommandAsync(args, _mainLog, timeout, cancellationToken: linkedCts.Token);
+
+                    await testReporter.CollectSimulatorResult(result);
+
+                    // cleanup after us
+                    if (ensureCleanSimulatorState)
+                    {
+                        await simulator.KillEverything(_mainLog);
+                    }
+
+                    foreach (var log in systemLogs)
+                    {
+                        log.StopCapture();
                     }
                 }
-
-                args.Add(new SimulatorUDIDArgument(simulator.UDID));
-
-                await crashReporter.StartCaptureAsync();
-
-                _mainLog.WriteLine("Starting test run");
-
-                var result = _processManager.ExecuteCommandAsync(args, _mainLog, timeout, cancellationToken: linkedCts.Token);
-
-                await testReporter.CollectSimulatorResult(result);
-
-                // cleanup after us
-                if (ensureCleanSimulatorState)
+                finally
                 {
-                    await simulator.KillEverything(_mainLog);
-                }
-
-                foreach (var log in systemLogs)
-                {
-                    log.StopCapture();
+                    foreach (var log in systemLogs)
+                    {
+                        log.StopCapture();
+                        log.Dispose();
+                    }
                 }
             }
             else
@@ -378,7 +389,9 @@ namespace Microsoft.DotNet.XHarness.iOS
 
                     // close a tunnel if it was created
                     if (!isSimulator && _listenerFactory.UseTunnel)
+                    {
                         await _listenerFactory.TunnelBore.Close(deviceName);
+                    }
                 }
 
                 // Upload the system log

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -218,6 +218,8 @@ namespace Microsoft.DotNet.XHarness.iOS
 
                 deviceName = simulator.Name;
 
+                string? stdoutLogPath = null, stderrLogPath = null;
+
                 if (!target.IsWatchOSTarget())
                 {
                     var stderrTty = _helpers.GetTerminalName(2);
@@ -227,10 +229,10 @@ namespace Microsoft.DotNet.XHarness.iOS
                     }
                     else
                     {
-                        var stdoutLog = _logs.CreateFile($"mlaunch-stdout-{_helpers.Timestamp}.log", "Standard output");
-                        var stderrLog = _logs.CreateFile($"mlaunch-stderr-{_helpers.Timestamp}.log", "Standard error");
-                        args.Add(new SetStdoutArgument(stdoutLog));
-                        args.Add(new SetStderrArgument(stderrLog));
+                        stdoutLogPath = _logs.CreateFile($"mlaunch-stdout-{_helpers.Timestamp}.log", "Standard output");
+                        stderrLogPath = _logs.CreateFile($"mlaunch-stderr-{_helpers.Timestamp}.log", "Standard error");
+                        args.Add(new SetStdoutArgument(stdoutLogPath));
+                        args.Add(new SetStderrArgument(stderrLogPath));
                     }
                 }
 
@@ -292,6 +294,25 @@ namespace Microsoft.DotNet.XHarness.iOS
                     {
                         log.StopCapture();
                         log.Dispose();
+                    }
+
+                    // Remove empty files
+                    if (stdoutLogPath != null)
+                    {
+                        var fileInfo = new FileInfo(stdoutLogPath);
+                        if (fileInfo.Exists && fileInfo.Length == 0)
+                        {
+                            fileInfo.Delete();
+                        }
+                    }
+
+                    if (stderrLogPath != null)
+                    {
+                        var fileInfo = new FileInfo(stderrLogPath);
+                        if (fileInfo.Exists && fileInfo.Length == 0)
+                        {
+                            fileInfo.Delete();
+                        }
                     }
                 }
             }

--- a/tests/integration-tests/helix-payload/osx-helix-payload.sh
+++ b/tests/integration-tests/helix-payload/osx-helix-payload.sh
@@ -55,9 +55,9 @@ dotnet xharness ios test           \
 
 result=$?
 
-ls -la $1
-
 set +e
+
+chmod 0666 $1/*
 
 test_results=`ls $1/xunit-*.xml`
 

--- a/tests/integration-tests/helix-payload/osx-helix-payload.sh
+++ b/tests/integration-tests/helix-payload/osx-helix-payload.sh
@@ -53,9 +53,11 @@ dotnet xharness ios test           \
     --launch-timeout=360           \
     --communication-channel=Network
 
-set +e
-
 result=$?
+
+ls -la $1
+
+set +e
 
 test_results=`ls $1/xunit-*.xml`
 


### PR DESCRIPTION
Somehow the files are this:
```
+ ls -la /tmp/helix/working/A97E097D/w/AD160905/uploads
total 6424
drwxr-xr-x  9 helix-runner  wheel      288 May 14 06:08 .
drwxr-xr-x  7 helix-runner  wheel      224 May 14 06:08 ..
-rw-r-----  1 root          wheel  3223956 May 14 06:08 iPhone X (iOS 13.4) - created by xharness.log
-rw-r--r--  1 root          wheel        0 May 14 06:08 mlaunch-stderr-20200514_060839.log
-rw-r--r--  1 root          wheel        0 May 14 06:08 mlaunch-stdout-20200514_060839.log
-rw-r--r--  1 root          wheel     6133 May 14 06:08 run-Simulator_iOS64.log
-rw-r--r--  1 root          wheel    42752 May 14 06:08 simulator-list-20200514_060822.log
-rw-r--r--  1 root          wheel     3848 May 14 06:08 test-ios-simulator-64-20200514_060821.log
-rw-r--r--  1 root          wheel     3849 May 14 06:08 xunit-test-ios-simulator-64-20200514_060821.xml
```

I guess this is thanks to the `sudo launchctl` we are doing. However, I won't waste energy on finding the cause and will just fix this symptom since we will move to Arcade soon.

Fixes: https://github.com/dotnet/xharness/issues/162
Fixes: https://github.com/dotnet/xharness/issues/117