### PR TITLE
Fix nullability annotation in AndroidApplicationEntryPoint Logger

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
         /// Implementors should provide a text writter than will be used to
         /// write the logging of the tests that are executed.
         /// </summary>
-        public abstract TextWriter Logger { get; }
+        public abstract TextWriter? Logger { get; }
 
         /// <summary>
         /// Implementors should provide a full path in which the final


### PR DESCRIPTION
Logger can definitely be set to null, so in order for classes that implement and override this property and return null they need to set it as nullable. However the nullable annotation needs to match on the abstract member and the override.

cc: @MattGal @EgorBo @akoeplinger @mandel-macaque 