### PR TITLE
[Runners] Make sure that we dispose things correctly.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/AndroidApplicationEntryPoint.cs
@@ -39,19 +39,21 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             var runner = await InternalRunAsync(logger);
             ConfigureRunner(runner, options);
 
-            TextWriter? writer = null;
-
             if (options.EnableXml)
             {
                 if (TestsResultsFinalPath == null)
                     throw new InvalidOperationException("Tests results final path cannot be null.");
 
-                using var stream = File.Create(TestsResultsFinalPath);
-                writer = new StreamWriter(stream);
+                using (var stream = File.Create(TestsResultsFinalPath))
+                using (var writer = new StreamWriter(stream))
+                {
+                    WriteResults(runner, options, logger, writer);
+                }
             }
-
-            WriteResults(runner, options, logger, writer);
-            writer?.Dispose();
+            else
+            {
+                WriteResults(runner, options, logger, Console.Out);
+            }
 
             logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
             if (options.TerminateAfterExecution)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using System.Xml.Serialization;
 using Microsoft.DotNet.XHarness.Tests.Runners.Core;
 using Microsoft.DotNet.XHarness.Tests.Runners.Xunit;
 
@@ -170,15 +168,17 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
             runner.RunAllTestsByDefault = options.RunAllTestsByDefault;
         }
 
-        internal static string WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer = null)
+        internal static string WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer)
         {
+            if (options.EnableXml && writer == null)
+                throw new ArgumentNullException(nameof(writer));
             TestRunner.Jargon jargon = options.XmlVersion.ToTestRunnerJargon();
             string resultsFilePath = null;
 
             if (options.EnableXml)
             {
-                runner.WriteResultsToFile(writer ?? Console.Out, jargon);
-                logger.Info("Xml file was written to the tcp listener.");
+                runner.WriteResultsToFile(writer, jargon);
+                logger.Info("Xml file was written to the provided writer.");
             }
             else
             {

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/iOSApplicationEntryPoint.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
 
             ConfigureRunner(runner, options);
 
-            WriteResults(runner, options, logger, writer);
+            WriteResults(runner, options, logger, writer ?? Console.Out);
 
             logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
 


### PR DESCRIPTION
There was an issue with the ownership of the IDisposable objects. We
cannot be as smart as we want. Move back to the if statement, do not
default the writer to null.

fixes: https://github.com/dotnet/xharness/issues/199