### PR TITLE
[iOS] Allow users to use lldb to debug issues in test applications.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
             { "xml-jargon=|xj=", $"The xml format to be used in the unit test results. Can be {XmlResultJargon.TouchUnit}, {XmlResultJargon.NUnitV2}, {XmlResultJargon.NUnitV3} or {XmlResultJargon.xUnit}.",
                 v => XmlResultJargon = ParseArgument("xml-jargon", v, invalidValues: XmlResultJargon.Missing)
             },
-            { "enable-lldb", "Allow to debug the launched application usinghe lldb.", v => EnableLldb = v != null },
+            { "enable-lldb", "Allow to debug the launched application using lldb.", v => EnableLldb = v != null },
         };
 
         public override void Validate()

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
@@ -63,6 +63,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
         /// </summary>
         public CommunicationChannel CommunicationChannel { get; set; } = CommunicationChannel.UsbTunnel;
 
+        /// <summary>
+        /// Enable the lldb debugger to be used with the launched application.
+        /// </summary>
+        public bool EnableLldb { get; set; }
+
         public override IReadOnlyCollection<string> Targets
         {
             get => TestTargets.Select(t => t.AsString()).ToArray();
@@ -121,6 +126,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
             { "xml-jargon=|xj=", $"The xml format to be used in the unit test results. Can be {XmlResultJargon.TouchUnit}, {XmlResultJargon.NUnitV2}, {XmlResultJargon.NUnitV3} or {XmlResultJargon.xUnit}.",
                 v => XmlResultJargon = ParseArgument("xml-jargon", v, invalidValues: XmlResultJargon.Missing)
             },
+            { "enable-lldb", "Allow to debug the launched application usinghe lldb.", v => EnableLldb = v != null },
         };
 
         public override void Validate()

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 Timestamp = false
             };
 
-            var aggregatedLog = Log.CreateAggregatedLog(runLog, consoleLog);
+            var aggregatedLog = Log.CreateAggregatedLogWithDefault(runLog, consoleLog);
             aggregatedLog.WriteLine("Generating scaffold app with:");
             aggregatedLog.WriteLine($"\tAppname: '{_arguments.AppPackageName}'");
             aggregatedLog.WriteLine($"\tAssemblies: '{string.Join(" ", _arguments.Assemblies)}'");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
@@ -29,6 +30,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
     {
         private readonly iOSTestCommandArguments _arguments = new iOSTestCommandArguments();
         private readonly ErrorKnowledgeBase _errorKnowledgeBase = new ErrorKnowledgeBase();
+        private static readonly string _mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".mtouch-launch-with-lldb");
+        private bool _createdLldbFile = false;
 
         protected override string CommandUsage { get; } = "ios test [OPTIONS]";
         protected override string CommandDescription { get; } = "Packaging command that will create a iOS/tvOS/watchOS or macOS application that can be used to run NUnit or XUnit-based test dlls";
@@ -64,6 +67,21 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             return exitCode;
         }
 
+        static bool IsLldbEnabled() => File.Exists(_mlaunchLldbConfigFile);
+
+        void NotifyUserLldbCommand(ILogger logger, string line)
+        {
+            if (!line.Contains("mtouch-lldb-prep-cmds")) return;
+
+            // let the user know the command to execute. Might change in mlaunch so trust the log
+            var sb = new StringBuilder();
+            sb.AppendLine("LLDB debugging is enabled.");
+            sb.AppendLine("You must now execute:");
+            sb.AppendLine(line.Substring(line.IndexOf("lldb", StringComparison.Ordinal)));
+
+            logger.LogInformation(sb.ToString());
+        }
+
         private async Task<ExitCode> RunTest(
             ILogger logger,
             TestTarget target,
@@ -74,6 +92,24 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             ITunnelBore? tunnelBore,
             CancellationToken cancellationToken = default)
         {
+            var isLldbEnabled = IsLldbEnabled();
+            if (isLldbEnabled && !_arguments.EnableLldb)
+            {
+                // the file is present, but the user did not set it, warn him about it
+                logger.LogWarning("Lldb will be used since '~/.mtouch-launch-with-lldb' was found in the system but it was not created by xharness.");
+            }
+            else if (_arguments.EnableLldb)
+            {
+                if (!File.Exists(_mlaunchLldbConfigFile))
+                {
+                    // create empty file
+                    var f = File.Create(_mlaunchLldbConfigFile);
+                    f.Dispose();
+                    _createdLldbFile = true;
+                }
+            }
+
+
             logger.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
 
             string mainLogFile = Path.Join(_arguments.OutputDirectory, $"run-{target}{(_arguments.DeviceName != null ? "-" + _arguments.DeviceName : null)}.log");
@@ -140,6 +176,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             logger.LogInformation($"Starting application '{appBundleInfo.AppName}' on " + (deviceName != null ? $"device '{deviceName}'" : target.AsString()));
 
+            // only add the extra callback if we do know that the feature was indeed enabled
+            Action<string>? logCallback = isLldbEnabled ? (l) => NotifyUserLldbCommand(logger, l) : (Action<string>?)null;
+
             var appRunner = new AppRunner(
                 processManager,
                 deviceLoader,
@@ -152,7 +191,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 mainLog,
                 logs,
                 new Helpers(),
-                useXmlOutput: true); // the cli ALWAYS will get the output as xml
+                useXmlOutput: true, // the cli ALWAYS will get the output as xml
+                logCallback: logCallback);
 
             try
             {
@@ -251,6 +291,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     {
                         logger.LogInformation($"Application '{appBundleInfo.AppName}' was uninstalled successfully");
                     }
+                }
+
+                if (_createdLldbFile) // clean after the setting
+                {
+                    File.Delete(_mlaunchLldbConfigFile);
                 }
             }
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
             public AggregatedLog(ILog defaultLog, params ILog[] logs)
             {
-                _defaultLog = defaultLog;
+                _defaultLog = defaultLog ?? throw new ArgumentNullException(nameof(defaultLog));
                 _logs.Add(defaultLog);
                 _logs.AddRange(logs);
             }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AggregatedLog.cs
@@ -3,15 +3,23 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
 
     public abstract partial class Log
     {
 
+        public static ILog CreateAggregatedLogWithDefault(ILog defaultLog, params ILog[] logs)
+        {
+            return new AggregatedLog(defaultLog, logs);
+        }
+
+        [Obsolete ("AggregatedLogs without a default log are dangerous. Use 'CreateAggregatedLogWithDefault' instead.")]
         public static ILog CreateAggregatedLog(params ILog[] logs)
         {
             return new AggregatedLog(logs);
@@ -20,42 +28,60 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         // Log that will duplicate log output to multiple other logs.
         class AggregatedLog : Log
         {
-            readonly ILog[] logs;
+            readonly ILog? _defaultLog;
+            readonly List<ILog> _logs = new List<ILog>();
+
+            public AggregatedLog(ILog defaultLog, params ILog[] logs)
+            {
+                _defaultLog = defaultLog;
+                _logs.Add(defaultLog);
+                _logs.AddRange(logs);
+            }
 
             public AggregatedLog(params ILog[] logs)
                 : base(null)
             {
-                this.logs = logs;
+                _logs.AddRange(logs);
             }
 
-            public override string FullPath => throw new NotImplementedException();
+            public override string FullPath
+            {
+                get
+                {
+                    if (_defaultLog == null)
+                        throw new InvalidOperationException("Default log not set.");
+                    return _defaultLog.FullPath;
+                }
+            }
 
             protected override void WriteImpl(string value)
             {
-                foreach (var log in logs)
+                foreach (var log in _logs)
                     log.Write(value);
             }
 
             public override void Write(byte[] buffer, int offset, int count)
             {
-                foreach (var log in logs)
+                foreach (var log in _logs)
                     log.Write(buffer, offset, count);
             }
 
             public override StreamReader GetReader()
             {
-                throw new NotSupportedException();
+                if (_defaultLog == null)
+                    throw new InvalidOperationException("Default log not set.");
+                return _defaultLog.GetReader();
             }
 
             public override void Flush()
             {
-                foreach (var log in logs)
+                foreach (var log in _logs)
                     log.Flush();
             }
 
             public override void Dispose()
             {
-                foreach (var log in logs)
+                foreach (var log in _logs)
                     log.Dispose();
             }
         }


### PR DESCRIPTION
Add support for the lldb feature in mtouch. User can pass a new flag to
state that lldb should be enabled, the CLI will then provide a command to
copy paste to access the lldb session.

The aggregated log was created to state which of the ILogs that was
passed should be considered the default log and therefore the one to
return the FullPath and the StreamReader.

When the flag is pass the user will get the following:

<img width="1268" alt="Screenshot 2020-05-14 at 23 27 10" src="https://user-images.githubusercontent.com/2190086/82008528-fcb1c600-963a-11ea-8c1f-a5714eefedbe.png">

While if the flag was found but not set by the current xharness execution, it will be respected but a warning will be printed:

<img width="1048" alt="Screenshot 2020-05-14 at 23 27 56" src="https://user-images.githubusercontent.com/2190086/82008556-0e936900-963b-11ea-89e2-6459bf02621a.png">
