### PR TITLE
[iOS] Fix the mess we had with the logs.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 Timestamp = false
             };
 
-            var aggregatedLog = Log.CreateAggregatedLogWithDefault(runLog, consoleLog);
+            var aggregatedLog = Log.CreateReadableAggregatedLog(runLog, consoleLog);
             aggregatedLog.WriteLine("Generating scaffold app with:");
             aggregatedLog.WriteLine($"\tAppname: '{_arguments.AppPackageName}'");
             aggregatedLog.WriteLine($"\tAssemblies: '{string.Join(" ", _arguments.Assemblies)}'");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
         private readonly iOSTestCommandArguments _arguments = new iOSTestCommandArguments();
         private readonly ErrorKnowledgeBase _errorKnowledgeBase = new ErrorKnowledgeBase();
         private static readonly string _mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".mtouch-launch-with-lldb");
-        private bool _createdLldbFile = false;
+        private bool _createdLldbFile;
 
         protected override string CommandUsage { get; } = "ios test [OPTIONS]";
         protected override string CommandDescription { get; } = "Packaging command that will create a iOS/tvOS/watchOS or macOS application that can be used to run NUnit or XUnit-based test dlls";
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             logger.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
 
             string mainLogFile = Path.Join(_arguments.OutputDirectory, $"run-{target}{(_arguments.DeviceName != null ? "-" + _arguments.DeviceName : null)}.log");
-            ILog mainLog = logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true);
+            IFileBackedLog mainLog = logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true);
             int verbosity = GetMlaunchVerbosity(_arguments.Verbosity);
 
             string? deviceName = _arguments.DeviceName;

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ILog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ILog.cs
@@ -13,15 +13,29 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
     {
         string Description { get; set; }
         bool Timestamp { get; set; }
-        string FullPath { get; }
         Encoding Encoding { get; }
-
         void Write(byte[] buffer, int offset, int count);
-        StreamReader GetReader();
         void Write(string value);
         void WriteLine(string value);
         void WriteLine(StringBuilder value);
         void WriteLine(string format, params object[] args);
         void Flush();
+    }
+
+    /// <summary>
+    /// Interface to be implemented by those loggers that provide a StreamReader to read
+    /// the already added info.
+    /// </summary>
+    public interface IReadable
+    {
+        StreamReader GetReader();
+
+    }
+
+    public interface IReadableLog : ILog, IReadable { }
+
+    public interface IFileBackedLog : IReadableLog
+    {
+        string FullPath { get; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ILog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ILog.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
     public interface ILog : IDisposable
     {
-        string Description { get; set; }
+        string? Description { get; set; }
         bool Timestamp { get; set; }
         Encoding Encoding { get; }
         void Write(byte[] buffer, int offset, int count);
@@ -22,17 +22,10 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
         void Flush();
     }
 
-    /// <summary>
-    /// Interface to be implemented by those loggers that provide a StreamReader to read
-    /// the already added info.
-    /// </summary>
-    public interface IReadable
+    public interface IReadableLog : ILog
     {
         StreamReader GetReader();
-
     }
-
-    public interface IReadableLog : ILog, IReadable { }
 
     public interface IFileBackedLog : IReadableLog
     {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
@@ -89,10 +89,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
 
                 log.WriteLine("Found {0} new crash report(s)", newCrashFiles.Count);
 
-                IEnumerable<ILog> crashReports;
+                IEnumerable<IFileBackedLog> crashReports;
                 if (!isDevice)
                 {
-                    crashReports = new List<ILog>(newCrashFiles.Count);
+                    crashReports = new List<IFileBackedLog>(newCrashFiles.Count);
                     foreach (var path in newCrashFiles)
                     {
                         logs.AddFile(path, $"Crash report: {Path.GetFileName(path)}");
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             } while (true);
         }
 
-        async Task<ILog> ProcessCrash(string crashFile)
+        async Task<IFileBackedLog> ProcessCrash(string crashFile)
         {
             var name = Path.GetFileName(crashFile);
             var crashReportFile = logs.Create(name, $"Crash report: {name}", timestamp: false);
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             }
         }
 
-        async Task<ILog> GetSymbolicateCrashReportAsync(ILog report)
+        async Task<IFileBackedLog> GetSymbolicateCrashReportAsync(IFileBackedLog report)
         {
             if (symbolicateCrashPath == null)
             {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="installLog">The installation log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownInstallIssue(ILog installLog, [NotNullWhen(true)] out string? knownFailureMessage);
+        bool IsKnownInstallIssue(IFileBackedLog installLog, [NotNullWhen(true)] out string? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the build failure is due to a known issue that the user can act upon.
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="buildLog">The build log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownBuildIssue(ILog buildLog, [NotNullWhen(true)] out string? knownFailureMessage);
+        bool IsKnownBuildIssue(IFileBackedLog buildLog, [NotNullWhen(true)] out string? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the run failure is due to a known issue that the user can act upon.
@@ -36,6 +36,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="runLog">The run log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownTestIssue(ILog runLog, [NotNullWhen(true)] out string? knownFailureMessage);
+        bool IsKnownTestIssue(IFileBackedLog runLog, [NotNullWhen(true)] out string? knownFailureMessage);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
@@ -6,7 +6,6 @@ using System;
 using System.IO;
 using System.Threading;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
@@ -18,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public string Path { get; private set; }
 
-        public SimpleFileListener(string path, ILog log, ILog testLog, bool xmlOutput) : base(log, testLog)
+        public SimpleFileListener(string path, ILog log, IFileBackedLog testLog, bool xmlOutput) : base(log, testLog)
         {
             Path = path ?? throw new ArgumentNullException(nameof(path));
             _xmlOutput = xmlOutput;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         private HttpListener _server;
         private bool _connected_once;
 
-        public SimpleHttpListener(ILog log, ILog testLog, bool autoExit) : base(log, testLog)
+        public SimpleHttpListener(ILog log, IFileBackedLog testLog, bool autoExit) : base(log, testLog)
         {
             _autoExit = autoExit;
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         Task CompletionTask { get; }
         Task ConnectedTask { get; }
         int Port { get; }
-        ILog TestLog { get; }
+        IFileBackedLog TestLog { get; }
 
         void Cancel();
         void Initialize();
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         private readonly TaskCompletionSource<bool> _stopped = new TaskCompletionSource<bool>();
         private readonly TaskCompletionSource<bool> _connected = new TaskCompletionSource<bool>();
 
-        public ILog TestLog { get; private set; }
+        public IFileBackedLog TestLog { get; private set; }
 
         protected readonly IPAddress Address = IPAddress.Any;
         protected ILog Log { get; }
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         public int Port { get; protected set; }
         public abstract void Initialize();
 
-        protected SimpleListener(ILog log, ILog testLog)
+        protected SimpleListener(ILog log, IFileBackedLog testLog)
         {
             Log = log ?? throw new ArgumentNullException(nameof(log));
             TestLog = testLog ?? throw new ArgumentNullException(nameof(testLog));

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -4,7 +4,6 @@
 
 using System;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
@@ -20,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         (ListenerTransport transport, ISimpleListener listener, string listenerTempFile) Create(
             RunMode mode,
             ILog log,
-            ILog testLog,
+            IFileBackedLog testLog,
             bool isSimulator,
             bool autoExit,
             bool xmlOutput);
@@ -42,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         public (ListenerTransport transport, ISimpleListener listener, string listenerTempFile) Create(
             RunMode mode,
             ILog log,
-            ILog testLog,
+            IFileBackedLog testLog,
             bool isSimulator,
             bool autoExit,
             bool xmlOutput)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -27,13 +27,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public TaskCompletionSource<bool> TunnelHoleThrough { get; } = new TaskCompletionSource<bool>();
 
-        public SimpleTcpListener(ILog log, ILog testLog, bool autoExit, bool tunnel = false) : base(log, testLog)
+        public SimpleTcpListener(ILog log, IFileBackedLog testLog, bool autoExit, bool tunnel = false) : base(log, testLog)
         {
             _autoExit = autoExit;
             _useTcpTunnel = tunnel;
         }
 
-        public SimpleTcpListener(int port, ILog log, ILog testLog, bool autoExit, bool tunnel = false) : this(log, testLog, autoExit, tunnel)
+        public SimpleTcpListener(int port, ILog log, IFileBackedLog testLog, bool autoExit, bool tunnel = false) : this(log, testLog, autoExit, tunnel)
         {
             Port = port;
         }
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             bool processed;
             try
             {
-                int timeout = TimeOutInit; ;
+                int timeout = TimeOutInit;
                 var watch = new System.Diagnostics.Stopwatch();
                 watch.Start();
                 while (true)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
@@ -12,10 +12,10 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
     // Monitor the output from 'mlaunch --installdev' and cancel the installation if there's no output for 1 minute.
-    public class AppInstallMonitorLog : Log
+    public class AppInstallMonitorLog : FileBackedLog
     {
 
-        readonly ILog copy_to;
+        readonly IFileBackedLog copy_to;
         readonly CancellationTokenSource cancellationSource;
 
         public override string FullPath => copy_to.FullPath;
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         public long AppTotalBytes;
         public long WatchAppTotalBytes;
 
-        public AppInstallMonitorLog(ILog copy_to)
+        public AppInstallMonitorLog(IFileBackedLog copy_to)
                 : base($"Watch transfer log for {copy_to.Description}")
         {
             this.copy_to = copy_to;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CallbackLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CallbackLog.cs
@@ -18,19 +18,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             this.onWrite = onWrite;
         }
 
-        public override string FullPath => throw new NotSupportedException();
-
         public override void Dispose()
         {
         }
 
         public override void Flush()
         {
-        }
-
-        public override StreamReader GetReader()
-        {
-            throw new NotSupportedException();
         }
 
         protected override void WriteImpl(string value)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         }
     }
 
-    public interface ICaptureLog : ILog
+    public interface ICaptureLog : IFileBackedLog
     {
         void StartCapture();
         void StopCapture();
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
     // A log that captures data written to a separate file between two moments in time
     // (between StartCapture and StopCapture).
-    public class CaptureLog : Log, ICaptureLog
+    public class CaptureLog : FileBackedLog, ICaptureLog
     {
         readonly bool entireFile;
 
@@ -45,7 +45,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         public override string FullPath { get; }
 
         public CaptureLog(string path, string capture_path, bool entireFile = false)
-            : base()
         {
             FullPath = path ?? throw new ArgumentNullException(nameof(path));
             CapturePath = capture_path ?? throw new ArgumentNullException(nameof(path));

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
@@ -9,7 +9,7 @@ using System.Text;
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
     // A log that writes to standard output
-    public class ConsoleLog : Log
+    public class ConsoleLog : ReadableLog
     {
         readonly StringBuilder captured = new StringBuilder();
 
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             captured.Append(value);
             Console.Write(value);
         }
-
-        public override string FullPath => throw new NotSupportedException();
 
         public override StreamReader GetReader()
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ILogs.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ILogs.cs
@@ -8,22 +8,22 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
-    public interface ILogs : IList<ILog>, IDisposable
+    public interface ILogs : IList<IFileBackedLog>, IDisposable
     {
         string Directory { get; set; }
 
         // Create a new log backed with a file
-        ILog Create(string filename, string name, bool? timestamp = null);
+        IFileBackedLog Create(string filename, string name, bool? timestamp = null);
 
         // Adds an existing file to this collection of logs.
         // If the file is not inside the log directory, then it's copied there.
         // 'path' must be a full path to the file.
-        ILog AddFile(string path);
+        IFileBackedLog AddFile(string path);
 
         // Adds an existing file to this collection of logs.
         // If the file is not inside the log directory, then it's copied there.
         // 'path' must be a full path to the file.
-        ILog AddFile(string path, string name);
+        IFileBackedLog AddFile(string path, string name);
 
         // Create an empty file in the log directory and return the full path to the file
         string CreateFile(string path, string description);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Log.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Log.cs
@@ -50,12 +50,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             Write(string.Format(format, args) + "\n");
         }
 
-        public abstract string FullPath { get; }
-
         protected abstract void WriteImpl(string value);
-
-        public abstract StreamReader GetReader();
-
+        
         public override string ToString() => Description;
 
         public abstract void Flush();

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Log.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Log.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.Text;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
 
@@ -14,10 +14,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
     {
 
         public virtual Encoding Encoding => Encoding.UTF8;
-        public string Description { get; set; }
+        public string? Description { get; set; }
         public bool Timestamp { get; set; } = true;
 
-        protected Log(string description = null)
+        protected Log(string? description = null)
         {
             Description = description;
         }
@@ -51,8 +51,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         }
 
         protected abstract void WriteImpl(string value);
-        
-        public override string ToString() => Description;
+
+        public override string ToString() => Description ?? string.Empty;
 
         public abstract void Flush();
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
-    public class LogFile : Log, ILog
+    public class LogFile : FileBackedLog
     {
         readonly object lock_obj = new object();
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
-    public class Logs : List<ILog>, ILogs
+    public class Logs : List<IFileBackedLog>, ILogs
     {
         private readonly IHelpers _helpers = new Helpers();
 
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         }
 
         // Create a new log backed with a file
-        public ILog Create(string filename, string name, bool? timestamp = null)
+        public IFileBackedLog Create(string filename, string name, bool? timestamp = null)
         {
             return Create(Directory, filename, name, timestamp);
         }
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         // Adds an existing file to this collection of logs.
         // If the file is not inside the log directory, then it's copied there.
         // 'path' must be a full path to the file.
-        public ILog AddFile(string path)
+        public IFileBackedLog AddFile(string path)
         {
             return AddFile(path, Path.GetFileName(path));
         }
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         // Adds an existing file to this collection of logs.
         // If the file is not inside the log directory, then it's copied there.
         // 'path' must be a full path to the file.
-        public ILog AddFile(string path, string name)
+        public IFileBackedLog AddFile(string path, string name)
         {
             if (path == null)
                 throw new ArgumentNullException(nameof(path));

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/MemoryLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/MemoryLog.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
     /// <summary>
     /// Log that only writes to memory
     /// </summary>
-    public class MemoryLog : Log
+    public class MemoryLog : ReadableLog
     {
         readonly StringBuilder captured = new StringBuilder();
 
@@ -19,8 +19,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         {
             captured.Append(value);
         }
-
-        public override string FullPath => throw new NotSupportedException();
 
         public override StreamReader GetReader()
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
@@ -1,12 +1,13 @@
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
     public abstract class ReadableLog : Log, IReadableLog
     {
 
-        protected ReadableLog(string description = null) : base(description) { }
+        protected ReadableLog(string? description = null) : base(description) { }
 
         public abstract StreamReader GetReader();
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using Microsoft.DotNet.XHarness.Common.Logging;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
+{
+    public abstract class ReadableLog : Log, IReadableLog
+    {
+
+        protected ReadableLog(string description = null) : base(description) { }
+
+        public abstract StreamReader GetReader();
+    }
+
+    public abstract class FileBackedLog : ReadableLog, IFileBackedLog
+    {
+        protected FileBackedLog(string description = null) : base(description) { }
+
+        public abstract string FullPath { get; }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ReadableLog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
     public abstract class FileBackedLog : ReadableLog, IFileBackedLog
     {
-        protected FileBackedLog(string description = null) : base(description) { }
+        protected FileBackedLog(string? description = null) : base(description) { }
 
         public abstract string FullPath { get; }
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -30,9 +30,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
     public class TestReporter : ITestReporter
     {
 
-        const string _timeoutMessage = "Test run timed out after {0} minute(s).";
-        const string _completionMessage = "Test run completed";
-        const string _failureMessage = "Test run failed";
+        private const string _timeoutMessage = "Test run timed out after {0} minute(s).";
+        private const string _completionMessage = "Test run completed";
+        private const string _failureMessage = "Test run failed";
 
         readonly ISimpleListener listener;
         readonly IFileBackedLog mainLog;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -30,14 +30,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
     public class TestReporter : ITestReporter
     {
 
-        const string timeoutMessage = "Test run timed out after {0} minute(s).";
-        const string completionMessage = "Test run completed";
-        const string failureMessage = "Test run failed";
+        const string _timeoutMessage = "Test run timed out after {0} minute(s).";
+        const string _completionMessage = "Test run completed";
+        const string _failureMessage = "Test run failed";
 
         readonly ISimpleListener listener;
-        readonly ILog mainLog;
+        readonly IFileBackedLog mainLog;
         readonly ILogs crashLogs;
-        readonly ILog runLog;
+        readonly IReadableLog runLog;
         readonly ILogs logs;
         readonly ICrashSnapshotReporter crashReporter;
         readonly IResultParser resultParser;
@@ -77,8 +77,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         public TestReporter(IMLaunchProcessManager processManager,
-            ILog mainLog,
-            ILog runLog,
+            IFileBackedLog mainLog,
+            IReadableLog runLog,
             ILogs logs,
             ICrashSnapshotReporter crashReporter,
             ISimpleListener simpleListener,
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         }
 
         // return the reason for a crash found in a log
-        void GetCrashReason(int pid, ILog crashLog, out string? crashReason)
+        void GetCrashReason(int pid, IReadableLog crashLog, out string? crashReason)
         {
             crashReason = null;
             using var crashReader = crashLog.GetReader(); // dispose when we leave the method
@@ -242,16 +242,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             {
                 timedout = true;
                 Success = false;
-                mainLog.WriteLine(timeoutMessage, timeout.TotalMinutes);
+                mainLog.WriteLine(_timeoutMessage, timeout.TotalMinutes);
             }
             else if (result.Succeeded)
             {
-                mainLog.WriteLine(completionMessage);
+                mainLog.WriteLine(_completionMessage);
                 Success = true;
             }
             else
             {
-                mainLog.WriteLine(failureMessage);
+                mainLog.WriteLine(_failureMessage);
                 Success = false;
             }
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
 {
     public interface ITestReporterFactory
     {
-        ITestReporter Create(ILog mainLog,
-            ILog runLog,
+        ITestReporter Create(IFileBackedLog mainLog,
+            IReadableLog runLog,
             ILogs logs,
             ICrashSnapshotReporter crashSnapshotReporter,
             ISimpleListener simpleListener,
@@ -41,8 +41,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             this.processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
         }
 
-        public ITestReporter Create(ILog mainLog,
-            ILog runLog,
+        public ITestReporter Create(IFileBackedLog mainLog,
+            IReadableLog runLog,
             ILogs logs,
             ICrashSnapshotReporter crashReporter,
             ISimpleListener simpleListener,

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.XHarness.iOS
         private readonly IDeviceLogCapturerFactory _deviceLogCapturerFactory;
         private readonly ITestReporterFactory _testReporterFactory;
         private readonly ILogs _logs;
-        private readonly ILog _mainLog;
+        private readonly IFileBackedLog _mainLog;
         private readonly IHelpers _helpers;
         private readonly bool _useXmlOutput;
 
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             ICaptureLogFactory captureLogFactory,
             IDeviceLogCapturerFactory deviceLogCapturerFactory,
             ITestReporterFactory reporterFactory,
-            ILog mainLog,
+            IFileBackedLog mainLog,
             ILogs logs,
             IHelpers helpers,
             bool useXmlOutput,
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             else
             {
                 // create using the main as the default log
-                _mainLog = Log.CreateAggregatedLogWithDefault(mainLog, new CallbackLog(logCallback));
+                _mainLog = Log.CreateReadableAggregatedLog(mainLog, new CallbackLog(logCallback));
             }
 
         }
@@ -407,7 +407,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     _mainLog.WriteLine("Starting test run");
 
                     // We need to check for MT1111 (which means that mlaunch won't wait for the app to exit).
-                    var aggregatedLog = Log.CreateAggregatedLogWithDefault(_mainLog, testReporter.CallbackLog);
+                    var aggregatedLog = Log.CreateReadableAggregatedLog(_mainLog, testReporter.CallbackLog);
                     Task<ProcessExecutionResult> runTestTask = _processManager.ExecuteCommandAsync(
                         args,
                         aggregatedLog,

--- a/src/Microsoft.DotNet.XHarness.iOS/ErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/ErrorKnowledgeBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.XHarness.iOS
     {
         const string IncorrectArchPrefix = "IncorrectArchitecture";
 
-        public bool IsKnownInstallIssue(ILog installLog, [NotNullWhen(true)] out string? knownFailureMessage)
+        public bool IsKnownInstallIssue(IFileBackedLog installLog, [NotNullWhen(true)] out string? knownFailureMessage)
         {
             knownFailureMessage = null;
             if (installLog == null)
@@ -47,13 +47,13 @@ namespace Microsoft.DotNet.XHarness.iOS
             return false;
         }
 
-        public bool IsKnownBuildIssue(ILog buildLog, [NotNullWhen(true)] out string? knownFailureMessage)
+        public bool IsKnownBuildIssue(IFileBackedLog buildLog, [NotNullWhen(true)] out string? knownFailureMessage)
         {
             knownFailureMessage = null;
             return false;
         }
 
-        public bool IsKnownTestIssue(ILog runLog, [NotNullWhen(true)] out string? knownFailureMessage)
+        public bool IsKnownTestIssue(IFileBackedLog runLog, [NotNullWhen(true)] out string? knownFailureMessage)
         {
             knownFailureMessage = null;
             return false;

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
@@ -59,8 +59,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             const string crashLogPath = "/path/to/crash.log";
             const string symbolicateLogPath = "/path/to/" + deviceName + ".symbolicated.log";
 
-            var crashReport = Mock.Of<ILog>(x => x.FullPath == crashLogPath);
-            var symbolicateReport = Mock.Of<ILog>(x => x.FullPath == symbolicateLogPath);
+            var crashReport = Mock.Of<IFileBackedLog>(x => x.FullPath == crashLogPath);
+            var symbolicateReport = Mock.Of<IFileBackedLog>(x => x.FullPath == symbolicateLogPath);
 
             // Crash report is added
             _logs.Setup(x => x.Create(deviceName, "Crash report: " + deviceName, It.IsAny<bool>()))

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Moq;
 using Xunit;
 
@@ -15,13 +14,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
     public class SimpleFileListenerTest : IDisposable
     {
         private readonly string _path;
-        private readonly Mock<ILog> _testLog;
+        private readonly Mock<IFileBackedLog> _testLog;
         private readonly Mock<ILog> _log;
 
         public SimpleFileListenerTest()
         {
             _path = Path.GetTempFileName();
-            _testLog = new Mock<ILog>();
+            _testLog = new Mock<IFileBackedLog>();
             _log = new Mock<ILog>();
             File.Delete(_path);
         }
@@ -45,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         [InlineData("<!-- the end -->", true)]
         public void TestProcess(string endLine, bool isXml)
         {
-            var lines = new string[] { "first line", "second line", "last line" };
+            var lines = new[] { "first line", "second line", "last line" };
             // set mock expectations
             _testLog.Setup(l => l.WriteLine("Tests have started executing"));
             _testLog.Setup(l => l.WriteLine("Tests have finished executing"));

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Moq;
 using Xunit;
 
@@ -12,12 +11,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
 {
     public class SimpleListenerFactoryTest
     {
-        private readonly Mock<ILog> _log;
+        private readonly Mock<IFileBackedLog> _log;
         private readonly SimpleListenerFactory _factory;
 
         public SimpleListenerFactoryTest()
         {
-            _log = new Mock<ILog>();
+            _log = new Mock<IFileBackedLog>();
             _factory = new SimpleListenerFactory();
         }
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
 {
     public class SimpleTcpListenerTest
     {
-        private readonly Mock<ILog> _log;
-        private readonly Mock<ILog> _testLog;
+        private readonly Mock<IReadableLog> _log;
+        private readonly Mock<IFileBackedLog> _testLog;
 
         public SimpleTcpListenerTest()
         {
-            _log = new Mock<ILog>();
-            _testLog = new Mock<ILog>();
+            _log = new Mock<IReadableLog>();
+            _testLog = new Mock<IFileBackedLog>();
         }
 
         [Fact(Skip = "Test is flaky - https://github.com/dotnet/xharness/issues/52")]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/ConsoleLogTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/ConsoleLogTest.cs
@@ -24,9 +24,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Logging
         }
 
         [Fact]
-        public void FullPathTest() => Assert.Throws<NotSupportedException>(() => { string path = _log.FullPath; });
-
-        [Fact]
         public void TestWrite()
         {
             var message = "This is a log message";

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         private readonly Mock<ICrashSnapshotReporter> _crashReporter;
         private readonly Mock<IMLaunchProcessManager> _processManager;
         private readonly IResultParser _parser;
-        private readonly Mock<ILog> _runLog;
-        private readonly Mock<ILog> _mainLog;
+        private readonly Mock<IReadableLog> _runLog;
+        private readonly Mock<IFileBackedLog> _mainLog;
         private readonly Mock<ILogs> _logs;
         private readonly Mock<ISimpleListener> _listener;
         private readonly AppBundleInformation _appInformation;
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             _crashReporter = new Mock<ICrashSnapshotReporter>();
             _processManager = new Mock<IMLaunchProcessManager>();
             _parser = new XmlResultParser();
-            _runLog = new Mock<ILog>();
-            _mainLog = new Mock<ILog>();
+            _runLog = new Mock<IReadableLog>();
+            _mainLog = new Mock<IFileBackedLog>();
             _logs = new Mock<ILogs>();
             _listener = new Mock<ISimpleListener>();
             _appInformation = new AppBundleInformation(
@@ -279,7 +279,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         public async Task ParseResultFailingTestsTest()
         {
             var sample = CreateSampleFile("NUnitV3SampleFailure.xml");
-            var listenerLog = new Mock<ILog>();
+            var listenerLog = new Mock<IFileBackedLog>();
             _listener.Setup(l => l.TestLog).Returns(listenerLog.Object);
             listenerLog.Setup(l => l.FullPath).Returns(sample);
 
@@ -297,7 +297,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         {
             // get a file with a success result so that we can return it as part of the listener log
             var sample = CreateSampleFile("NUnitV3SampleSuccess.xml");
-            var listenerLog = new Mock<ILog>();
+            var listenerLog = new Mock<IFileBackedLog>();
             _listener.Setup(l => l.TestLog).Returns(listenerLog.Object);
             listenerLog.Setup(l => l.FullPath).Returns(sample);
 
@@ -317,7 +317,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             var tcs = new TaskCompletionSource<object>();
             _listener.Setup(l => l.CompletionTask).Returns(tcs.Task); // will never be set to be completed
 
-            var listenerLog = new Mock<ILog>();
+            var listenerLog = new Mock<IFileBackedLog>();
             _listener.Setup(l => l.TestLog).Returns(listenerLog.Object);
             listenerLog.Setup(l => l.FullPath).Returns("/my/missing/path");
 
@@ -326,7 +326,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             _runLog.Setup(l => l.GetReader()).Returns(new StreamReader(GetRunLogSample()));
 
             var failurePath = Path.Combine(_logsDirectory, "my-failure.xml");
-            var failureLog = new Mock<ILog>();
+            var failureLog = new Mock<IFileBackedLog>();
             failureLog.Setup(l => l.FullPath).Returns(failurePath);
             _logs.Setup(l => l.Create(It.IsAny<string>(), It.IsAny<string>(), null)).Returns(failureLog.Object);
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/XmlResultParserTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/XmlResultParserTests.cs
@@ -266,8 +266,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
 
             // create a path with data in it
             var logs = new Mock<ILogs>();
-            var tmpLogMock = new Mock<ILog>();
-            var xmlLogMock = new Mock<ILog>();
+            var tmpLogMock = new Mock<IFileBackedLog>();
+            var xmlLogMock = new Mock<IFileBackedLog>();
 
             var tmpPath = Path.GetTempFileName();
             var finalPath = Path.GetTempFileName();

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
         private readonly Mock<IMLaunchProcessManager> _processManager;
         private readonly Mock<ILogs> _logs;
-        private readonly Mock<ILog> _mainLog;
+        private readonly Mock<IFileBackedLog> _mainLog;
         private readonly Mock<ISimulatorLoader> _simulatorLoader;
         private readonly Mock<ISimpleListener> _listener;
         private readonly Mock<ICrashSnapshotReporter> _snapshotReporter;
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
         public AppRunnerTests()
         {
-            _mainLog = new Mock<ILog>();
+            _mainLog = new Mock<IFileBackedLog>();
 
             _processManager = new Mock<IMLaunchProcessManager>();
             _processManager.SetReturnsDefault(Task.FromResult(new ProcessExecutionResult() { ExitCode = 0 }));
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 .Setup(x => x.FindSimulators(TestTarget.Simulator_tvOS, _mainLog.Object, true, false))
                 .ReturnsAsync(new ISimulatorDevice[0]);
 
-            var listenerLogFile = new Mock<ILog>();
+            var listenerLogFile = new Mock<IFileBackedLog>();
 
             _logs
                 .Setup(x => x.Create(It.IsAny<string>(), "TestLog", It.IsAny<bool>()))
@@ -221,10 +221,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             _simulatorLoader
                 .Setup(x => x.FindSimulators(TestTarget.Simulator_tvOS, _mainLog.Object, true, false))
-                .ReturnsAsync(new ISimulatorDevice[] { simulator.Object });
+                .ReturnsAsync(new[] { simulator.Object });
 
             var testResultFilePath = Path.GetTempFileName();
-            var listenerLogFile = Mock.Of<ILog>(x => x.FullPath == testResultFilePath);
+            var listenerLogFile = Mock.Of<IFileBackedLog>(x => x.FullPath == testResultFilePath);
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs
@@ -360,7 +360,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
         [InlineData(true, true)] // tunnel and xml
         public async Task RunOnDeviceSuccessfullyTest(bool useTunnel, bool useXml)
         {
-            var deviceSystemLog = new Mock<ILog>();
+            var deviceSystemLog = new Mock<IFileBackedLog>();
             deviceSystemLog.SetupGet(x => x.FullPath).Returns(Path.GetTempFileName());
 
             var deviceLogCapturer = new Mock<IDeviceLogCapturer>();
@@ -371,7 +371,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 .Returns(deviceLogCapturer.Object);
 
             var testResultFilePath = Path.GetTempFileName();
-            var listenerLogFile = Mock.Of<ILog>(x => x.FullPath == testResultFilePath);
+            var listenerLogFile = Mock.Of<IFileBackedLog>(x => x.FullPath == testResultFilePath);
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs


### PR DESCRIPTION
The initial implementation of the logs, yet useful, it was wrong. It
made it very easy to pass Logs that do have certain missing properties
and methods to other classes that used those methods, resulting in
runtime issues.

We move to have different interfaces that will allow to say which is the
min amount of methods to be implemented (ILog) or the max one
(IFileBackedLog) so that the compiler will help us to not pass a
MemoryLog or a ConsoleLog to those methods that will like to use, for
example, the FullPath of the log.

This might look like a breaking change for xamarin-macios, but whatever
it breaks was a hidden bug.