### PR TITLE
[Runners] Allow to provide specific tests and test classes.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
     {
         private string? _appPackagePath = null;
         private string? _outputDirectory = null;
+        private List<string> _singleMethodFilters = new List<string>();
+        private List<string> _classMethodFilters = new List<string>();
 
         /// <summary>
         /// Path to packaged app
@@ -43,6 +45,16 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(15);
 
+        /// <summary>
+        /// Methods to be included in the test run while all others are ignored.
+        /// </summary>
+        public IEnumerable<string> SingleMethodFilters => _singleMethodFilters;
+
+        /// <summary>
+        /// Tests classes to be included in the run while all others are ignored.
+        /// </summary>
+        public List<string> ClassMethodFilters => _classMethodFilters;
+
         protected sealed override OptionSet GetCommandOptions()
         {
             var options = new OptionSet
@@ -67,6 +79,18 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
                         Timeout = TimeSpan.FromSeconds(timeout);
                     }
                 },
+                {
+                    "method|m=", "Method to be ran in the test application. When this parameter is used only the " +
+                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "ignored. Can be used more than once.",
+                    v => _singleMethodFilters.Add(v)
+                },
+                {
+                    "class|c=", "Test class to be ran in the test application. When this parameter is used only the " +
+                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "ignored. Can be used more than once.",
+                    v => _classMethodFilters.Add(v)
+                }
             };
 
             foreach (var option in GetTestCommandOptions())

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
@@ -81,13 +81,13 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
                 },
                 {
                     "method|m=", "Method to be ran in the test application. When this parameter is used only the " +
-                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "tests that have been provided by the '--method' and '--class' arguments will be ran. All other test will be " +
                     "ignored. Can be used more than once.",
                     v => _singleMethodFilters.Add(v)
                 },
                 {
                     "class|c=", "Test class to be ran in the test application. When this parameter is used only the " +
-                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "tests that have been provided by the '--method' and '--class' arguments will be ran. All other test will be " +
                     "ignored. Can be used more than once.",
                     v => _classMethodFilters.Add(v)
                 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -215,7 +216,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     deviceName,
                     verbosity: verbosity,
                     xmlResultJargon: _arguments.XmlResultJargon,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: cancellationToken,
+                    skippedMethods: _arguments.SingleMethodFilters?.ToArray(),
+                    skippedTestClasses:_arguments.ClassMethodFilters?.ToArray());
 
                 switch (testResult)
                 {

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationEntryPoint.cs
@@ -166,6 +166,16 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
         internal static void ConfigureRunner(TestRunner runner, ApplicationOptions options)
         {
             runner.RunAllTestsByDefault = options.RunAllTestsByDefault;
+            // add the provided method and class filters
+            foreach (string methodName in options.SingleMethodFilters)
+            {
+                runner.SkipMethod(methodName, !options.RunAllTestsByDefault);
+            }
+
+            foreach (string className in options.ClassMethodFilters)
+            {
+                runner.SkipClass(className, !options.RunAllTestsByDefault);
+            }
         }
 
         internal static string WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -85,12 +85,12 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners
                 }},
                 {
                     "method|m=", "Method to be ran in the test application. When this parameter is used only the " +
-                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "tests that have been provided by the '--method' and '--class' arguments will be ran. All other test will be " +
                     "ignored. Can be used more than once.",
                     v => _singleMethodFilters.Add(v)
                 },
                 {
-                    "class|c=", "Test class to be ran in the test application. When this parameter is used only the " +
+                    "tests that have been provided by the '--method' and '--class' arguments will be ran. All other test will be " +
                     "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
                     "ignored. Can be used more than once.",
                     v => _classMethodFilters.Add(v)

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/ApplicationOptions.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
 using Mono.Options;
 
-namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
+namespace Microsoft.DotNet.XHarness.Tests.Runners
 {
 
     internal enum XmlMode
@@ -20,6 +21,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
     {
 
         static public ApplicationOptions Current = new ApplicationOptions();
+        private List<string> _singleMethodFilters = new List<string>();
+        private List<string> _classMethodFilters = new List<string>();
 
         public ApplicationOptions()
         {
@@ -51,6 +54,16 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                 LogFile = Environment.GetEnvironmentVariable(EnviromentVariables.LogFilePath);
             if (bool.TryParse(Environment.GetEnvironmentVariable(EnviromentVariables.RunAllTestsByDefault), out b))
                 RunAllTestsByDefault = b;
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.SkippedMethods)))
+            {
+                var methods = Environment.GetEnvironmentVariable(EnviromentVariables.SkippedMethods);
+                _singleMethodFilters.AddRange(methods.Split(','));
+            }
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.SkippedClasses)))
+            {
+                var classes = Environment.GetEnvironmentVariable(EnviromentVariables.SkippedClasses);
+                _classMethodFilters.AddRange(classes.Split(','));
+            }
 
             var os = new OptionSet() {
                 { "autoexit", "Exit application once the test run has completed.", v => TerminateAfterExecution = true },
@@ -69,7 +82,19 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
                     // if cannot parse, use default
                     if (Boolean.TryParse(v, out var runAll))
                         RunAllTestsByDefault = runAll;
-                }}
+                }},
+                {
+                    "method|m=", "Method to be ran in the test application. When this parameter is used only the " +
+                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "ignored. Can be used more than once.",
+                    v => _singleMethodFilters.Add(v)
+                },
+                {
+                    "class|c=", "Test class to be ran in the test application. When this parameter is used only the " +
+                    "tests that vave been provided my 'method' and 'class' will be ran. All other test will be " +
+                    "ignored. Can be used more than once.",
+                    v => _classMethodFilters.Add(v)
+                }
             };
 
             try
@@ -156,5 +181,14 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         /// </summary>
         public bool RunAllTestsByDefault { get; set; } = true;
 
+        /// <summary>
+        /// Specify the methods to be ran in the app.
+        /// </summary>
+        public IEnumerable<string> SingleMethodFilters => _singleMethodFilters;
+
+        /// <summary>
+        /// Specify the test classes to be ran in the app.
+        /// </summary>
+        public IEnumerable<string> ClassMethodFilters => _classMethodFilters;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/Core/TestRunner.cs
@@ -115,6 +115,8 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Core
         public abstract void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon);
         public abstract void SkipTests(IEnumerable<string> tests);
         public abstract void SkipCategories(IEnumerable<string> categories);
+        public abstract void SkipMethod(string method, bool isExcluded);
+        public abstract void SkipClass(string className, bool isExcluded);
 
         protected void OnError(string message)
         {

--- a/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Tests.Runners/xUnit/XUnitTestRunner.cs
@@ -1054,5 +1054,11 @@ namespace Microsoft.DotNet.XHarness.Tests.Runners.Xunit
                 }
             }
         }
+
+        public override void SkipMethod(string method, bool isExcluded)
+            => filters.Add(XUnitFilter.CreateSingleFilter(singleTestName: method, exclude: isExcluded));
+
+        public override void SkipClass(string className, bool isExcluded)
+            => filters.Add(XUnitFilter.CreateClassFilter(className: className, exclude: isExcluded));
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/EnviromentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Mlaunch/EnviromentVariables.cs
@@ -74,5 +74,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch
         /// Env var used to notify the test application if all the tests should be ran by default.
         /// </summary>
         public const string RunAllTestsByDefault = "NUNIT_RUN_ALL";
+
+        /// <summary>
+        /// Env var used to notify the test application which tests will be excluded.
+        /// </summary>
+        public const string SkippedMethods = "NUNIT_SKIPPED_METHODS";
+
+        /// <summary>
+        /// Env var uses to notify the test application which test classes will be excluded.
+        /// </summary>
+        public const string SkippedClasses = "NUNIT_SKIPPED_CLASSES";
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -104,8 +104,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                 new SetEnvVariableArgument(EnviromentVariables.DisableSystemPermissionTests, 1),
             };
 
-            if ((skippedMethods != null && skippedMethods.Length > 0) ||
-                (skippedTestClasses != null && skippedTestClasses.Length > 0))
+            if (skippedMethods?.Any() ?? skippedTestClasses?.Any() ?? false)
             {
                 // do not run all the tests, we are using filters
                 args.Add(new SetEnvVariableArgument(EnviromentVariables.RunAllTestsByDefault, false));

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -83,6 +83,8 @@ namespace Microsoft.DotNet.XHarness.iOS
             bool ensureCleanSimulatorState = false,
             int verbosity = 1,
             XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
+            string[]? skippedMethods = null,
+            string[]? skippedTestClasses = null,
             CancellationToken cancellationToken = default)
         {
             var args = new MlaunchArguments
@@ -101,6 +103,26 @@ namespace Microsoft.DotNet.XHarness.iOS
                 // So by default ignore any tests that would pop up permission dialogs in CI.
                 new SetEnvVariableArgument(EnviromentVariables.DisableSystemPermissionTests, 1),
             };
+
+            if ((skippedMethods != null && skippedMethods.Length > 0) ||
+                (skippedTestClasses != null && skippedTestClasses.Length > 0))
+            {
+                // do not run all the tests, we are using filters
+                args.Add(new SetEnvVariableArgument(EnviromentVariables.RunAllTestsByDefault, false));
+
+                // add the skipped test classes and methods
+                if (skippedMethods != null && skippedMethods.Length > 0)
+                {
+                    var skippedMethodsValue = string.Join(',', skippedMethods);
+                    args.Add(new SetEnvVariableArgument(EnviromentVariables.SkippedMethods, skippedMethodsValue));
+                }
+
+                if (skippedTestClasses != null && skippedTestClasses!.Length > 0)
+                {
+                    var skippedClassesValue = string.Join(',', skippedTestClasses);
+                    args.Add(new SetEnvVariableArgument(EnviromentVariables.SkippedClasses, skippedClassesValue));
+                }
+            }
 
             for (int i = -1; i < verbosity; i++)
             {


### PR DESCRIPTION
Add new parameters to allow to tell the runners to skip all tests and
just run a subset of them via:

-method: The fullname of the method to execute.
-class: The fullname of the test class to execute.

Both allw to be used more than once.

fixes: https://github.com/dotnet/xharness/issues/144