### PR TITLE
Improve retry and logging around adb devices

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -317,11 +317,12 @@ namespace Microsoft.DotNet.XHarness.Android
             var result = RunAdbCommand("devices -l", TimeSpan.FromSeconds(30));
             string standardOutput = result.StandardOutput;
 
-            // Retry up to 1 min til we get output; if the ADB server isn't started the output will come from a child process and we'll miss it.
-            int retriesLeft = 6;
-            // Empty string = Adb started another process to do the work and we should call again
-            while (retriesLeft-- > 0 && string.IsNullOrEmpty(standardOutput)) 
+            // Retry up to 5 mins til we get output; if the ADB server isn't started the output will come from a child process and we'll miss it.
+            int retriesLeft = 30;
+            // Empty string + success = Adb started another process to do the work and we should call again
+            while (retriesLeft-- > 0 && (string.IsNullOrEmpty(standardOutput) || (result.ExitCode != (int)AdbExitCodes.SUCCESS))) 
             {
+                _log.LogDebug($"Result: exit code={result.ExitCode} Output: {result.StandardOutput} {Environment.NewLine} {result.StandardError}");
                 Thread.Sleep(10000);
                 result = RunAdbCommand("devices -l", TimeSpan.FromSeconds(30));
                 standardOutput = result.StandardOutput;


### PR DESCRIPTION
I can't repro [this error](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-arcade-refs-heads-prvysoky-xharness-io432a676f47944fefa8/xharness-System.Numerics.Vectors.Tests-x86/console.ca83ad82.log) but I know it's out there.  

My approach is to try longer (not the problem in this case, but this is an absolutely breaking problem for > 1 device machines), print out the outputs in case of failure, and tighten up the condition for device listing. I may introduce retry at a different layer if this doesn't work.