### PR TITLE
[iOS] Refactor AppRunner

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -209,7 +209,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 mainLog,
                 logs,
                 new Helpers(),
-                useXmlOutput: true, // the cli ALWAYS will get the output as xml
                 logCallback: logCallback);
 
             try
@@ -318,6 +317,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             }
             finally
             {
+                mainLog.Dispose();
+
                 if (!target.IsSimulator() && deviceName != null)
                 {
                     logger.LogInformation($"Uninstalling the application '{appBundleInfo.AppName}' from device '{deviceName}'");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -205,6 +205,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 new CaptureLogFactory(),
                 new DeviceLogCapturerFactory(processManager),
                 new TestReporterFactory(processManager),
+                new XmlResultParser(),
                 mainLog,
                 logs,
                 new Helpers(),

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -75,11 +74,14 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             return exitCode;
         }
 
-        static bool IsLldbEnabled() => File.Exists(_mlaunchLldbConfigFile);
+        private static bool IsLldbEnabled() => File.Exists(_mlaunchLldbConfigFile);
 
-        void NotifyUserLldbCommand(ILogger logger, string line)
+        private void NotifyUserLldbCommand(ILogger logger, string line)
         {
-            if (!line.Contains("mtouch-lldb-prep-cmds")) return;
+            if (!line.Contains("mtouch-lldb-prep-cmds"))
+            {
+                return;
+            }
 
             // let the user know the command to execute. Might change in mlaunch so trust the log
             var sb = new StringBuilder();
@@ -224,7 +226,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                     xmlResultJargon: _arguments.XmlResultJargon,
                     cancellationToken: cancellationToken,
                     skippedMethods: _arguments.SingleMethodFilters?.ToArray(),
-                    skippedTestClasses:_arguments.ClassMethodFilters?.ToArray());
+                    skippedTestClasses: _arguments.ClassMethodFilters?.ToArray());
 
                 switch (testResult)
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             IFileBackedLog mainLog = Log.CreateReadableAggregatedLog(
                 logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true),
-                new CallbackLog(message => logger.LogDebug(message)) { Timestamp = false });
+                new CallbackLog(message => logger.LogDebug(message.Trim())) { Timestamp = false });
 
             int verbosity = GetMlaunchVerbosity(_arguments.Verbosity);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -111,12 +111,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 if (!File.Exists(_mlaunchLldbConfigFile))
                 {
                     // create empty file
-                    var f = File.Create(_mlaunchLldbConfigFile);
-                    f.Dispose();
+                    File.WriteAllText(_mlaunchLldbConfigFile, string.Empty);
                     _createdLldbFile = true;
                 }
             }
-
 
             logger.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
 
@@ -158,7 +156,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 }
                 catch (NoDeviceFoundException)
                 {
-                    logger.LogError($"Failed to find suitable device for target {target.AsString()}");
+                    logger.LogError($"Failed to find suitable device for target {target.AsString()}" + Environment.NewLine +
+                        "Please make sure the device is connected and unlocked.");
                     return ExitCode.DEVICE_NOT_FOUND;
                 }
                 catch (Exception e)
@@ -293,7 +292,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             }
             catch (NoDeviceFoundException)
             {
-                logger.LogError($"Failed to find suitable device for target {target.AsString()}");
+                logger.LogError($"Failed to find suitable device for target {target.AsString()}" +
+                    (target.IsSimulator() ? Environment.NewLine + "Please make sure suitable Simulator is installed in Xcode" : string.Empty));
+
                 return ExitCode.DEVICE_NOT_FOUND;
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -321,6 +321,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             try
             {
                 rv.ExitCode = process.ExitCode;
+                log.WriteLine($"Process exited with {rv.ExitCode}");
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
@@ -6,36 +6,67 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 {
     public class SimRuntime
     {
-        public string Name;
-        public string Identifier;
-        public long Version;
+        public string Name { get; }
+        public string Identifier { get; }
+        public long Version { get; }
+
+        public SimRuntime(string name, string identifier, long version)
+        {
+            Name = name;
+            Identifier = identifier;
+            Version = version;
+        }
     }
 
     public class SimDeviceType
     {
-        public string Name;
-        public string Identifier;
-        public string ProductFamilyId;
-        public long MinRuntimeVersion;
-        public long MaxRuntimeVersion;
-        public bool Supports64Bits;
+        public string Name { get; }
+        public string Identifier { get; }
+        public string ProductFamilyId { get; }
+        public long MinRuntimeVersion { get; }
+        public long MaxRuntimeVersion { get; }
+        public bool Supports64Bits { get; }
+
+        public SimDeviceType(string name, string identifier, string productFamilyId, long minRuntimeVersion, long maxRuntimeVersion, bool supports64Bits)
+        {
+            Name = name;
+            Identifier = identifier;
+            ProductFamilyId = productFamilyId;
+            MinRuntimeVersion = minRuntimeVersion;
+            MaxRuntimeVersion = maxRuntimeVersion;
+            Supports64Bits = supports64Bits;
+        }
     }
 
     public class SimDevicePair
     {
-        public string UDID;
-        public string Companion;
-        public string Gizmo;
+        public string UDID { get; }
+        public string Companion { get; }
+        public string Gizmo { get; }
+
+        public SimDevicePair(string uDID, string companion, string gizmo)
+        {
+            UDID = uDID;
+            Companion = companion;
+            Gizmo = gizmo;
+        }
     }
 
     public class SimDeviceSpecification
     {
-        public SimulatorDevice Main;
-        public SimulatorDevice Companion; // the phone for watch devices
+        public SimulatorDevice Main { get; }
+        public SimulatorDevice Companion { get; } // the phone for watch devices
+
+        public SimDeviceSpecification(SimulatorDevice main, SimulatorDevice companion)
+        {
+            Main = main;
+            Companion = companion;
+        }
     }
 
     public interface ISimulatorDevice : IDevice
@@ -58,7 +89,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         IEnumerable<SimDeviceType> SupportedDeviceTypes { get; }
         IEnumerable<SimulatorDevice> AvailableDevices { get; }
         IEnumerable<SimDevicePair> AvailableDevicePairs { get; }
-        Task<ISimulatorDevice[]> FindSimulators(TestTarget target, ILog log, bool create_if_needed = true, bool min_version = false);
+        Task<ISimulatorDevice[]?> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
         ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device);
         IEnumerable<ISimulatorDevice> SelectDevices(TestTarget target, ILog log, bool min_version);
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         IEnumerable<SimDeviceType> SupportedDeviceTypes { get; }
         IEnumerable<SimulatorDevice> AvailableDevices { get; }
         IEnumerable<SimDevicePair> AvailableDevicePairs { get; }
-        Task<(ISimulatorDevice? Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
+        Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
         ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device);
         IEnumerable<ISimulatorDevice?> SelectDevices(TestTarget target, ILog log, bool min_version);
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
@@ -89,8 +89,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         IEnumerable<SimDeviceType> SupportedDeviceTypes { get; }
         IEnumerable<SimulatorDevice> AvailableDevices { get; }
         IEnumerable<SimDevicePair> AvailableDevicePairs { get; }
-        Task<ISimulatorDevice[]?> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
+        Task<(ISimulatorDevice? Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
         ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device);
-        IEnumerable<ISimulatorDevice> SelectDevices(TestTarget target, ILog log, bool min_version);
+        IEnumerable<ISimulatorDevice?> SelectDevices(TestTarget target, ILog log, bool min_version);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -71,12 +71,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 
                 var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromSeconds(30));
 
-                if (!result.Succeeded)
+                // mlaunch can sometimes return 0 but hang and timeout. It still outputs returns valid content to the tmp file
+                if (result.ExitCode != 0)
                 {
-                    throw new Exception("Failed to list simulators.");
+                    throw new Exception($"Failed to list simulators (mlaunch returned {result.ExitCode})");
                 }
 
-                log.WriteLine("Result:" + Environment.NewLine + File.ReadAllText(tmpfile));
+                var xmlContent = File.ReadAllText(tmpfile);
+
+                log.WriteLine("Simulator listing returned:" + Environment.NewLine + xmlContent);
 
                 var simulatorData = new XmlDocument();
                 simulatorData.LoadWithoutNetworkAccess(tmpfile);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                         new ListSimulatorsArgument(tmpfile),
                         new XmlOutputFormatArgument());
 
-                    var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(1));
+                    var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromSeconds(30));
 
                     if (!result.Succeeded)
                     {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -18,158 +17,167 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared.Collections;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 {
-
     public class SimulatorLoader : ISimulatorLoader
     {
-        readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
-        readonly BlockingEnumerableCollection<SimRuntime> supported_runtimes = new BlockingEnumerableCollection<SimRuntime>();
-        readonly BlockingEnumerableCollection<SimDeviceType> supported_device_types = new BlockingEnumerableCollection<SimDeviceType>();
-        readonly BlockingEnumerableCollection<SimulatorDevice> available_devices = new BlockingEnumerableCollection<SimulatorDevice>();
-        readonly BlockingEnumerableCollection<SimDevicePair> available_device_pairs = new BlockingEnumerableCollection<SimDevicePair>();
-        readonly IMLaunchProcessManager processManager;
+        private readonly BlockingEnumerableCollection<SimRuntime> _supportedRuntimes = new BlockingEnumerableCollection<SimRuntime>();
+        private readonly BlockingEnumerableCollection<SimDeviceType> _supportedDeviceTypes = new BlockingEnumerableCollection<SimDeviceType>();
+        private readonly BlockingEnumerableCollection<SimulatorDevice> _availableDevices = new BlockingEnumerableCollection<SimulatorDevice>();
+        private readonly BlockingEnumerableCollection<SimDevicePair> _availableDevicePairs = new BlockingEnumerableCollection<SimDevicePair>();
 
-        bool loaded;
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        private readonly IMLaunchProcessManager _processManager;
+        private bool _loaded;
 
-        public IEnumerable<SimRuntime> SupportedRuntimes => supported_runtimes;
-        public IEnumerable<SimDeviceType> SupportedDeviceTypes => supported_device_types;
-        public IEnumerable<SimulatorDevice> AvailableDevices => available_devices;
-        public IEnumerable<SimDevicePair> AvailableDevicePairs => available_device_pairs;
+        public IEnumerable<SimRuntime> SupportedRuntimes => _supportedRuntimes;
+        public IEnumerable<SimDeviceType> SupportedDeviceTypes => _supportedDeviceTypes;
+        public IEnumerable<SimulatorDevice> AvailableDevices => _availableDevices;
+        public IEnumerable<SimDevicePair> AvailableDevicePairs => _availableDevicePairs;
 
         public SimulatorLoader(IMLaunchProcessManager processManager)
         {
-            this.processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
+            _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
         }
 
         public async Task LoadDevices(ILog log, bool includeLocked = false, bool forceRefresh = false, bool listExtraData = false)
         {
-            await semaphore.WaitAsync();
-            if (loaded)
+            await _semaphore.WaitAsync();
+            if (_loaded)
             {
                 if (!forceRefresh)
                 {
-                    semaphore.Release();
+                    _semaphore.Release();
                     return;
                 }
-                supported_runtimes.Reset();
-                supported_device_types.Reset();
-                available_devices.Reset();
-                available_device_pairs.Reset();
+                _supportedRuntimes.Reset();
+                _supportedDeviceTypes.Reset();
+                _availableDevices.Reset();
+                _availableDevicePairs.Reset();
             }
-            loaded = true;
+            _loaded = true;
 
             await Task.Run(async () =>
             {
                 var tmpfile = Path.GetTempFileName();
                 try
                 {
-                    using (var process = new Process())
+                    var arguments = new MlaunchArguments(
+                        new ListSimulatorsArgument(tmpfile),
+                        new XmlOutputFormatArgument());
+
+                    var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromSeconds(30));
+
+                    if (!result.Succeeded)
                     {
-                        var arguments = new MlaunchArguments(
-                            new ListSimulatorsArgument(tmpfile),
-                            new XmlOutputFormatArgument());
+                        throw new Exception("Failed to list simulators.");
+                    }
 
-                        var task = processManager.RunAsync(process, arguments, log, timeout: TimeSpan.FromSeconds(30));
-                        log.WriteLine("Launching {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
-
-                        var result = await task;
-
-                        if (!result.Succeeded)
-                            throw new Exception("Failed to list simulators.");
-
-                        log.WriteLine("Result:");
-                        log.WriteLine(File.ReadAllText(tmpfile));
-                        var simulator_data = new XmlDocument();
-                        simulator_data.LoadWithoutNetworkAccess(tmpfile);
-                        foreach (XmlNode sim in simulator_data.SelectNodes("/MTouch/Simulator/SupportedRuntimes/SimRuntime"))
+                    log.WriteLine("Result:");
+                    log.WriteLine(File.ReadAllText(tmpfile));
+                    var simulatorData = new XmlDocument();
+                    simulatorData.LoadWithoutNetworkAccess(tmpfile);
+                    foreach (XmlNode? sim in simulatorData.SelectNodes("/MTouch/Simulator/SupportedRuntimes/SimRuntime"))
+                    {
+                        if (sim == null)
                         {
-                            supported_runtimes.Add(new SimRuntime()
-                            {
-                                Name = sim.SelectSingleNode("Name").InnerText,
-                                Identifier = sim.SelectSingleNode("Identifier").InnerText,
-                                Version = long.Parse(sim.SelectSingleNode("Version").InnerText),
-                            });
+                            continue;
                         }
 
-                        foreach (XmlNode sim in simulator_data.SelectNodes("/MTouch/Simulator/SupportedDeviceTypes/SimDeviceType"))
+                        _supportedRuntimes.Add(new SimRuntime(
+                            name: sim.SelectSingleNode("Name").InnerText,
+                            identifier: sim.SelectSingleNode("Identifier").InnerText,
+                            version: long.Parse(sim.SelectSingleNode("Version").InnerText)));
+                    }
+
+                    foreach (XmlNode? sim in simulatorData.SelectNodes("/MTouch/Simulator/SupportedDeviceTypes/SimDeviceType"))
+                    {
+                        if (sim == null)
                         {
-                            supported_device_types.Add(new SimDeviceType()
-                            {
-                                Name = sim.SelectSingleNode("Name").InnerText,
-                                Identifier = sim.SelectSingleNode("Identifier").InnerText,
-                                ProductFamilyId = sim.SelectSingleNode("ProductFamilyId").InnerText,
-                                MinRuntimeVersion = long.Parse(sim.SelectSingleNode("MinRuntimeVersion").InnerText),
-                                MaxRuntimeVersion = long.Parse(sim.SelectSingleNode("MaxRuntimeVersion").InnerText),
-                                Supports64Bits = bool.Parse(sim.SelectSingleNode("Supports64Bits").InnerText),
-                            });
+                            continue;
                         }
 
-                        foreach (XmlNode sim in simulator_data.SelectNodes("/MTouch/Simulator/AvailableDevices/SimDevice"))
+                        _supportedDeviceTypes.Add(new SimDeviceType(
+                            name: sim.SelectSingleNode("Name").InnerText,
+                            identifier: sim.SelectSingleNode("Identifier").InnerText,
+                            productFamilyId: sim.SelectSingleNode("ProductFamilyId").InnerText,
+                            minRuntimeVersion: long.Parse(sim.SelectSingleNode("MinRuntimeVersion").InnerText),
+                            maxRuntimeVersion: long.Parse(sim.SelectSingleNode("MaxRuntimeVersion").InnerText),
+                            supports64Bits: bool.Parse(sim.SelectSingleNode("Supports64Bits").InnerText)));
+                    }
+
+                    foreach (XmlNode? sim in simulatorData.SelectNodes("/MTouch/Simulator/AvailableDevices/SimDevice"))
+                    {
+                        if (sim == null)
                         {
-                            available_devices.Add(new SimulatorDevice(processManager, new TCCDatabase(processManager))
-                            {
-                                Name = sim.Attributes["Name"].Value,
-                                UDID = sim.Attributes["UDID"].Value,
-                                SimRuntime = sim.SelectSingleNode("SimRuntime").InnerText,
-                                SimDeviceType = sim.SelectSingleNode("SimDeviceType").InnerText,
-                                DataPath = sim.SelectSingleNode("DataPath").InnerText,
-                                LogPath = sim.SelectSingleNode("LogPath").InnerText,
-                            });
+                            continue;
                         }
 
-
-                        var sim_device_pairs = simulator_data.
-                            SelectNodes("/MTouch/Simulator/AvailableDevicePairs/SimDevicePair").
-                            Cast<XmlNode>().
-                            // There can be duplicates, so remove those.
-                            Distinct(new SimulatorXmlNodeComparer());
-                        foreach (XmlNode sim in sim_device_pairs)
+                        _availableDevices.Add(new SimulatorDevice(_processManager, new TCCDatabase(_processManager))
                         {
-                            available_device_pairs.Add(new SimDevicePair()
-                            {
-                                UDID = sim.Attributes["UDID"].Value,
-                                Companion = sim.SelectSingleNode("Companion").InnerText,
-                                Gizmo = sim.SelectSingleNode("Gizmo").InnerText,
-                            });
-                        }
+                            Name = sim.Attributes["Name"].Value,
+                            UDID = sim.Attributes["UDID"].Value,
+                            SimRuntime = sim.SelectSingleNode("SimRuntime").InnerText,
+                            SimDeviceType = sim.SelectSingleNode("SimDeviceType").InnerText,
+                            DataPath = sim.SelectSingleNode("DataPath").InnerText,
+                            LogPath = sim.SelectSingleNode("LogPath").InnerText,
+                        });
+                    }
+
+                    var sim_device_pairs = simulatorData.
+                        SelectNodes("/MTouch/Simulator/AvailableDevicePairs/SimDevicePair").
+                        Cast<XmlNode>().
+                        // There can be duplicates, so remove those.
+                        Distinct(new SimulatorXmlNodeComparer());
+
+                    foreach (XmlNode sim in sim_device_pairs)
+                    {
+                        _availableDevicePairs.Add(new SimDevicePair(
+                            uDID: sim.Attributes["UDID"].Value,
+                            companion: sim.SelectSingleNode("Companion").InnerText,
+                            gizmo: sim.SelectSingleNode("Gizmo").InnerText));
                     }
                 }
                 finally
                 {
-                    supported_runtimes.SetCompleted();
-                    supported_device_types.SetCompleted();
-                    available_devices.SetCompleted();
-                    available_device_pairs.SetCompleted();
+                    _supportedRuntimes.SetCompleted();
+                    _supportedDeviceTypes.SetCompleted();
+                    _availableDevices.SetCompleted();
+                    _availableDevicePairs.SetCompleted();
                     File.Delete(tmpfile);
-                    semaphore.Release();
+                    _semaphore.Release();
                 }
             });
         }
 
-        string CreateName(string devicetype, string runtime)
+        private string CreateName(string deviceType, string runtime)
         {
-            var runtime_name = supported_runtimes?.Where((v) => v.Identifier == runtime).FirstOrDefault()?.Name ?? Path.GetExtension(runtime).Substring(1);
-            var device_name = supported_device_types?.Where((v) => v.Identifier == devicetype).FirstOrDefault()?.Name ?? Path.GetExtension(devicetype).Substring(1);
-            return $"{device_name} ({runtime_name}) - created by xharness";
+            var runtimeName = _supportedRuntimes?.Where((v) => v.Identifier == runtime).FirstOrDefault()?.Name ?? Path.GetExtension(runtime).Substring(1);
+            var deviceName = _supportedDeviceTypes?.Where((v) => v.Identifier == deviceType).FirstOrDefault()?.Name ?? Path.GetExtension(deviceType).Substring(1);
+            return $"{deviceName} ({runtimeName}) - created by XHarness";
         }
 
         // Will return all devices that match the runtime + devicetype (even if a new device was created, any other devices will also be returned)
-        async Task<IEnumerable<ISimulatorDevice>> FindOrCreateDevicesAsync(ILog log, string runtime, string devicetype, bool force = false)
+        private async Task<IEnumerable<ISimulatorDevice>?> FindOrCreateDevicesAsync(ILog log, string? runtime, string? devicetype, bool force = false)
         {
             if (runtime == null || devicetype == null)
+            {
                 return null;
+            }
 
-            IEnumerable<ISimulatorDevice> devices = null;
+            IEnumerable<ISimulatorDevice>? devices = null;
 
             if (!force)
             {
                 devices = AvailableDevices.Where(v => v.SimRuntime == runtime && v.SimDeviceType == devicetype);
                 if (devices.Any())
+                {
                     return devices;
+                }
             }
 
-            var rv = await processManager.ExecuteXcodeCommandAsync("simctl", new[] { "create", CreateName(devicetype, runtime), devicetype, runtime }, log, TimeSpan.FromMinutes(1));
+            var rv = await _processManager.ExecuteXcodeCommandAsync("simctl", new[] { "create", CreateName(devicetype, runtime), devicetype, runtime }, log, TimeSpan.FromMinutes(1));
             if (!rv.Succeeded)
             {
                 log.WriteLine($"Could not create device for runtime={runtime} and device type={devicetype}.");
@@ -188,7 +196,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
             return devices;
         }
 
-        async Task<bool> CreateDevicePair(ILog log, ISimulatorDevice device, ISimulatorDevice companion_device, string runtime, string devicetype, bool create_device)
+        private async Task<bool> CreateDevicePair(ILog log, ISimulatorDevice device, ISimulatorDevice companion_device, string runtime, string devicetype, bool create_device)
         {
             if (create_device)
             {
@@ -196,9 +204,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                 var matchingDevices = await FindOrCreateDevicesAsync(log, runtime, devicetype, force: true);
                 var unPairedDevices = matchingDevices.Where((v) => !AvailableDevicePairs.Any((p) => { return p.Gizmo == v.UDID; }));
                 if (device != null)                     // If we're creating a new watch device, assume that the one we were given is not usable.
+                {
                     unPairedDevices = unPairedDevices.Where((v) => v.UDID != device.UDID);
+                }
+
                 if (unPairedDevices?.Any() != true)
+                {
                     return false;
+                }
+
                 device = unPairedDevices.First();
             }
 
@@ -210,7 +224,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                 log.Write(value);
                 capturedLog.Append(value);
             });
-            var rv = await processManager.ExecuteXcodeCommandAsync("simctl", new[] { "pair", device.UDID, companion_device.UDID }, pairLog, TimeSpan.FromMinutes(1));
+
+            var rv = await _processManager.ExecuteXcodeCommandAsync("simctl", new[] { "pair", device.UDID, companion_device.UDID }, pairLog, TimeSpan.FromMinutes(1));
             if (!rv.Succeeded)
             {
                 if (!create_device)
@@ -229,18 +244,25 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                 log.WriteLine($"Could not create device pair for '{device.Name}' ({device.UDID}) and '{companion_device.Name}' ({companion_device.UDID})");
                 return false;
             }
+
             return true;
         }
 
-        async Task<SimDevicePair> FindOrCreateDevicePairAsync(ILog log, IEnumerable<ISimulatorDevice> devices, IEnumerable<ISimulatorDevice> companion_devices)
+        private async Task<SimDevicePair?> FindOrCreateDevicePairAsync(ILog log, IEnumerable<ISimulatorDevice> devices, IEnumerable<ISimulatorDevice> companionDevices)
         {
             // Check if we already have a device pair with the specified devices
             var pairs = AvailableDevicePairs.Where((pair) =>
             {
                 if (!devices.Any((v) => v.UDID == pair.Gizmo))
+                {
                     return false;
-                if (!companion_devices.Any((v) => v.UDID == pair.Companion))
+                }
+
+                if (!companionDevices.Any((v) => v.UDID == pair.Companion))
+                {
                     return false;
+                }
+
                 return true;
             });
 
@@ -250,19 +272,27 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                 // First check if the watch is already paired
                 var unPairedDevices = devices.Where((v) => !AvailableDevicePairs.Any((p) => { return p.Gizmo == v.UDID; }));
                 var unpairedDevice = unPairedDevices.FirstOrDefault();
-                var companion_device = companion_devices.First();
+                var companion_device = companionDevices.First();
                 var device = devices.First();
                 if (!await CreateDevicePair(log, unpairedDevice, companion_device, device.SimRuntime, device.SimDeviceType, unpairedDevice == null))
+                {
                     return null;
+                }
 
                 await LoadDevices(log, forceRefresh: true);
 
                 pairs = AvailableDevicePairs.Where((pair) =>
                 {
                     if (!devices.Any((v) => v.UDID == pair.Gizmo))
+                    {
                         return false;
-                    if (!companion_devices.Any((v) => v.UDID == pair.Companion))
+                    }
+
+                    if (!companionDevices.Any((v) => v.UDID == pair.Companion))
+                    {
                         return false;
+                    }
+
                     return true;
                 });
             }
@@ -270,201 +300,182 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
             return pairs.FirstOrDefault();
         }
 
-        public async Task<ISimulatorDevice[]> FindSimulators(TestTarget target, ILog log, bool create_if_needed = true, bool min_version = false)
+        public async Task<ISimulatorDevice[]?> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false)
         {
-            ISimulatorDevice[] simulators = null;
+            ISimulatorDevice[]? simulators = null;
 
-            string simulator_devicetype;
-            string simulator_runtime;
-            string companion_devicetype = null;
-            string companion_runtime = null;
+            string simulatorDeviceType;
+            string simulatorRuntime;
+            string? companionDevicetype = null;
+            string? companionRuntime = null;
 
             switch (target)
             {
                 case TestTarget.Simulator_iOS32:
-                    simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
-                    simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (min_version ? SdkVersions.MiniOSSimulator : "10-3").Replace('.', '-');
+                    simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
+                    simulatorRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MiniOSSimulator : "10-3").Replace('.', '-');
                     break;
                 case TestTarget.Simulator_iOS64:
-                    simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType." + (min_version ? "iPhone-6" : "iPhone-X");
-                    simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (min_version ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator).Replace('.', '-');
+                    simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X");
+                    simulatorRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator).Replace('.', '-');
                     break;
                 case TestTarget.Simulator_iOS:
-                    simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
-                    simulator_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (min_version ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator).Replace('.', '-');
+                    simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.iPhone-5";
+                    simulatorRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator).Replace('.', '-');
                     break;
                 case TestTarget.Simulator_tvOS:
-                    simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p";
-                    simulator_runtime = "com.apple.CoreSimulator.SimRuntime.tvOS-" + (min_version ? SdkVersions.MinTVOSSimulator : SdkVersions.MaxTVOSSimulator).Replace('.', '-');
+                    simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p";
+                    simulatorRuntime = "com.apple.CoreSimulator.SimRuntime.tvOS-" + (minVersion ? SdkVersions.MinTVOSSimulator : SdkVersions.MaxTVOSSimulator).Replace('.', '-');
                     break;
                 case TestTarget.Simulator_watchOS:
-                    simulator_devicetype = "com.apple.CoreSimulator.SimDeviceType." + (min_version ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm");
-                    simulator_runtime = "com.apple.CoreSimulator.SimRuntime.watchOS-" + (min_version ? SdkVersions.MinWatchOSSimulator : SdkVersions.MaxWatchOSSimulator).Replace('.', '-');
-                    companion_devicetype = "com.apple.CoreSimulator.SimDeviceType." + (min_version ? "iPhone-6" : "iPhone-X");
-                    companion_runtime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (min_version ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
+                    simulatorDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm");
+                    simulatorRuntime = "com.apple.CoreSimulator.SimRuntime.watchOS-" + (minVersion ? SdkVersions.MinWatchOSSimulator : SdkVersions.MaxWatchOSSimulator).Replace('.', '-');
+                    companionDevicetype = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X");
+                    companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
                     break;
                 default:
                     throw new Exception(string.Format("Unknown simulator target: {0}", target));
             }
 
-            var devices = await FindOrCreateDevicesAsync(log, simulator_runtime, simulator_devicetype);
-            var companion_devices = await FindOrCreateDevicesAsync(log, companion_runtime, companion_devicetype);
+            var devices = await FindOrCreateDevicesAsync(log, simulatorRuntime, simulatorDeviceType);
+            var companionDevices = await FindOrCreateDevicesAsync(log, companionRuntime, companionDevicetype);
 
             if (devices?.Any() != true)
             {
-                log.WriteLine($"Could not find or create devices runtime={simulator_runtime} and device type={simulator_devicetype}.");
+                log.WriteLine($"Could not find or create devices runtime={simulatorRuntime} and device type={simulatorDeviceType}.");
                 return null;
             }
 
-            if (companion_runtime == null)
+            if (companionRuntime == null)
             {
                 simulators = new ISimulatorDevice[] { devices.First() };
             }
             else
             {
-                if (companion_devices?.Any() != true)
+                if (companionDevices?.Any() != true)
                 {
-                    log.WriteLine($"Could not find or create companion devices runtime={companion_runtime} and device type={companion_devicetype}.");
+                    log.WriteLine($"Could not find or create companion devices runtime={companionRuntime} and device type={companionDevicetype}.");
                     return null;
                 }
 
-                var pair = await FindOrCreateDevicePairAsync(log, devices, companion_devices);
+                var pair = await FindOrCreateDevicePairAsync(log, devices, companionDevices);
                 if (pair == null)
                 {
-                    log.WriteLine($"Could not find or create device pair runtime={companion_runtime} and device type={companion_devicetype}.");
+                    log.WriteLine($"Could not find or create device pair runtime={companionRuntime} and device type={companionDevicetype}.");
                     return null;
                 }
 
                 simulators = new ISimulatorDevice[] {
                     devices.First ((v) => v.UDID == pair.Gizmo),
-                    companion_devices.First ((v) => v.UDID == pair.Companion),
+                    companionDevices.First ((v) => v.UDID == pair.Companion),
                 };
             }
 
             if (simulators == null)
             {
-                log.WriteLine($"Could not find simulator for runtime={simulator_runtime} and device type={simulator_devicetype}.");
+                log.WriteLine($"Could not find simulator for runtime={simulatorRuntime} and device type={simulatorDeviceType}.");
                 return null;
             }
 
             log.WriteLine("Found simulator: {0} {1}", simulators[0].Name, simulators[0].UDID);
             if (simulators.Length > 1)
+            {
                 log.WriteLine("Found companion simulator: {0} {1}", simulators[1].Name, simulators[1].UDID);
+            }
 
             return simulators;
         }
 
         public ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device)
         {
-            var pair = available_device_pairs.Where((v) => v.Gizmo == device.UDID).Single();
-            return available_devices.Single((v) => v.UDID == pair.Companion);
+            var pair = _availableDevicePairs.Where((v) => v.Gizmo == device.UDID).Single();
+            return _availableDevices.Single((v) => v.UDID == pair.Companion);
         }
 
-        public IEnumerable<ISimulatorDevice> SelectDevices(TestTarget target, ILog log, bool min_version)
-        {
-            return new SimulatorEnumerable
-            {
-                Simulators = this,
-                Target = target,
-                MinVersion = min_version,
-                Log = log,
-            };
-        }
+        public IEnumerable<ISimulatorDevice> SelectDevices(TestTarget target, ILog log, bool minVersion) => new SimulatorEnumerable(this, target, minVersion, log);
 
-        class SimulatorXmlNodeComparer : IEqualityComparer<XmlNode>
+        private class SimulatorXmlNodeComparer : IEqualityComparer<XmlNode>
         {
-            public bool Equals(XmlNode a, XmlNode b)
+            public bool Equals(XmlNode? a, XmlNode? b)
             {
+                if (a == null)
+                {
+                    return b == null;
+                }
+
+                if (b == null)
+                {
+                    return a == null;
+                }
+
                 return a["Gizmo"].InnerText == b["Gizmo"].InnerText && a["Companion"].InnerText == b["Companion"].InnerText;
             }
 
-            public int GetHashCode(XmlNode node)
+            public int GetHashCode(XmlNode? node)
             {
+                if (node == null)
+                {
+                    return 0;
+                }
+
                 return node["Gizmo"].InnerText.GetHashCode() ^ node["Companion"].InnerText.GetHashCode();
             }
         }
 
-        class SimulatorEnumerable : IEnumerable<ISimulatorDevice>, IAsyncEnumerable
+        private class SimulatorEnumerable : IEnumerable<ISimulatorDevice>, IAsyncEnumerable
         {
-            public SimulatorLoader Simulators;
-            public TestTarget Target;
-            public bool MinVersion;
-            public ILog Log;
-            readonly object lock_obj = new object();
-            Task<ISimulatorDevice[]> findTask;
+            private readonly Lazy<Task<ISimulatorDevice[]?>> _findTask;
+            private readonly string _toString;
 
-            public override string ToString()
+            public SimulatorEnumerable(ISimulatorLoader simulators, TestTarget target, bool minVersion, ILog log)
             {
-                return $"Simulators for {Target} (MinVersion: {MinVersion})";
+                _findTask = new Lazy<Task<ISimulatorDevice[]?>>(() => simulators.FindSimulators(target, log, minVersion: minVersion), LazyThreadSafetyMode.ExecutionAndPublication);
+                _toString = $"Simulators for {target} (MinVersion: {minVersion})";
             }
 
-            public IEnumerator<ISimulatorDevice> GetEnumerator()
+            public override string ToString() => _toString;
+
+            public IEnumerator<ISimulatorDevice> GetEnumerator() => new Enumerator(this);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public Task ReadyTask => _findTask.Value;
+
+            public Task<ISimulatorDevice[]?> Find() => _findTask.Value;
+
+            private class Enumerator : IEnumerator<ISimulatorDevice>
             {
-                return new Enumerator()
+                private readonly Lazy<ISimulatorDevice[]?> _devices;
+
+                public Enumerator(SimulatorEnumerable? enumerable)
                 {
-                    Enumerable = this,
-                };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-
-            Task<ISimulatorDevice[]> Find()
-            {
-                lock (lock_obj)
-                {
-                    if (findTask == null)
-                        findTask = Simulators.FindSimulators(Target, Log, min_version: MinVersion);
-                    return findTask;
-                }
-            }
-
-            public Task ReadyTask
-            {
-                get { return Find(); }
-            }
-
-            class Enumerator : IEnumerator<ISimulatorDevice>
-            {
-                internal SimulatorEnumerable Enumerable;
-                ISimulatorDevice[] devices;
-                bool moved;
-
-                public ISimulatorDevice Current
-                {
-                    get
-                    {
-                        return devices[0];
-                    }
+                    _devices = new Lazy<ISimulatorDevice[]?>(() => enumerable?.Find()?.Result?.ToArray(), LazyThreadSafetyMode.ExecutionAndPublication);
                 }
 
-                object IEnumerator.Current
-                {
-                    get
-                    {
-                        return Current;
-                    }
-                }
+                private bool _moved;
 
-                public void Dispose()
-                {
-                }
+                public ISimulatorDevice Current => _devices.Value.FirstOrDefault();
+
+                object IEnumerator.Current => Current;
 
                 public bool MoveNext()
                 {
-                    if (moved)
+                    if (_moved)
+                    {
                         return false;
-                    if (devices == null)
-                        devices = Enumerable.Find()?.Result?.ToArray(); // Create a copy of the list of devices, so we can have enumerator-specific current index.
-                    moved = true;
-                    return devices?.Length > 0;
+                    }
+
+                    _moved = true;
+                    return _devices.Value?.Length > 0;
                 }
 
                 public void Reset()
                 {
-                    moved = false;
+                    _moved = false;
+                }
+
+                public void Dispose()
+                {
                 }
             }
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                         new ListSimulatorsArgument(tmpfile),
                         new XmlOutputFormatArgument());
 
-                    var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromSeconds(30));
+                    var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(1));
 
                     if (!result.Succeeded)
                     {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             Finished(true);
         }
 
-        public override int Initialize()
+        public override int InitializeAndGetPort()
         {
             _processorThread = new Thread(Processing);
             return 0;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
@@ -31,9 +31,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             Finished(true);
         }
 
-        public override void Initialize()
+        public override int Initialize()
         {
             _processorThread = new Thread(Processing);
+            return 0;
         }
 
         protected override void Start()

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
@@ -17,12 +16,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         private HttpListener _server;
         private bool _connected_once;
 
+        public int Port { get; private set; }
+
         public SimpleHttpListener(ILog log, IFileBackedLog testLog, bool autoExit) : base(log, testLog)
         {
             _autoExit = autoExit;
         }
 
-        public override void Initialize()
+        public override int Initialize()
         {
             _server = new HttpListener();
 
@@ -50,6 +51,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     Log.WriteLine("Failed to listen on port {0}: {1}", newPort, ex.Message);
                 }
             }
+
+            return Port;
         }
 
         protected override void Stop()

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             _autoExit = autoExit;
         }
 
-        public override int Initialize()
+        public override int InitializeAndGetPort()
         {
             _server = new HttpListener();
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         IFileBackedLog TestLog { get; }
 
         void Cancel();
-        int Initialize();
+        int InitializeAndGetPort();
         void StartAsync();
     }
 
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         protected abstract void Stop();
 
         public Task ConnectedTask => _connected.Task;
-        public abstract int Initialize();
+        public abstract int InitializeAndGetPort();
 
         protected SimpleListener(ILog log, IFileBackedLog testLog)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
@@ -15,11 +14,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
     {
         Task CompletionTask { get; }
         Task ConnectedTask { get; }
-        int Port { get; }
         IFileBackedLog TestLog { get; }
 
         void Cancel();
-        void Initialize();
+        int Initialize();
         void StartAsync();
     }
 
@@ -36,8 +34,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         protected abstract void Stop();
 
         public Task ConnectedTask => _connected.Task;
-        public int Port { get; protected set; }
-        public abstract void Initialize();
+        public abstract int Initialize();
 
         protected SimpleListener(ILog log, IFileBackedLog testLog)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             _server?.Server?.Shutdown(SocketShutdown.Both);
         }
 
-        public override int Initialize()
+        public override int InitializeAndGetPort()
         {
             if (_useTcpTunnel && Port != 0)
             {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
@@ -26,6 +25,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         private TcpClient _client;
 
         public TaskCompletionSource<bool> TunnelHoleThrough { get; } = new TaskCompletionSource<bool>();
+
+        public int Port { get; private set; }
 
         public SimpleTcpListener(ILog log, IFileBackedLog testLog, bool autoExit, bool tunnel = false) : base(log, testLog)
         {
@@ -48,11 +49,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             _server?.Server?.Shutdown(SocketShutdown.Both);
         }
 
-        public override void Initialize()
+        public override int Initialize()
         {
             if (_useTcpTunnel && Port != 0)
             {
-                return;
+                return Port;
             }
 
             _server = new TcpListener(Address, Port);
@@ -71,6 +72,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
                 _server.Stop();
             }
+
+            return Port;
         }
 
         private void StartNetworkTcp()

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
     public interface ITunnelListener : ISimpleListener
     {
         TaskCompletionSource<bool> TunnelHoleThrough { get; }
+
+        int Port { get; }
     }
 
     // interface implemented by a tcp tunnel between the host and the device.

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
@@ -11,18 +11,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
     public interface ICaptureLogFactory
     {
-        ICaptureLog Create(string logDirectory, string systemLogPath, bool entireFile, string description = null);
+        ICaptureLog Create(string path, string systemLogPath, bool entireFile, string description = null);
     }
 
     public class CaptureLogFactory : ICaptureLogFactory
     {
-        public ICaptureLog Create(string logDirectory, string systemLogPath, bool entireFile, string description = null)
-        {
-            return new CaptureLog(logDirectory, systemLogPath, entireFile)
+        public ICaptureLog Create(string path, string systemLogPath, bool entireFile, string description = null) =>
+            new CaptureLog(path, systemLogPath, entireFile)
             {
                 Description = description
             };
-        }
     }
 
     public interface ICaptureLog : IFileBackedLog

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -104,7 +104,29 @@ namespace Microsoft.DotNet.XHarness.iOS
             // Find devices
             if (isSimulator)
             {
-                (simulator, companionSimulator) = await FindSimulators(target);
+                int attempt = 1;
+                const int maxAttempts = 3;
+                while (true) {
+                    try
+                    {
+                        (simulator, companionSimulator) = await FindSimulators(target);
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        _mainLog.WriteLine($"Failed to list simulator (attempt {attempt}/{maxAttempts}):" + Environment.NewLine + e);
+
+                        if (attempt == maxAttempts)
+                        {
+                            throw new NoDeviceFoundException("Failed to list simulators");
+                        }
+                    }
+                    finally
+                    {
+                        attempt++;
+                    }
+                }
+
                 deviceName = companionSimulator?.Name ?? simulator.Name;
             }
             else

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -126,14 +126,16 @@ namespace Microsoft.DotNet.XHarness.iOS
                     throw;
                 }
 
-                (simulator, companionSimulator) = await _simulatorLoader.FindSimulators(target, _mainLog);
-                if (simulator == null)
+                try
                 {
-                    _mainLog.WriteLine("Didn't find any suitable simulator");
-                    throw new NoDeviceFoundException();
+                    (simulator, companionSimulator) = await _simulatorLoader.FindSimulators(target, _mainLog);
+                    deviceName = simulator.Name;
                 }
-
-                deviceName = simulator.Name;
+                catch (NoDeviceFoundException e)
+                {
+                    _mainLog.WriteLine($"Didn't find any suitable simulator: {e.Message}");
+                    throw;
+                }
 
                 mlaunchArguments.AddRange(GetSimulatorArguments(appInformation, simulator));
             }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
@@ -36,25 +36,20 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         [InlineData(true)] // timeout
         public async Task LoadAsyncProcessErrorTest(bool timeout)
         {
-            string processPath = null;
             MlaunchArguments passedArguments = null;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
                 {
                     // we are going set the used args to validate them later, will always return an error from this method
-                    processPath = p.StartInfo.FileName;
                     passedArguments = args;
-                    if (!timeout)
+                    return Task.FromResult(new ProcessExecutionResult
                     {
-                        return Task.FromResult(new ProcessExecutionResult { ExitCode = 1, TimedOut = false });
-                    }
-                    else
-                    {
-                        return Task.FromResult(new ProcessExecutionResult { ExitCode = 0, TimedOut = true });
-                    }
+                        ExitCode = timeout ? 0 : 1,
+                        TimedOut = timeout
+                    });
                 });
 
             await Assert.ThrowsAsync<Exception>(async () =>
@@ -96,14 +91,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         [Fact]
         public async Task LoadAsyncProcessSuccess()
         {
-            string processPath = null;
             MlaunchArguments passedArguments = null;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
-            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) =>
+            _processManager.Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
                 {
-                    processPath = p.StartInfo.FileName;
                     passedArguments = args;
 
                     // we get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
@@ -132,7 +125,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         [InlineData(TestTarget.Simulator_watchOS, 2)]
         public async Task FindAsyncDoNotCreateTest(TestTarget target, int expected)
         {
-            string processPath = null;
             MlaunchArguments passedArguments = null;
 
             _processManager
@@ -141,10 +133,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
                 {
-                    processPath = p.StartInfo.FileName;
                     passedArguments = args;
 
                     // we get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -31,10 +30,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             _simulators = new SimulatorLoader(_processManager.Object);
         }
 
-        [Theory]
-        [InlineData(false)] // no timeout
-        [InlineData(true)] // timeout
-        public async Task LoadAsyncProcessErrorTest(bool timeout)
+        [Fact]
+        public async Task LoadAsyncProcessErrorTest()
         {
             MlaunchArguments passedArguments = null;
 
@@ -47,8 +44,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
                     passedArguments = args;
                     return Task.FromResult(new ProcessExecutionResult
                     {
-                        ExitCode = timeout ? 0 : 1,
-                        TimedOut = timeout
+                        ExitCode = 1,
+                        TimedOut = false
                     });
                 });
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
@@ -160,11 +160,5 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
                 Assert.Null(companion);
             }
         }
-
-        private void AssertArgumentValue(MlaunchArgument arg, string expected, string message = null)
-        {
-            var value = arg.AsCommandLineArgument().Split(new char[] { '=' }, 2).LastOrDefault();
-            Assert.Equal(expected, value);
-        }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorsTest.cs
@@ -119,11 +119,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         }
 
         [Theory]
-        [InlineData(TestTarget.Simulator_iOS64, 1)]
-        [InlineData(TestTarget.Simulator_iOS32, 1)]
-        [InlineData(TestTarget.Simulator_tvOS, 1)]
-        [InlineData(TestTarget.Simulator_watchOS, 2)]
-        public async Task FindAsyncDoNotCreateTest(TestTarget target, int expected)
+        [InlineData(TestTarget.Simulator_iOS64, false)]
+        [InlineData(TestTarget.Simulator_iOS32, false)]
+        [InlineData(TestTarget.Simulator_tvOS, false)]
+        [InlineData(TestTarget.Simulator_watchOS, true)]
+        public async Task FindAsyncDoNotCreateTest(TestTarget target, bool shouldFindCompanion)
         {
             MlaunchArguments passedArguments = null;
 
@@ -147,9 +147,18 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
                 });
 
             await _simulators.LoadDevices(_executionLog.Object);
-            var sims = await _simulators.FindSimulators(target, _executionLog.Object, false, false);
+            var (simulator, companion) = await _simulators.FindSimulators(target, _executionLog.Object, false, false);
 
-            Assert.Equal(expected, sims.Count());
+            Assert.NotNull(simulator);
+
+            if (shouldFindCompanion)
+            {
+                Assert.NotNull(companion);
+            }
+            else
+            {
+                Assert.Null(companion);
+            }
         }
 
         private void AssertArgumentValue(MlaunchArgument arg, string expected, string message = null)

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             using (var sourceWriter = new StreamWriter(_path))
             {
                 var listener = new SimpleFileListener(_path, _log.Object, _testLog.Object, isXml);
-                listener.Initialize();
+                listener.InitializeAndGetPort();
                 listener.StartAsync();
                 // write a number of lines and ensure that those are called in the mock
                 sourceWriter.WriteLine("[Runner executing:");

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             // create a linstener that will start in an other thread, connect to it
             // and send the data.
             var listener = new SimpleTcpListener(_log.Object, _testLog.Object, true, true);
-            listener.Initialize();
+            listener.InitializeAndGetPort();
             var connectionPort = listener.Port;
             listener.StartAsync();
             // create a tcp client which will write the logs, then verity that

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,18 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.DotNet.XHarness.iOS.Shared\Microsoft.DotNet.XHarness.iOS.Shared.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Samples\" />
-    <Folder Include="Samples\TestProject\" />
-    <Folder Include="Hardware\" />
-    <Folder Include="Listeners\" />
-    <Folder Include="Logging\" />
-    <Folder Include="TestImporter\" />
-    <Folder Include="TestImporter\Templates\" />
-    <Folder Include="TestImporter\Templates\Managed\" />
-    <Folder Include="Utilities\" />
-    <Folder Include="Execution\" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Samples\devices.xml" />

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             _simulatorLoader
                 .Setup(x => x.FindSimulators(TestTarget.Simulator_tvOS, _mainLog.Object, true, false))
-                .ReturnsAsync((null, null));
+                .ThrowsAsync(new NoDeviceFoundException("Failed to find simulator"));
 
             var listenerLogFile = new Mock<IFileBackedLog>();
 

--- a/tests/integration-tests/helix-payloads/cli-integration-tests.sh
+++ b/tests/integration-tests/helix-payloads/cli-integration-tests.sh
@@ -53,6 +53,9 @@ fi
 open -a "$xcode_path/Applications/Simulator.app"
 
 dotnet tool restore --no-cache
+
+set +e
+
 dotnet xharness ios test            \
     --app="$here/$app_name"         \
     --output-directory="$1"         \
@@ -62,8 +65,6 @@ dotnet xharness ios test            \
     -v
 
 result=$?
-
-set +e
 
 chmod 0644 "$1"/*.log "$1"/*.xml
 

--- a/tests/integration-tests/helix-payloads/cli-integration-tests.sh
+++ b/tests/integration-tests/helix-payloads/cli-integration-tests.sh
@@ -65,7 +65,7 @@ result=$?
 
 set +e
 
-chmod 0666 "$1/*"
+chmod 0644 "$1"/*.log "$1"/*.xml
 
 test_results=`ls $1/xunit-*.xml`
 


### PR DESCRIPTION
This PR fixes #196 and refactors the AppRunner formerly from Xamarin to enable better logging, easier debugging, fixes some small bugs and splits large methods.

- Refactor `AppRunner`
  - Split very long methods by Device/Simulator bound logic
  - Separate logic for test orchestration with mlaunch argument preparation
  - Dispose logs/listeners correctly
  - Look for devices before we start the listeners and log capturers
  - Improved unit test readability where the most important part (mlaunch arg checking) is now easier to read and safe to make changes when logic changes
- Improve finding simulators:
  - Enable nullability for `BlockingEnumerable`, `SimulatorLoader` and connected POCO classes
  - Improve error messages
  - Make `SimulatorLoader` retry listing devices as that might fail occasionally
  - Make it more clear that `SimulatorLoader` only looks for device tuples `(simulator, companion)` and not all simulators on the MacOS
- Log exit codes

Fixes: #96
Fixes: #196