### PR TITLE
Install the dotnet tools via --tool-path in our CI tests

### DIFF
--- a/tests/integration-tests/helix-payloads/cli-integration-tests.sh
+++ b/tests/integration-tests/helix-payloads/cli-integration-tests.sh
@@ -2,46 +2,24 @@
 
 set -e
 
-if [ $# -ne 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+if [ "$#" -ne 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
     echo "The script expects 2 arguments: where to store result logs and where to upload test results (ie. \$HELIX_WORKITEM_UPLOAD_ROOT \$HELIX_WORKITEM_ROOT)" 1>2
     exit 1
 fi
-
-version='1.0.0-ci'
-
-# Clean the NuGet cache from the previous 1.0.0-ci version of the tool
-# TODO: This might have a better solution: https://github.com/dotnet/xharness/issues/123
-echo "Cleaning the NuGet cache from the previous version of the tool..."
-
-# Call dotnet to get rid of the welcome message since the nuget command doesn't respect the --no-logo
-dotnet nuget locals All -l
-cache_dirs=`dotnet nuget locals All -l | cut -d':' -f 2 | tr -d ' '`
-while IFS= read -r path; do
-    echo "Purging cache in $path..."
-    rm -vrf "$path/microsoft.dotnet.xharness.cli/$version"
-    rm -vrf "$path/Microsoft.DotNet.XHarness.CLI/$version"
-done <<< "$cache_dirs"
 
 set -x
 
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+export DOTNET_ROOT=$(dirname $(which dotnet))
+dotnet tool install --no-cache --tool-path "$here/xharness-cli" --version "1.0.0-ci" --add-source "$here" Microsoft.DotNet.XHarness.CLI
+
 # TODO - Package the app bundle here using `dotnet xharness ios package ..`
 # For now we download a pre-bundled app:
-curl -L --output $here/app.zip "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/System.Numerics.Vectors.Tests.app.zip"
+curl -L --output "$here/app.zip" "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/macos/test-ios-app/System.Numerics.Vectors.Tests.app.zip"
 app_name='System.Numerics.Vectors.Tests.app'
 
 tar -xzf app.zip
-
-mkdir "$here/tools"
-cd "$here/tools"
-
-dotnet new tool-manifest
-
-dotnet tool install --no-cache --version "$version" --add-source .. Microsoft.DotNet.XHarness.CLI
-
-export XHARNESS_DISABLE_COLORED_OUTPUT=true
-export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
 # Restart the simulator to make sure it is tied to the right user session
 xcode_path=`xcode-select -p`
@@ -52,20 +30,22 @@ fi
 
 open -a "$xcode_path/Applications/Simulator.app"
 
-dotnet tool restore --no-cache
-
 set +e
 
-dotnet xharness ios test            \
-    --app="$here/$app_name"         \
-    --output-directory="$1"         \
-    --targets=ios-simulator-64      \
-    --timeout=600                   \
-    --launch-timeout=360            \
+export XHARNESS_DISABLE_COLORED_OUTPUT=true
+export XHARNESS_LOG_WITH_TIMESTAMPS=true
+
+"$here/xharness-cli/xharness" ios test \
+    --app="$here/$app_name"            \
+    --output-directory="$1"            \
+    --targets=ios-simulator-64         \
+    --timeout=600                      \
+    --launch-timeout=360               \
     -v
 
 result=$?
 
+# iPhone simulator logs are published under root and cannot be read
 chmod 0644 "$1"/*.log "$1"/*.xml
 
 test_results=`ls $1/xunit-*.xml`

--- a/tests/integration-tests/helix-payloads/cli-integration-tests.sh
+++ b/tests/integration-tests/helix-payloads/cli-integration-tests.sh
@@ -12,7 +12,7 @@ set -x
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export DOTNET_ROOT=$(dirname $(which dotnet))
-dotnet tool install --no-cache --tool-path "$here/xharness-cli" --version "1.0.0-ci" --add-source "$here" Microsoft.DotNet.XHarness.CLI
+dotnet tool install --no-cache --tool-path "$HELIX_CORRELATION_PAYLOAD/xharness-cli" --version "1.0.0-ci" --add-source "$here" Microsoft.DotNet.XHarness.CLI
 
 # TODO - Package the app bundle here using `dotnet xharness ios package ..`
 # For now we download a pre-bundled app:
@@ -35,17 +35,17 @@ set +e
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
-"$here/xharness-cli/xharness" ios test \
-    --app="$here/$app_name"            \
-    --output-directory="$1"            \
-    --targets=ios-simulator-64         \
-    --timeout=600                      \
-    --launch-timeout=360               \
+"$HELIX_CORRELATION_PAYLOAD/xharness-cli/xharness" ios test \
+    --app="$here/$app_name"     \
+    --output-directory="$1"     \
+    --targets=ios-simulator-64  \
+    --timeout=600               \
+    --launch-timeout=360        \
     -v
 
 result=$?
 
-# iPhone simulator logs are published under root and cannot be read
+# iPhone simulator logs are published with wrong permissions and the files cannot be read
 chmod 0644 "$1"/*.log "$1"/*.xml
 
 test_results=`ls $1/xunit-*.xml`

--- a/tests/integration-tests/helix-payloads/cli-integration-tests.sh
+++ b/tests/integration-tests/helix-payloads/cli-integration-tests.sh
@@ -12,7 +12,7 @@ set -x
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export DOTNET_ROOT=$(dirname $(which dotnet))
-dotnet tool install --no-cache --tool-path "$HELIX_CORRELATION_PAYLOAD/xharness-cli" --version "1.0.0-ci" --add-source "$here" Microsoft.DotNet.XHarness.CLI
+dotnet tool install --no-cache --tool-path "$here/xharness-cli" --version "1.0.0-ci" --add-source "$here" Microsoft.DotNet.XHarness.CLI
 
 # TODO - Package the app bundle here using `dotnet xharness ios package ..`
 # For now we download a pre-bundled app:
@@ -35,17 +35,17 @@ set +e
 export XHARNESS_DISABLE_COLORED_OUTPUT=true
 export XHARNESS_LOG_WITH_TIMESTAMPS=true
 
-"$HELIX_CORRELATION_PAYLOAD/xharness-cli/xharness" ios test \
-    --app="$here/$app_name"     \
-    --output-directory="$1"     \
-    --targets=ios-simulator-64  \
-    --timeout=600               \
-    --launch-timeout=360        \
+"$here/xharness-cli/xharness" ios test \
+    --app="$here/$app_name"            \
+    --output-directory="$1"            \
+    --targets=ios-simulator-64         \
+    --timeout=600                      \
+    --launch-timeout=360               \
     -v
 
 result=$?
 
-# iPhone simulator logs are published with wrong permissions and the files cannot be read
+# iPhone simulator logs are published under root and cannot be read
 chmod 0644 "$1"/*.log "$1"/*.xml
 
 test_results=`ls $1/xunit-*.xml`


### PR DESCRIPTION
This changes how we install the dotnet tools that are being tested during our integration testing.

We won't need to purge the NuGet cache anymore so this also fixes #123.

