### PR TITLE
[Runners] Do publish the Common pkg.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>


### PR DESCRIPTION
Else we will have issues like the following one:

```
error NU1101: Unable to find package Microsoft.DotNet.XHarness.TestRunners.Common. No packages exist with this id in source(s): dotnet-eng, dotnet-tools, dotnet5, dotnet5-transport, nuget.org
```