### PR TITLE
[wasm] Add running wasm tests as a process starting a javascript engine with arguments

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             { "engine=|e=", "Specifies the JavaScript engine to be used",
                 v => Engine = ParseArgument<JavaScriptEngine>("engine", v)
             },
-            { "engine-arg=", "Argument to pass to the javascript engine. It can be used more than once.",
+            { "engine-arg=", "Argument to pass to the JavaScript engine. Can be used more than once.",
                 v => EngineArgs.Add(v)
             },
             { "js-file=", "Main JavaScript file to be run on the JavaScript engine",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             { "engine-arg=", "Argument to pass to the javascript engine. It can be used more than once.",
                 v => EngineArgs.Add(v)
             },
-            { "js-file=", "Main javascript file to be run on the javscript engine",
+            { "js-file=", "Main JavaScript file to be run on the JavaScript engine",
                 v => JSFile = v
             },
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -9,7 +9,9 @@ using Mono.Options;
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     /// <summary>
-    /// Specifies the javascript engine that is used to run WASM.
+    /// Specifies a name of a JavaScript engine binary used to run WASM application.
+    /// The invocation of the engine binary doesn't depend on a case,
+    /// i.g. both "v8 ..." and "V8 ..." should work.
     /// </summary>
     internal enum JavaScriptEngine
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -8,8 +8,55 @@ using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
+    /// <summary>
+    /// Specifies the javascript engine that is used to run WASM.
+    /// </summary>
+    internal enum JavaScriptEngine
+    {
+        /// <summary>
+        /// V8
+        /// </summary>
+        V8,
+        /// <summary>
+        /// JavaScriptCore
+        /// </summary>
+        JSC,
+        /// <summary>
+        /// SpiderMonkey
+        /// </summary>
+        SM,
+    }
+
     internal class WasmTestCommandArguments : TestCommandArguments
     {
-        protected override OptionSet GetTestCommandOptions() => new OptionSet();
+        private JavaScriptEngine? _engine;
+
+        public JavaScriptEngine Engine
+        {
+            get => _engine ?? throw new ArgumentException("Engine not specified");
+            set => _engine = value;
+        }
+
+        public List<string> EngineArgs { get; set; } = new List<string>();
+
+        public string JSFile { get; set;} = "runtime.js";
+
+        protected override OptionSet GetTestCommandOptions() => new OptionSet{
+            { "engine=|e=", "Run on the listed javascript engine.",
+                v => Engine = ParseArgument<JavaScriptEngine>("engine", v)
+            },
+            { "engine-arg=", "Argument to pass to the javascript engine. It can be used more than once.",
+                v => EngineArgs.Add(v)
+            },
+            { "js-file=", "Main javascript file to be run on the javscript engine",
+                v => JSFile = v
+            },
+        };
+
+        public override void Validate()
+        {
+            base.Validate();
+            Engine = Engine;
+        }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public string JSFile { get; set;} = "runtime.js";
 
         protected override OptionSet GetTestCommandOptions() => new OptionSet{
-            { "engine=|e=", "Run on the listed javascript engine.",
+            { "engine=|e=", "Specifies the JavaScript engine to be used",
                 v => Engine = ParseArgument<JavaScriptEngine>("engine", v)
             },
             { "engine-arg=", "Argument to pass to the javascript engine. It can be used more than once.",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             { "engine-arg=", "Argument to pass to the JavaScript engine. Can be used more than once.",
                 v => EngineArgs.Add(v)
             },
-            { "js-file=", "Main JavaScript file to be run on the JavaScript engine",
+            { "js-file=", "Main JavaScript file to be run on the JavaScript engine. Default is runtime.js",
                 v => JSFile = v
             },
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/TestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/TestCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
         protected override XHarnessCommandArguments Arguments => TestArguments;
         protected abstract TestCommandArguments TestArguments { get; }
 
-        public TestCommand(string? help) : base("test", allowsExtraArgs: false, help)
+        public TestCommand(string? help, bool allowsExtraArgs = false) : base("test", allowsExtraArgs, help)
         {
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 {
     internal class WasmTestCommand : TestCommand
     {
-        private const string CommandHelp = "Executes BCL xunit tests on WASM";
+        private const string CommandHelp = "Executes BCL xunit tests on WASM. It starts a JavaScript engine which calls a test runner inside of the WASM application.";
         private readonly WasmTestCommandArguments _arguments = new WasmTestCommandArguments();
         protected override TestCommandArguments TestArguments => _arguments;
         protected override string CommandUsage { get; } = "wasm test [OPTIONS] -- [ENGINE OPTIONS]";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
@@ -2,12 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 {
@@ -18,16 +22,25 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         protected override TestCommandArguments TestArguments => _arguments;
         protected override string CommandUsage { get; } = "wasm test [OPTIONS]";
         protected override string CommandDescription { get; } = CommandHelp;
+        public IEnumerable<string> PassThroughArgs => PassThroughArguments;
 
-        protected override Task<ExitCode> InvokeInternal(ILogger logger)
+        protected override async Task<ExitCode> InvokeInternal(ILogger logger)
         {
-            logger.LogDebug($"Wasm Test command called");
+            var processManager = new MacOSProcessManager();
 
-            var result = 0;
-            return Task.FromResult(result == 0 ? ExitCode.SUCCESS : ExitCode.GENERAL_FAILURE);
+            // Expected syntax
+            // xharness wasm test --engine=v8 --engine-arg=--expose_wasm --engine-arg=--some-other-thing --js-file=runtime.js -- --enable-gc --run WasmTestRunner.dll System.Buffers.Tests.dll
+           
+            var result = await processManager.ExecuteCommandAsync(
+                _arguments.Engine.ToString(),
+                _arguments.EngineArgs.Concat(new List<string>{ "--" }).Concat(PassThroughArgs).ToList(),
+                new CallbackLog(m => logger.LogDebug(m)),
+                _arguments.Timeout);
+
+            return result.Succeeded ? ExitCode.SUCCESS : ExitCode.GENERAL_FAILURE;
         }
 
-        public WasmTestCommand() : base(CommandHelp)
+        public WasmTestCommand() : base(CommandHelp, true)
         {
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         private const string CommandHelp = "Executes BCL xunit tests on WASM";
         private readonly WasmTestCommandArguments _arguments = new WasmTestCommandArguments();
         protected override TestCommandArguments TestArguments => _arguments;
-        protected override string CommandUsage { get; } = "wasm test [OPTIONS]";
+        protected override string CommandUsage { get; } = "wasm test [OPTIONS] -- [ENGINE OPTIONS]";
         protected override string CommandDescription { get; } = CommandHelp;
         public IEnumerable<string> PassThroughArgs => PassThroughArguments;
 


### PR DESCRIPTION
There are several javascript engines (e.g. v8, javascriptcore etc) which wasm tests can run on currently  and this list might be extended. Each of js engine can have (potentially different) set of arguments. e.g.
`v8 --expose_wasm runtime.js -- --enable-gc --run WasmTestRunner.dll System.Buffers.Tests.dll`

So the idea is to run the wasm runner inside of the wasm app by starting a js engine as a process and pass in respective arguments, in particular test runner and test assembly name.

This change is simplified version of what we want to get in the end.

cc @akoeplinger @steveisok 