### PR TITLE
Use RollForward msbuild property instead of rollForwardOnNoCandidateFx in json

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>xharness</ToolCommandName>
+    <RollForward>Major</RollForward>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
 

--- a/src/Microsoft.DotNet.XHarness.CLI/runtimeconfig.template.json
+++ b/src/Microsoft.DotNet.XHarness.CLI/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-  "rollForwardOnNoCandidateFx": 2
-}

--- a/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/Microsoft.DotNet.XHarness.SimulatorInstaller.csproj
+++ b/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/Microsoft.DotNet.XHarness.SimulatorInstaller.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>simulator-installer</ToolCommandName>
+    <RollForward>Major</RollForward>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>

--- a/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/runtimeconfig.template.json
+++ b/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/runtimeconfig.template.json
@@ -1,3 +1,0 @@
-{
-  "rollForwardOnNoCandidateFx": 2
-}


### PR DESCRIPTION
This is a better way than https://github.com/dotnet/xharness/pull/30 since .NET Core 3.1 added an official msbuild property for setting that value.