### PR TITLE
[Runners] Add a new delegating sink that converts failures to skips.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/DelegatingSkippedTestSink.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/DelegatingSkippedTestSink.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
+{
+    /// <summary>
+    /// A delegating implementation that will convert all failed tests due to the SkipTestException to be skipped
+    /// tests rather than failed ones.
+    /// </summary>
+    public class DelegatingSkippedTestSink : LongLivedMarshalByRefObject, IExecutionSink
+    {
+       private readonly IExecutionSink _innerSink;
+       private int _skipCount;
+
+        public DelegatingSkippedTestSink(IExecutionSink innerSink)
+            => this._innerSink = innerSink ?? throw new ArgumentNullException(nameof(innerSink));
+
+        public ExecutionSummary ExecutionSummary => _innerSink.ExecutionSummary;
+
+        public ManualResetEvent Finished => _innerSink.Finished;
+
+        public void Dispose()
+            => _innerSink.Dispose();
+
+        public bool OnMessageWithTypes(IMessageSinkMessage message, HashSet<string> messageTypes)
+        {
+            var testFailed = message.Cast<ITestFailed>(messageTypes);
+            if (testFailed != null)
+            {
+                // if we failed due to the SkipException, create a test skipped
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    _skipCount++;
+                    var testSkipped = new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault());
+                    return _innerSink.OnMessage(testSkipped);
+                }
+                else
+                {
+                    return _innerSink.OnMessage(testFailed);
+                }
+            }
+
+            var testCollectionFinished = message.Cast<ITestCollectionFinished>(messageTypes);
+            if (testCollectionFinished != null)
+            {
+                testCollectionFinished = new TestCollectionFinished(testCollectionFinished.TestCases,
+                                                                    testCollectionFinished.TestCollection,
+                                                                    testCollectionFinished.ExecutionTime,
+                                                                    testCollectionFinished.TestsRun,
+                                                                    testCollectionFinished.TestsFailed + testCollectionFinished.TestsSkipped,
+                                                                    0);
+                return _innerSink.OnMessage(testCollectionFinished);
+            }
+
+            var assemblyFinished = message.Cast<ITestAssemblyFinished>(messageTypes);
+            if (assemblyFinished != null)
+            {
+                assemblyFinished = new TestAssemblyFinished(assemblyFinished.TestCases,
+                                                            assemblyFinished.TestAssembly,
+                                                            assemblyFinished.ExecutionTime,
+                                                            assemblyFinished.TestsRun,
+                                                            assemblyFinished.TestsFailed + assemblyFinished.TestsSkipped,
+                                                            0);
+                return _innerSink.OnMessage(assemblyFinished);
+            }
+
+            return _innerSink.OnMessageWithTypes(message, messageTypes);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -987,7 +987,10 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
                     var assemblyElement = new XElement("assembly");
                     IExecutionSink resultsSink = new DelegatingExecutionSummarySink(messageSink, null, null);
+                    // write the xml
                     resultsSink = new DelegatingXmlCreationSink(resultsSink, assemblyElement);
+                    // converts failed tests due to the SkipTestException to Skipped tests
+                    resultsSink = new DelegatingSkippedTestSink(resultsSink);
                     ITestFrameworkExecutionOptions executionOptions = GetFrameworkOptionsForExecution(configuration);
                     executionOptions.SetDisableParallelization(!RunInParallel);
                     executionOptions.SetSynchronousMessageReporting(true);


### PR DESCRIPTION
Create a new delegating sink that will convert those tests that failed
due to the SkipException to sskipped tests rather than failed ones.

fixes: https://github.com/dotnet/xharness/issues/205