### PR TITLE
WASM: don't preenumerate Theories during xunit test discovery

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
                 ParseEqualSeparatedArgument(filters.ExcludedTraits, trait);
             }
 
-            var configuration = new TestAssemblyConfiguration() { ShadowCopy = false, ParallelizeAssembly = false, ParallelizeTestCollections = false, MaxParallelThreads = 1 };
+            var configuration = new TestAssemblyConfiguration() { ShadowCopy = false, ParallelizeAssembly = false, ParallelizeTestCollections = false, MaxParallelThreads = 1, PreEnumerateTheories = false };
             var discoveryOptions = TestFrameworkOptions.ForDiscovery(configuration);
             var discoverySink = new TestDiscoverySink();
             var diagnosticSink = new ConsoleDiagnosticMessageSink();
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
                 Console.WriteLine($"STARTRESULTXML");
                 var resultsXml = new XElement("assemblies");
                 resultsXml.Add(resultsXmlAssembly);
-                Console.WriteLine(resultsXml.ToString());
+                resultsXml.Save(Console.OpenStandardOutput());
                 Console.WriteLine();
                 Console.WriteLine($"ENDRESULTXML");
             }


### PR DESCRIPTION
This takes about 3mins and is useless since we don't support a way to select a single theory test case to be run.
The official xunit console runner also disables this.
Additionally added a small fix to make sure the result xml has the correct xml header.