### PR TITLE
Allow to specify desired Simulator runtime (iOS/tvOS/WatchOS version)

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/iOS/iOSTestCommandArguments.cs
@@ -73,19 +73,21 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
             get => TestTargets.Select(t => t.AsString()).ToArray();
             protected set
             {
-                var testTargets = new List<TestTarget>();
+                var testTargets = new List<TestTargetOs>();
 
                 foreach (string targetName in value ?? throw new ArgumentNullException("Targets cannot be empty"))
                 {
                     try
                     {
-                        testTargets.Add(targetName.ParseAsAppRunnerTarget());
+                        testTargets.Add(targetName.ParseAsAppRunnerTargetOs());
                     }
                     catch (ArgumentOutOfRangeException)
                     {
                         throw new ArgumentException(
                             $"Failed to parse test target '{targetName}'. Available targets are:" +
-                            GetAllowedValues(t => t.AsString(), invalidValues: TestTarget.None));
+                            GetAllowedValues(t => t.AsString(), invalidValues: TestTarget.None) +
+                            Environment.NewLine + Environment.NewLine +
+                            "You can also specify desired iOS/tvOS/WatchOS version. Example: ios-simulator-64_13.4");
                     }
                 }
 
@@ -96,7 +98,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
         /// <summary>
         /// Parsed strong-typed targets.
         /// </summary>
-        public IReadOnlyCollection<TestTarget> TestTargets { get; private set; } = Array.Empty<TestTarget>();
+        public IReadOnlyCollection<TestTargetOs> TestTargets { get; private set; } = Array.Empty<TestTargetOs>();
 
         protected override OptionSet GetTestCommandOptions() => new OptionSet
         {
@@ -142,7 +144,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS
             {
                 throw new ArgumentException(
                     "No targets specified. At least one target must be provided. Available targets are:" +
-                    GetAllowedValues(t => t.AsString(), invalidValues: TestTarget.None));
+                    GetAllowedValues(t => t.AsString(), invalidValues: TestTarget.None) +
+                    Environment.NewLine + Environment.NewLine +
+                    "You can also specify desired iOS/tvOS/WatchOS version. Example: ios-simulator-64_13.4");
             }
 
             if (!File.Exists(MlaunchPath))

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             var exitCode = ExitCode.SUCCESS;
 
-            foreach (TestTarget target in _arguments.TestTargets)
+            foreach ((TestTarget target, string? osVersion) in _arguments.TestTargets)
             {
                 var tunnelBore = (_arguments.CommunicationChannel == CommunicationChannel.UsbTunnel && !target.IsSimulator())
                     ? new TunnelBore(processManager)
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
         private async Task<ExitCode> RunTest(
             ILogger logger,
-            TestTarget target,
+            TestTargetOs target,
             Logs logs,
             MLaunchProcessManager processManager,
             IHardwareDeviceLoader deviceLoader,
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             try
             {
-                appBundleInfo = await appBundleInformationParser.ParseFromAppBundle(_arguments.AppPackagePath, target, mainLog, cancellationToken);
+                appBundleInfo = await appBundleInformationParser.ParseFromAppBundle(_arguments.AppPackagePath, target.Platform, mainLog, cancellationToken);
             }
             catch (Exception e)
             {
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 return ExitCode.FAILED_TO_GET_BUNDLE_INFO;
             }
 
-            if (!target.IsSimulator())
+            if (!target.Platform.IsSimulator())
             {
                 logger.LogInformation($"Installing application '{appBundleInfo.AppName}' on " + (deviceName != null ? $" on device '{deviceName}'" : target.AsString()));
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -57,9 +57,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             var exitCode = ExitCode.SUCCESS;
 
-            foreach ((TestTarget target, string? osVersion) in _arguments.TestTargets)
+            foreach (var target in _arguments.TestTargets)
             {
-                var tunnelBore = (_arguments.CommunicationChannel == CommunicationChannel.UsbTunnel && !target.IsSimulator())
+                var tunnelBore = (_arguments.CommunicationChannel == CommunicationChannel.UsbTunnel && !target.Platform.IsSimulator())
                     ? new TunnelBore(processManager)
                     : null;
                 var exitCodeForRun = await RunTest(logger, target, logs, processManager, deviceLoader, simulatorLoader,
@@ -296,7 +296,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             catch (NoDeviceFoundException)
             {
                 logger.LogError($"Failed to find suitable device for target {target.AsString()}" +
-                    (target.IsSimulator() ? Environment.NewLine + "Please make sure suitable Simulator is installed in Xcode" : string.Empty));
+                    (target.Platform.IsSimulator() ? Environment.NewLine + "Please make sure suitable Simulator is installed in Xcode" : string.Empty));
 
                 return ExitCode.DEVICE_NOT_FOUND;
             }
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
             {
                 mainLog.Dispose();
 
-                if (!target.IsSimulator() && deviceName != null)
+                if (!target.Platform.IsSimulator() && deviceName != null)
                 {
                     logger.LogInformation($"Uninstalling the application '{appBundleInfo.AppName}' from device '{deviceName}'");
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
@@ -90,6 +90,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         IEnumerable<SimulatorDevice> AvailableDevices { get; }
         IEnumerable<SimDevicePair> AvailableDevicePairs { get; }
         Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
+        Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTargetOs target, ILog log, bool createIfNeeded = true);
         ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device);
         IEnumerable<ISimulatorDevice?> SelectDevices(TestTarget target, ILog log, bool min_version);
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/ISimulatorDevice.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         IEnumerable<SimulatorDevice> AvailableDevices { get; }
         IEnumerable<SimDevicePair> AvailableDevicePairs { get; }
         Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false);
-        Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTargetOs target, ILog log, bool createIfNeeded = true);
+        Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTargetOs target, ILog log, bool createIfNeeded = true, bool minVersion = false);
         ISimulatorDevice FindCompanionDevice(ILog log, ISimulatorDevice device);
         IEnumerable<ISimulatorDevice?> SelectDevices(TestTarget target, ILog log, bool min_version);
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -361,7 +361,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                     .OrderByDescending(r => r.Identifier)
                     .FirstOrDefault()?
                     .Identifier
-                    .Substring(runtimePrefix.Length + 1);
+                    .Substring(runtimePrefix.Length);
 
                 runtimeVersion = firstOsVersion ?? throw new NoDeviceFoundException($"Failed to find a suitable OS runtime version for {target.AsString()}");
             }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -339,7 +339,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         {
             var runtimePrefix = target.Platform switch
             {
-                TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimRuntime.iOS-10-3",
+                TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimRuntime.iOS-",
                 TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimRuntime.iOS-",
                 TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimRuntime.iOS-",
                 TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimRuntime.tvOS-",

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -449,27 +449,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 
         public Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTarget target, ILog log, bool createIfNeeded = true, bool minVersion = false)
         {
-            TestTargetOs testTarget;
-            switch (target)
+            TestTargetOs testTarget = target switch
             {
-                case TestTarget.Simulator_iOS32:
-                    testTarget = new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : "10.3");
-                    break;
-                case TestTarget.Simulator_iOS64:
-                    testTarget = new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator);
-                    break;
-                case TestTarget.Simulator_iOS:
-                    testTarget = new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator);
-                    break;
-                case TestTarget.Simulator_tvOS:
-                    testTarget = new TestTargetOs(target, minVersion ? SdkVersions.MinTVOSSimulator : SdkVersions.MaxTVOSSimulator);
-                    break;
-                case TestTarget.Simulator_watchOS:
-                    testTarget = new TestTargetOs(target, minVersion ? SdkVersions.MinWatchOSSimulator : SdkVersions.MaxWatchOSSimulator);
-                    break;
-                default:
-                    throw new Exception(string.Format("Unknown simulator target: {0}", target));
-            }
+                TestTarget.Simulator_iOS32 => new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : "10.3"),
+                TestTarget.Simulator_iOS64 => new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator),
+                TestTarget.Simulator_iOS => new TestTargetOs(target, minVersion ? SdkVersions.MiniOSSimulator : SdkVersions.MaxiOSSimulator),
+                TestTarget.Simulator_tvOS => new TestTargetOs(target, minVersion ? SdkVersions.MinTVOSSimulator : SdkVersions.MaxTVOSSimulator),
+                TestTarget.Simulator_watchOS => new TestTargetOs(target, minVersion ? SdkVersions.MinWatchOSSimulator : SdkVersions.MaxWatchOSSimulator),
+                _ => throw new Exception(string.Format("Invalid simulator target: {0}", target))
+            };
 
             return FindSimulators(testTarget, log, createIfNeeded: createIfNeeded, minVersion: minVersion);
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestTarget.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestTarget.cs
@@ -4,6 +4,7 @@
 
 using System;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared
 {
     public enum TestTarget
@@ -17,6 +18,25 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         Device_iOS,
         Device_tvOS,
         Device_watchOS,
+    }
+
+    public class TestTargetOs
+    {
+        /// <summary>
+        /// Platform, i.e. Simulator iOS x64
+        /// </summary>
+        public TestTarget Platform { get; }
+
+        /// <summary>
+        /// OS version, i.e. "13.4".
+        /// </summary>
+        public string? OSVersion { get; }
+
+        public TestTargetOs(TestTarget platform, string? osVersion)
+        {
+            Platform = platform;
+            OSVersion = osVersion;
+        }
     }
 
     public static class TestTargetExtensions

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
         };
 
         public static string AsString(this TestTargetOs targetOs) =>
-            targetOs.AsString() + (targetOs.OSVersion != null ? "_" + targetOs.OSVersion : null);
+            targetOs.Platform.AsString() + (targetOs.OSVersion != null ? "_" + targetOs.OSVersion : null);
 
         public static TestTarget ParseAsAppRunnerTarget(this string target) => target switch
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
@@ -7,90 +7,73 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
 {
     public static class Extensions
     {
-        public static string AsString(this TestTarget @this)
+        public static string AsString(this TestTarget target) => target switch
         {
-            switch (@this)
+            TestTarget.Device_iOS => "ios-device",
+            TestTarget.Device_tvOS => "tvos-device",
+            TestTarget.Device_watchOS => "watchos-device",
+            TestTarget.Simulator_iOS => "ios-simulator",
+            TestTarget.Simulator_iOS32 => "ios-simulator-32",
+            TestTarget.Simulator_iOS64 => "ios-simulator-64",
+            TestTarget.Simulator_tvOS => "tvos-simulator",
+            TestTarget.Simulator_watchOS => "watchos-simulator",
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        public static string AsString(this TestTargetOs targetOs) =>
+            targetOs.AsString() + (targetOs.OSVersion != null ? "_" + targetOs.OSVersion : null);
+
+        public static TestTarget ParseAsAppRunnerTarget(this string target) => target switch
+        {
+            "ios-device" => TestTarget.Device_iOS,
+            "tvos-device" => TestTarget.Device_tvOS,
+            "watchos-device" => TestTarget.Device_watchOS,
+            "ios-simulator" => TestTarget.Simulator_iOS,
+            "ios-simulator-32" => TestTarget.Simulator_iOS32,
+            "ios-simulator-64" => TestTarget.Simulator_iOS64,
+            "tvos-simulator" => TestTarget.Simulator_tvOS,
+            "watchos-simulator" => TestTarget.Simulator_watchOS,
+            null => TestTarget.None,
+            "" => TestTarget.None,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        public static TestTargetOs ParseAsAppRunnerTargetOs(this string targetName)
+        {
+            var index = targetName.LastIndexOf('_');
+            TestTarget target;
+            string? osVersion = null;
+            if (index != -1)
             {
-                case TestTarget.None:
-                    return null;
-                case TestTarget.Device_iOS:
-                    return "ios-device";
-                case TestTarget.Device_tvOS:
-                    return "tvos-device";
-                case TestTarget.Device_watchOS:
-                    return "watchos-device";
-                case TestTarget.Simulator_iOS:
-                    return "ios-simulator";
-                case TestTarget.Simulator_iOS32:
-                    return "ios-simulator-32";
-                case TestTarget.Simulator_iOS64:
-                    return "ios-simulator-64";
-                case TestTarget.Simulator_tvOS:
-                    return "tvos-simulator";
-                case TestTarget.Simulator_watchOS:
-                    return "watchos-simulator";
-                default:
-                    throw new ArgumentOutOfRangeException();
+                target = targetName.Substring(0, index).ParseAsAppRunnerTarget();
+                osVersion = targetName.Substring(index + 1);
             }
+            else
+            {
+                target = targetName.ParseAsAppRunnerTarget();
+            }
+
+            return new TestTargetOs(target, osVersion);
         }
 
-        public static TestTarget ParseAsAppRunnerTarget(this string @this)
+        public static Extension ParseFromNSExtensionPointIdentifier(this string identifier) => identifier switch
         {
-            switch (@this)
-            {
-                case "ios-device":
-                    return TestTarget.Device_iOS;
-                case "tvos-device":
-                    return TestTarget.Device_tvOS;
-                case "watchos-device":
-                    return TestTarget.Device_watchOS;
-                case "ios-simulator":
-                    return TestTarget.Simulator_iOS;
-                case "ios-simulator-32":
-                    return TestTarget.Simulator_iOS32;
-                case "ios-simulator-64":
-                    return TestTarget.Simulator_iOS64;
-                case "tvos-simulator":
-                    return TestTarget.Simulator_tvOS;
-                case "watchos-simulator":
-                    return TestTarget.Simulator_watchOS;
-                case null:
-                case "":
-                    return TestTarget.None;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+            "com.apple.widget-extension" => Extension.TodayExtension,
+            "com.apple.watchkit" => Extension.WatchKit2,
+            _ => throw new ArgumentOutOfRangeException()
+        };
 
-        public static Extension ParseFromNSExtensionPointIdentifier(this string @this)
+        public static string AsNSExtensionPointIdentifier(this Extension extension) => extension switch
         {
-            switch (@this)
-            {
-                case "com.apple.widget-extension":
-                    return Extension.TodayExtension;
-                case "com.apple.watchkit":
-                    return Extension.WatchKit2;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        public static string AsNSExtensionPointIdentifier(this Extension @this)
-        {
-            switch (@this)
-            {
-                case Extension.TodayExtension:
-                    return "com.apple.widget-extension";
-                case Extension.WatchKit2:
-                    return "com.apple.watchkit";
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
+            Extension.TodayExtension => "com.apple.widget-extension",
+            Extension.WatchKit2 => "com.apple.watchkit",
+            _ => throw new ArgumentOutOfRangeException()
+        };
 
         public static void DoNotAwait(this Task task)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS/AppInstaller.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppInstaller.cs
@@ -30,9 +30,9 @@ namespace Microsoft.DotNet.XHarness.iOS
             _verbosity = verbosity;
         }
 
-        public async Task<(string deviceName, ProcessExecutionResult result)> InstallApp(AppBundleInformation appBundleInformation, TestTarget target, string? deviceName = null, CancellationToken cancellationToken = default)
+        public async Task<(string deviceName, ProcessExecutionResult result)> InstallApp(AppBundleInformation appBundleInformation, TestTargetOs target, string? deviceName = null, CancellationToken cancellationToken = default)
         {
-            if (target.IsSimulator())
+            if (target.Platform.IsSimulator())
             {
                 // We reset the simulator when running, so a separate install step does not make much sense.
                 throw new InvalidOperationException("Installing to a simulator is not supported.");
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                 }
                 else
                 {
-                    device = target switch
+                    device = target.Platform switch
                     {
                         TestTarget.Device_iOS => _deviceLoader.Connected64BitIOS.FirstOrDefault(),
                         TestTarget.Device_tvOS => _deviceLoader.ConnectedTV.FirstOrDefault(),
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     };
                 }
 
-                deviceName = target.IsWatchOSTarget() ? (await _deviceLoader.FindCompanionDevice(_mainLog, device)).Name : device?.Name;
+                deviceName = target.Platform.IsWatchOSTarget() ? (await _deviceLoader.FindCompanionDevice(_mainLog, device)).Name : device?.Name;
             }
 
             if (deviceName == null)
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             args.Add(new InstallAppOnDeviceArgument(appBundleInformation.LaunchAppPath));
             args.Add(new DeviceNameArgument(deviceName));
 
-            if (target.IsWatchOSTarget())
+            if (target.Platform.IsWatchOSTarget())
             {
                 args.Add(new DeviceArgument("ios,watchos"));
             }

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -568,12 +568,12 @@ namespace Microsoft.DotNet.XHarness.iOS
             }
         }
 
-        private async Task<string> FindDevice(TestTarget target)
+        private async Task<string> FindDevice(TestTargetOs target)
         {
             IHardwareDevice? companionDevice = null;
-            IHardwareDevice device = await _hardwareDeviceLoader.FindDevice(target.ToRunMode(), _mainLog, includeLocked: false, force: false);
+            IHardwareDevice device = await _hardwareDeviceLoader.FindDevice(target.Platform.ToRunMode(), _mainLog, includeLocked: false, force: false);
 
-            if (target.IsWatchOSTarget())
+            if (target.Platform.IsWatchOSTarget())
             {
                 companionDevice = await _hardwareDeviceLoader.FindCompanionDevice(_mainLog, device);
             }

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.XHarness.iOS
 
         public async Task<(string DeviceName, TestExecutingResult Result, string ResultMessage)> RunApp(
             AppBundleInformation appInformation,
-            TestTarget target,
+            TestTargetOs target,
             TimeSpan timeout,
             TimeSpan testLaunchTimeout,
             string? deviceName = null,
@@ -86,8 +86,8 @@ namespace Microsoft.DotNet.XHarness.iOS
             string[]? skippedTestClasses = null,
             CancellationToken cancellationToken = default)
         {
-            var runMode = target.ToRunMode();
-            bool isSimulator = target.IsSimulator();
+            var runMode = target.Platform.ToRunMode();
+            bool isSimulator = target.Platform.IsSimulator();
 
             var deviceListenerLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: true);
             var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     var mlaunchArguments = GetDeviceArguments(
                         appInformation,
                         deviceName,
-                        target.IsWatchOSTarget(),
+                        target.Platform.IsWatchOSTarget(),
                         verbosity,
                         xmlResultJargon,
                         skippedMethods,
@@ -543,7 +543,7 @@ namespace Microsoft.DotNet.XHarness.iOS
             return args;
         }
 
-        private async Task<(ISimulatorDevice, ISimulatorDevice?)> FindSimulators(TestTarget target)
+        private async Task<(ISimulatorDevice, ISimulatorDevice?)> FindSimulators(TestTargetOs target)
         {
             IFileBackedLog simulatorLoadingLog = _logs.Create($"simulator-list-{_helpers.Timestamp}.log", "Simulator list");
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppInstallerTests.cs
@@ -46,14 +46,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             _hardwareDeviceLoader = new Mock<IHardwareDeviceLoader>();
             _hardwareDeviceLoader
-                .Setup(x => x.Connected64BitIOS).Returns(new List<IHardwareDevice> {s_mockDevice});
+                .Setup(x => x.Connected64BitIOS).Returns(new List<IHardwareDevice> { s_mockDevice });
 
             Directory.CreateDirectory(s_appPath);
             _appBundleInformation = new AppBundleInformation(
                 appName: "AppName",
                 bundleIdentifier: s_appIdentifier,
                 appPath: s_appPath,
-                launchAppPath:s_appPath,
+                launchAppPath: s_appPath,
                 supports32b: false,
                 extension: null);
         }
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await appInstaller.InstallApp(_appBundleInformation, TestTarget.Simulator_iOS64));
+                async () => await appInstaller.InstallApp(_appBundleInformation, new TestTargetOs(TestTarget.Simulator_iOS64, null)));
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
 
             await Assert.ThrowsAsync<NoDeviceFoundException>(
-                async () => await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS));
+                async () => await appInstaller.InstallApp(_appBundleInformation, new TestTargetOs(TestTarget.Device_iOS, null)));
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             // Act
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 2);
 
-            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS);
+            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, new TestTargetOs(TestTarget.Device_iOS, null));
 
             // Verify
             Assert.Equal(0, result.ExitCode);
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             // Act
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 2);
 
-            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, TestTarget.Device_iOS, deviceName: "OtherDevice");
+            var (deviceName, result) = await appInstaller.InstallApp(_appBundleInformation, new TestTargetOs(TestTarget.Device_iOS, null), deviceName: "OtherDevice");
 
             // Verify
             Assert.Equal(0, result.ExitCode);
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             var appInstaller = new AppInstaller(_processManager.Object, _hardwareDeviceLoader.Object, _mainLog.Object, 1);
 
             await Assert.ThrowsAsync<NoDeviceFoundException>(
-                async () => await appInstaller.InstallApp(appBundle32b, TestTarget.Device_iOS));
+                async () => await appInstaller.InstallApp(appBundle32b, new TestTargetOs(TestTarget.Device_iOS, null)));
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             string simulatorLogPath = Path.Combine(Path.GetTempPath(), "simulator-logs");
 
             _simulatorLoader
-                .Setup(x => x.FindSimulators(TestTarget.Simulator_tvOS, _mainLog.Object, true, false))
+                .Setup(x => x.FindSimulators(It.Is<TestTargetOs>(t => t.Platform == TestTarget.Simulator_tvOS), _mainLog.Object, true, false))
                 .ThrowsAsync(new NoDeviceFoundException("Failed to find simulator"));
 
             var listenerLogFile = new Mock<IFileBackedLog>();
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             await Assert.ThrowsAsync<NoDeviceFoundException>(
                 async () => await appRunner.RunApp(
                     appInformation,
-                    TestTarget.Simulator_tvOS,
+                    new TestTargetOs(TestTarget.Simulator_tvOS, null),
                     TimeSpan.FromSeconds(30),
                     TimeSpan.FromSeconds(30)));
 
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             simulator.SetupGet(x => x.SystemLog).Returns(Path.Combine(simulatorLogPath, "system.log"));
 
             _simulatorLoader
-                .Setup(x => x.FindSimulators(TestTarget.Simulator_tvOS, _mainLog.Object, true, false))
+                .Setup(x => x.FindSimulators(It.Is<TestTargetOs>(t => t.Platform == TestTarget.Simulator_tvOS), _mainLog.Object, true, false))
                 .ReturnsAsync((simulator.Object, null));
 
             var testResultFilePath = Path.GetTempFileName();
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,
-                TestTarget.Simulator_tvOS,
+                new TestTargetOs(TestTarget.Simulator_tvOS, null),
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(30),
                 ensureCleanSimulatorState: true);
@@ -362,7 +362,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             await Assert.ThrowsAsync<NoDeviceFoundException>(
                 async () => await appRunner.RunApp(
                     appInformation,
-                    TestTarget.Device_iOS,
+                    new TestTargetOs(TestTarget.Device_iOS, null),
                     TimeSpan.FromSeconds(30),
                     TimeSpan.FromSeconds(30),
                     ensureCleanSimulatorState: true));
@@ -425,7 +425,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,
-                TestTarget.Device_iOS,
+                new TestTargetOs(TestTarget.Device_iOS, null),
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(30));
 
@@ -540,7 +540,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,
-                TestTarget.Device_iOS,
+                new TestTargetOs(TestTarget.Device_iOS, null),
                 timeout:TimeSpan.FromSeconds(30),
                 testLaunchTimeout:TimeSpan.FromSeconds(30),
                 skippedMethods: skippedTests);
@@ -652,7 +652,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
 
             var (deviceName, result, resultMessage) = await appRunner.RunApp(
                 appInformation,
-                TestTarget.Device_iOS,
+                new TestTargetOs(TestTarget.Device_iOS, null),
                 timeout:TimeSpan.FromSeconds(30),
                 testLaunchTimeout:TimeSpan.FromSeconds(30),
                 skippedTestClasses: skippedClasses);


### PR DESCRIPTION
- Allow to specify for example `ios-simulator-64_13.4` as test target
- When no version is specified (only `ios-simulator-64`), find the first suitable Simulator
- Xamarin functionality not changed