### PR TITLE
[iOS] Do not fail if 0 tests were run

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResultParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResultParser.cs
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             var passed = total - errors - failed - notRun - inconclusive - ignored - skipped - invalid;
             var resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
             writer?.WriteLine(resultLine);
-            return (resultLine, total == 0 || errors != 0 || failed != 0);
+            return (resultLine, errors != 0 || failed != 0);
         }
 
         static (string resultLine, bool failed) ParseNUnitXml(StreamReader stream, StreamWriter? writer)
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
             writer?.WriteLine(resultLine);
 
-            return (resultLine, total == 0 | errors != 0 || failed != 0);
+            return (resultLine, errors != 0 || failed != 0);
         }
 
         static (string resultLine, bool failed) ParsexUnitXml(StreamReader stream, StreamWriter? writer)
@@ -311,7 +311,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             string resultLine = $"Tests run: {total} Passed: {passed} Inconclusive: {inconclusive} Failed: {failed + errors} Ignored: {ignored + skipped + invalid}";
             writer?.WriteLine(resultLine);
 
-            return (resultLine, total == 0 | errors != 0 || failed != 0);
+            return (resultLine, errors != 0 || failed != 0);
         }
 
         public string GetXmlFilePath(string path, XmlResultJargon xmlType)


### PR DESCRIPTION
If all tests are ignored, return 0 exit code.

Fixes: #258 

```
info: test[0]
      Starting test for ios-simulator-64..
info: test[0]
      Starting application 'System.Globalization.Tests' on ios-simulator-64
info: test[0]
      Application finished the test run successfully
info: test[0]
      Tests run: 0 Passed: 0 Inconclusive: 0 Failed: 0 Ignored: 0
XHarness exit code: 0
```