### PR TITLE
Improve logging experience (add NullLog, ConsoleLog thread-safe, ps aux not logged)

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSGetStateCommand.cs
@@ -17,6 +17,7 @@ using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.Extensions.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
 using Microsoft.DotNet.XHarness.iOS;
+using Microsoft.DotNet.XHarness.Common.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 {
@@ -149,7 +150,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             try
             {
-                result = await processManager.ExecuteCommandAsync(new MlaunchArguments(new MlaunchVersionArgument()), new MemoryLog(), mlaunchLog, new MemoryLog(), TimeSpan.FromSeconds(10));
+                result = await processManager.ExecuteCommandAsync(new MlaunchArguments(new MlaunchVersionArgument()), new NullLog(), mlaunchLog, new NullLog(), TimeSpan.FromSeconds(10));
             }
             catch (Exception e)
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSPackageCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.CLI.CommandArguments.iOS;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.Common.CLI.Commands;
+using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution.Mlaunch;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
@@ -57,7 +58,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
                 process.StartInfo.FileName = "bash";
                 process.StartInfo.Arguments = "-c \"" + _arguments.DotnetPath + " --info | grep \\\"Base Path\\\" | cut -d':' -f 2 | tr -d '[:space:]'\"";
 
-                var result = await processManager.RunAsync(process, new MemoryLog(), dotnetLog, new MemoryLog(), TimeSpan.FromSeconds(5));
+                var result = await processManager.RunAsync(process, new NullLog(), dotnetLog, new NullLog(), TimeSpan.FromSeconds(5));
 
                 if (result.Succeeded)
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/iOS/iOSTestCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.iOS
 
             logger.LogInformation($"Starting test for {target.AsString()}{ (_arguments.DeviceName != null ? " targeting " + _arguments.DeviceName : null) }..");
 
-            string mainLogFile = Path.Join(_arguments.OutputDirectory, $"run-{target}{(_arguments.DeviceName != null ? "-" + _arguments.DeviceName : null)}.log");
+            string mainLogFile = Path.Join(_arguments.OutputDirectory, $"run-{target.AsString()}{(_arguments.DeviceName != null ? "-" + _arguments.DeviceName : null)}.log");
 
             IFileBackedLog mainLog = Log.CreateReadableAggregatedLog(
                 logs.Create(mainLogFile, LogType.ExecutionLog.ToString(), true),

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -121,14 +121,14 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                 log.WriteLine($"Pids to kill: {string.Join(", ", pids.Select((v) => v.ToString()).ToArray())}");
                 using (var ps = new Process())
                 {
-                    log.WriteLine("Writing process list:");
+                    log.WriteLine("Getting process list..");
                     ps.StartInfo.FileName = "ps";
                     ps.StartInfo.Arguments = "-A -o pid,ruser,ppid,pgid,%cpu=%CPU,%mem=%MEM,flags=FLAGS,lstart,rss,vsz,tty,state,time,command";
                     await RunAsyncInternal(
                         process: ps,
                         log: log,
-                        stdout:log,
-                        stderr:log,
+                        stdout: new NullLog(),
+                        stderr: new NullLog(),
                         kill: kill,
                         getChildrenPS: getChildrenPS,
                         timeout: TimeSpan.FromSeconds(5),

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
@@ -6,6 +6,9 @@ using System.Text;
 
 namespace Microsoft.DotNet.XHarness.Common.Logging
 {
+    /// <summary>
+    /// Log that discards everything
+    /// </summary>
     public class NullLog : ILog
     {
         public string? Description { get; set; } = "NullLog";

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Microsoft.DotNet.XHarness.Common.Logging
+{
+    public class NullLog : ILog
+    {
+        public string? Description { get; set; } = "NullLog";
+        public bool Timestamp { get; set; }
+
+        public Encoding Encoding => Encoding.UTF8;
+
+        public void Dispose()
+        {
+        }
+
+        public void Flush()
+        {
+        }
+
+        public void Write(byte[] buffer, int offset, int count)
+        {
+        }
+
+        public void Write(string value)
+        {
+        }
+
+        public void WriteLine(string value)
+        {
+        }
+
+        public void WriteLine(StringBuilder value)
+        {
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/ConsoleLog.cs
@@ -8,21 +8,30 @@ using System.Text;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
-    // A log that writes to standard output
+    /// <summary>
+    /// A log that writes to standard output
+    /// </summary>
     public class ConsoleLog : ReadableLog
     {
-        readonly StringBuilder captured = new StringBuilder();
+        readonly StringBuilder _captured = new StringBuilder();
 
         protected override void WriteImpl(string value)
         {
-            captured.Append(value);
+            lock (_captured)
+            {
+                _captured.Append(value);
+            }
+
             Console.Write(value);
         }
 
         public override StreamReader GetReader()
         {
-            var str = new MemoryStream(Encoding.GetBytes(captured.ToString()));
-            return new StreamReader(str, Encoding, false);
+            lock (_captured)
+            {
+                var str = new MemoryStream(Encoding.GetBytes(_captured.ToString()));
+                return new StreamReader(str, Encoding, false);
+            }
         }
 
         public override void Flush()


### PR DESCRIPTION
- Stop logging `ps aux` output because the logs are hard to read with the ps output and it brings no value really
- Introduce the `NullLog` and use it where we don't care about process outputs
- Make ConsoleLog thread-safe