### PR TITLE
[iOS] Improve simulator loading

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -331,10 +331,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
         /// This is a new implementation that can .
         /// Old implementation of FindSimulators is kept intact because it is being used in Xamarin.
         /// </summary>
-        /// <param name="target"></param>
-        /// <param name="log"></param>
-        /// <param name="createIfNeeded"></param>
-        /// <returns></returns>
         public async Task<(ISimulatorDevice Simulator, ISimulatorDevice? CompanionSimulator)> FindSimulators(TestTargetOs target, ILog log, bool createIfNeeded = true, bool minVersion = false)
         {
             var runtimePrefix = target.Platform switch

--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                 {
                     try
                     {
-                        (simulator, companionSimulator) = await FindSimulators(target);
+                        (simulator, companionSimulator) = await _simulatorLoader.FindSimulators(target, _mainLog);
                         break;
                     }
                     catch (Exception e)
@@ -548,31 +548,6 @@ namespace Microsoft.DotNet.XHarness.iOS
             }
 
             return args;
-        }
-
-        private async Task<(ISimulatorDevice, ISimulatorDevice?)> FindSimulators(TestTargetOs target)
-        {
-            IFileBackedLog simulatorLoadingLog = _logs.Create($"simulator-list-{_helpers.Timestamp}.log", "Simulator list");
-
-            try
-            {
-                await _simulatorLoader.LoadDevices(simulatorLoadingLog, false, false);
-            }
-            catch
-            {
-                _mainLog.WriteLine("Failed to load simulators!");
-                throw;
-            }
-
-            try
-            {
-                return await _simulatorLoader.FindSimulators(target, _mainLog);
-            }
-            catch (NoDeviceFoundException e)
-            {
-                _mainLog.WriteLine($"Didn't find any suitable simulator: {e.Message}");
-                throw;
-            }
         }
 
         private async Task<string> FindDevice(TestTargetOs target)

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -70,9 +70,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 .ReturnsAsync(s_mockDevice);
 
             _simulatorLoader = new Mock<ISimulatorLoader>();
-            _simulatorLoader
-                .Setup(x => x.LoadDevices(It.IsAny<ILog>(), false, false, false))
-                .Returns(Task.CompletedTask);
 
             _listener = new Mock<ISimpleListener>();
             _listener


### PR DESCRIPTION
`LoadDevices` is called internally inside `SimulatorLoader`. The only reason it stays public is for Xamarin flows.