### PR TITLE
Make sure redirected stdout events are finished in ProcessManager

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -318,8 +318,17 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     }
                 }
             }
+            else
+            {
+                await WaitForExitAsync(process);
+            }
 
-            await WaitForExitAsync(process);
+            if (process.HasExited)
+            {
+                // make sure redirected output events are finished
+                process.WaitForExit();
+            }
+
             Task.WaitAll(new Task[] { stderrCompletion.Task, stdoutCompletion.Task }, TimeSpan.FromSeconds(1));
 
             try


### PR DESCRIPTION
We hit an issue in the wasm testing in dotnet/runtime where xharness would exit with 0 failed tests but the testResult.xml was empty.
This happens because we get the xml by reading stdout from the JS engine, but if xharness exits quickly enough the stdout event isn't handled anymore.

The documentation for the Process class mentions that you need to call WaitForExit() to make sure these events are called: See remarks in https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netcore-3.1#System_Diagnostics_Process_WaitForExit_System_Int32_