### PR TITLE
Remove Windows build leg from internal builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,61 +34,8 @@ pr:
     - master
 
 stages:
-- ${{ if eq(variables._RunAsInternal, False) }}:
-  - stage: Build_Windows_NT
-    displayName: Build Windows
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        enableTelemetry: true
-        enablePublishBuildArtifacts: true
-        enableMicrobuild: true
-        enablePublishUsingPipelines: true
-        enablePublishBuildAssets: true
-        helixRepo: dotnet/xharness
-
-        jobs:
-        - job: Windows_NT
-          pool:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Server.Amd64.VS2019.Open
-          strategy:
-            matrix:
-              Release:
-                _BuildConfig: Release
-              Debug:
-                _BuildConfig: Debug
-          steps:
-          - script: eng\common\CIBuild.cmd
-              -configuration $(_BuildConfig)
-              -prepareMachine
-              $(_InternalBuildArgs)
-            name: Build
-            displayName: Build and run tests
-            condition: succeeded()
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Unit Test Results'
-            inputs:
-              testResultsFormat: xUnit
-              testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
-              mergeTestResults: true
-              searchFolder: $(system.defaultworkingdirectory)
-              testRunTitle: XHarness unit tests - $(Agent.JobName)
-            condition: succeededOrFailed()
-
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Logs to VSTS
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-              PublishLocation: Container
-              ArtifactName: $(Agent.Os)_$(Agent.JobName)
-            continueOnError: true
-            condition: always()
-
-- stage: Build_OSX
-  displayName: Build OSX
-  dependsOn:
+- stage: Build_Windows_NT
+  displayName: Build Windows
   jobs:
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
@@ -100,9 +47,14 @@ stages:
       helixRepo: dotnet/xharness
 
       jobs:
-      - job: OSX
+      - job: Windows_NT
         pool:
-          name: Hosted macOS
+          ${{ if eq(variables._RunAsInternal, True) }}:
+            name: NetCoreInternal-Pool
+            queue: BuildPool.Server.Amd64.VS2019
+          ${{ if eq(variables._RunAsPublic, True) }}:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Server.Amd64.VS2019.Open
         strategy:
           matrix:
             Release:
@@ -112,9 +64,9 @@ stages:
                 _BuildConfig: Debug
         steps:
         - ${{ if eq(variables._RunAsPublic, False) }}:
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
+          - script: eng\common\CIBuild.cmd
+              -configuration $(_BuildConfig)
+              -prepareMachine
               $(_InternalBuildArgs)
               /p:Test=false
             name: Build
@@ -122,32 +74,13 @@ stages:
             condition: succeeded()
 
         - ${{ if eq(variables._RunAsPublic, True) }}:
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
+          - script: eng\common\CIBuild.cmd
+              -configuration $(_BuildConfig)
+              -prepareMachine
               $(_InternalBuildArgs)
             name: Build
             displayName: Build and run tests
             condition: succeeded()
-
-          - bash: |
-              targetDir=$(Build.ArtifactStagingDirectory)/Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
-              mkdir $targetDir
-              cp tests/integration-tests/iOS/helix-payloads/simulatorinstaller-integration-tests.sh $targetDir
-              cp artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.DotNet.XHarness.SimulatorInstaller*.nupkg $targetDir
-            displayName: Prepare the SimulatorInstaller IntegrationTests artifact
-            workingDirectory: $(Build.SourcesDirectory)
-            condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
-
-          - publish: $(Build.ArtifactStagingDirectory)/Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
-            artifact: Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
-            displayName: Publish the SimulatorInstaller IntegrationTests artifact
-            condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
-
-          - publish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.DotNet.XHarness.CLI.1.0.0-ci.nupkg
-            artifact: Microsoft.DotNet.XHarness.CLI.$(_BuildConfig)
-            displayName: Publish XHarness CLI for Helix Testing
-            condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
 
           - task: PublishTestResults@2
             displayName: 'Publish Unit Test Results'
@@ -169,6 +102,87 @@ stages:
           condition: always()
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
+  - stage: Build_OSX
+    displayName: Build OSX
+    dependsOn:
+    jobs:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableTelemetry: true
+        enablePublishBuildArtifacts: true
+        enableMicrobuild: true
+        enablePublishUsingPipelines: true
+        enablePublishBuildAssets: true
+        helixRepo: dotnet/xharness
+
+        jobs:
+        - job: OSX
+          pool:
+            name: Hosted macOS
+          strategy:
+            matrix:
+              Release:
+                _BuildConfig: Release
+              ${{ if eq(variables._RunAsPublic, True) }}:
+                Debug:
+                  _BuildConfig: Debug
+          steps:
+          - ${{ if eq(variables._RunAsPublic, False) }}:
+            - script: eng/common/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                $(_InternalBuildArgs)
+                /p:Test=false
+              name: Build
+              displayName: Build
+              condition: succeeded()
+
+          - ${{ if eq(variables._RunAsPublic, True) }}:
+            - script: eng/common/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                $(_InternalBuildArgs)
+              name: Build
+              displayName: Build and run tests
+              condition: succeeded()
+
+            - bash: |
+                targetDir=$(Build.ArtifactStagingDirectory)/Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
+                mkdir $targetDir
+                cp tests/integration-tests/iOS/helix-payloads/simulatorinstaller-integration-tests.sh $targetDir
+                cp artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.DotNet.XHarness.SimulatorInstaller*.nupkg $targetDir
+              displayName: Prepare the SimulatorInstaller IntegrationTests artifact
+              workingDirectory: $(Build.SourcesDirectory)
+              condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+
+            - publish: $(Build.ArtifactStagingDirectory)/Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
+              artifact: Microsoft.DotNet.XHarness.SimulatorInstaller.IntegrationTests.OSX.$(_BuildConfig)
+              displayName: Publish the SimulatorInstaller IntegrationTests artifact
+              condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+
+            - publish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/Microsoft.DotNet.XHarness.CLI.1.0.0-ci.nupkg
+              artifact: Microsoft.DotNet.XHarness.CLI.$(_BuildConfig)
+              displayName: Publish XHarness CLI for Helix Testing
+              condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+
+            - task: PublishTestResults@2
+              displayName: 'Publish Unit Test Results'
+              inputs:
+                testResultsFormat: xUnit
+                testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
+                mergeTestResults: true
+                searchFolder: $(system.defaultworkingdirectory)
+                testRunTitle: XHarness unit tests - $(Agent.JobName)
+              condition: succeededOrFailed()
+
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Logs to VSTS
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+              PublishLocation: Container
+              ArtifactName: $(Agent.Os)_$(Agent.JobName)
+            continueOnError: true
+            condition: always()
 
   - stage: Test_CLI_Package_In_Helix_Android
     displayName: 'CLI Android Integration tests (Helix SDK)'
@@ -330,9 +344,10 @@ stages:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       enableSymbolValidation: true
-      enableSourceLinkValidation: true
+      # Reenable once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
+      enableSourceLinkValidation: false
       validateDependsOn:
-      - Build_OSX
+      - Build_Windows_NT
       publishDependsOn:
       - Validate
       # This is to enable SDL runs part of Post-Build Validation Stage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,46 +34,31 @@ pr:
     - master
 
 stages:
-- stage: Build_Windows_NT
-  displayName: Build Windows
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableTelemetry: true
-      enablePublishBuildArtifacts: true
-      enableMicrobuild: true
-      enablePublishUsingPipelines: true
-      enablePublishBuildAssets: true
-      helixRepo: dotnet/xharness
+- ${{ if eq(variables._RunAsInternal, False) }}:
+  - stage: Build_Windows_NT
+    displayName: Build Windows
+    jobs:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableTelemetry: true
+        enablePublishBuildArtifacts: true
+        enableMicrobuild: true
+        enablePublishUsingPipelines: true
+        enablePublishBuildAssets: true
+        helixRepo: dotnet/xharness
 
-      jobs:
-      - job: Windows_NT
-        pool:
-          ${{ if eq(variables._RunAsInternal, True) }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2019
-          ${{ if eq(variables._RunAsPublic, True) }}:
+        jobs:
+        - job: Windows_NT
+          pool:
             name: NetCorePublic-Pool
             queue: BuildPool.Server.Amd64.VS2019.Open
-        strategy:
-          matrix:
-            Release:
-              _BuildConfig: Release
-            ${{ if eq(variables._RunAsPublic, True) }}:
+          strategy:
+            matrix:
+              Release:
+                _BuildConfig: Release
               Debug:
                 _BuildConfig: Debug
-        steps:
-        - ${{ if eq(variables._RunAsPublic, False) }}:
-          - script: eng\common\CIBuild.cmd
-              -configuration $(_BuildConfig)
-              -prepareMachine
-              $(_InternalBuildArgs)
-              /p:Test=false
-            name: Build
-            displayName: Build
-            condition: succeeded()
-
-        - ${{ if eq(variables._RunAsPublic, True) }}:
+          steps:
           - script: eng\common\CIBuild.cmd
               -configuration $(_BuildConfig)
               -prepareMachine
@@ -92,14 +77,14 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs to VSTS
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: $(Agent.Os)_$(Agent.JobName)
-          continueOnError: true
-          condition: always()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Logs to VSTS
+            inputs:
+              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+              PublishLocation: Container
+              ArtifactName: $(Agent.Os)_$(Agent.JobName)
+            continueOnError: true
+            condition: always()
 
 - stage: Build_OSX
   displayName: Build OSX
@@ -345,10 +330,8 @@ stages:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       enableSymbolValidation: true
-      # Reenable once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
-      enableSourceLinkValidation: false
+      enableSourceLinkValidation: true
       validateDependsOn:
-      - Build_Windows_NT
       - Build_OSX
       publishDependsOn:
       - Validate


### PR DESCRIPTION
Internal builds will now only run on OSX since running on both Windows and OSX was causing problems with Arcade trying to push to BAR twice as can be seen here:
https://dev.azure.com/dnceng/internal/_build/results?buildId=747943&view=logs&j=74e82b2b-41b5-505f-7026-605948fa01e2&t=45774f52-cdc2-5894-6dc7-2cfd734f27bf

I decided to keep OSX and not Windows leg since we test artifacts from OSX in our PR integration tests
