### PR TITLE
Ignore unused ADB files when scanning for Component Governance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,11 +92,11 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        # - ${{ if eq(variables._RunAsPublic, False) }}:
-        - task: ComponentGovernanceComponentDetection@0
-          displayName: Component Governance scan
-          inputs:
-            ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
+        - ${{ if eq(variables._RunAsPublic, False) }}:
+          - task: ComponentGovernanceComponentDetection@0
+            displayName: Component Governance scan
+            inputs:
+              ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,11 +92,11 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        - ${{ if eq(variables._RunAsPublic, False) }}:
-          - task: ComponentGovernanceComponentDetection@0
-            displayName: Component Governance scan
-            inputs:
-              ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
+        # - ${{ if eq(variables._RunAsPublic, False) }}:
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: Component Governance scan
+          inputs:
+            ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,10 +92,11 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        - task: ComponentGovernanceComponentDetection@0
-          displayName: Component Governance scan
-          inputs:
-            ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
+        - ${{ if eq(variables._RunAsPublic, False) }}:
+          - task: ComponentGovernanceComponentDetection@0
+            displayName: Component Governance scan
+            inputs:
+              ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX
@@ -170,11 +171,6 @@ stages:
                 searchFolder: $(system.defaultworkingdirectory)
                 testRunTitle: XHarness unit tests - $(Agent.JobName)
               condition: succeededOrFailed()
-
-          - task: ComponentGovernanceComponentDetection@0
-            displayName: Component Governance scan
-            inputs:
-              ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
   - stage: Test_CLI_Package_In_Helix_Android
     displayName: 'CLI Android Integration tests (Helix SDK)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,18 +92,10 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Logs to VSTS
-          inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: $(Agent.Os)_$(Agent.JobName)
-          continueOnError: true
-          condition: always()
-
         - task: ComponentGovernanceComponentDetection@0
+          displayName: Component Governance scan
           inputs:
-            ignoreDirectories: 'android-tools,android-tools-unzipped'
+            ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX
@@ -179,18 +171,10 @@ stages:
                 testRunTitle: XHarness unit tests - $(Agent.JobName)
               condition: succeededOrFailed()
 
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Logs to VSTS
-            inputs:
-              PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-              PublishLocation: Container
-              ArtifactName: $(Agent.Os)_$(Agent.JobName)
-            continueOnError: true
-            condition: always()
-
           - task: ComponentGovernanceComponentDetection@0
+            displayName: Component Governance scan
             inputs:
-              ignoreDirectories: 'android-tools,android-tools-unzipped'
+              ignoreDirectories: '$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
 
   - stage: Test_CLI_Package_In_Helix_Android
     displayName: 'CLI Android Integration tests (Helix SDK)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,10 @@ stages:
           continueOnError: true
           condition: always()
 
+        - task: ComponentGovernanceComponentDetection@0
+          inputs:
+            ignoreDirectories: 'android-tools,android-tools-unzipped'
+
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX
     displayName: Build OSX
@@ -183,6 +187,10 @@ stages:
               ArtifactName: $(Agent.Os)_$(Agent.JobName)
             continueOnError: true
             condition: always()
+
+          - task: ComponentGovernanceComponentDetection@0
+            inputs:
+              ignoreDirectories: 'android-tools,android-tools-unzipped'
 
   - stage: Test_CLI_Package_In_Helix_Android
     displayName: 'CLI Android Integration tests (Helix SDK)'


### PR DESCRIPTION
Attempt to fix #286 

Also removes duplicate upload of AzDO logs as artifacts