### PR TITLE
WASM: Add pumping of timer queue to ThreadlessXunitTestRunner

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -54,12 +54,14 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             controller.RunTests(testCasesToRun, resultsSink, testOptions);
             var threadpoolPump = typeof(ThreadPool).GetMethod("PumpThreadPool", BindingFlags.NonPublic | BindingFlags.Static);
+            var timerPump = Type.GetType("System.Threading.TimerQueue")?.GetMethod("PumpTimerQueue", BindingFlags.NonPublic | BindingFlags.Static);
 
-            if (threadpoolPump != null)
+            if (threadpoolPump != null && timerPump != null)
             {
                 while (!resultsSink.Finished.WaitOne(0))
                 {
                     threadpoolPump.Invoke(this, null);
+                    timerPump.Invoke(this, null);
                 }
             }
             else


### PR DESCRIPTION
Required for https://github.com/dotnet/runtime/issues/38931

/cc @premun @mandel-macaque 