### PR TITLE
Fix signing that broke with an earlier commit

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -11,23 +11,8 @@
     <FileSignInfo Include="mscorlib.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="System.Core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="System.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="WebDriver.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
-
-  <!-- We need  this to be inside a target to workaround: https://github.com/microsoft/msbuild/issues/5445 -->
-  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
-    <ItemGroup>
-      <!-- For Selenium.WebDriver -->
-      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'WebDriver'))" />
-      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
-    </ItemGroup>
-  </Target>
-
-  <PropertyGroup>
-    <!--
-      Signing of shipping artifacts (layout, msi, bundle) are handled separately.
-      It is therefore expected that above removal can yield an empty set.
-    -->
-    <AllowEmptySignList>true</AllowEmptySignList>
-  </PropertyGroup>
 
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -13,11 +13,14 @@
     <FileSignInfo Include="System.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- For Selenium.WebDriver -->
-    <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'WebDriver'))" />
-    <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
-  </ItemGroup>
+  <!-- We need  this to be inside a target to workaround: https://github.com/microsoft/msbuild/issues/5445 -->
+  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
+    <ItemGroup>
+      <!-- For Selenium.WebDriver -->
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'WebDriver'))" />
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
+    </ItemGroup>
+  </Target>
 
   <PropertyGroup>
     <!--


### PR DESCRIPTION
https://github.com/dotnet/xharness/pull/291 - introduced a change to
skip some 3rd party assemblies for the signing step, but this broke
because of a msbuild issue: https://github.com/dotnet/msbuild/issues/5445 .

- Essentially, it ended up removing *all* the items to sign.