### PR TITLE
Increase the timeout for listing simulators

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                     new ListSimulatorsArgument(tmpfile),
                     new XmlOutputFormatArgument());
 
-                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(1));
+                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(6));
 
                 if (!result.Succeeded)
                 {


### PR DESCRIPTION
Through investigation, I found out that mlaunch takes 2-4 minutes to list devices on a cold start. After that, some cache is in effect and listing of devices takes 1-30 seconds.
If we do not complete the run, next attempt requires the same amount of time. So if the timeout wouldn't be sufficient, retry won't help.

Increasing this timeout will prevent occasional problems. I will also be deleting all created devices from our infrastructure to speed things up but it doesn't solve the underlying issue completely and that is still up for an investigation.