### PR TITLE
[wasm] Allow serving of unknown files

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
@@ -31,7 +31,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             app.UseStaticFiles(new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(s_hostingEnvironment.ContentRootPath),
-                ContentTypeProvider = provider
+                ContentTypeProvider = provider,
+                ServeUnknownFileTypes = true
             });
         }
     }


### PR DESCRIPTION
By default, we only serve files with known MIME types, but that is an issue when dotnet library tests consume over a hundred different file extensions in their tests