### PR TITLE
[wasm][tests] Fix timeout issues with `test-browser`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -80,8 +80,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             // timing out when getLog() is waiting, and doesn't receive anything
             // for 60s.
             //
-            // Since, we almost all the output gets written via the websocket,
-            // the actual getLog() might not see anything for long durations!
+            // Since, we almost all the output gets written via the websocket now,
+            // getLog() might not see anything for long durations!
             //
             // So -> use a larger timeout!
             return (driverService, new ChromeDriver(driverService, options, _arguments.Timeout));

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -47,21 +47,44 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                                 logProcessor.Invoke,
                                 logger);
 
-            using var driver = GetChromeDriver();
-            return await runner.RunTestsWithWebDriver(driver);
+            var (driverService, driver) = GetChromeDriver();
+            try
+            {
+                return await runner.RunTestsWithWebDriver(driverService, driver);
+            }
+            finally
+            {
+                driverService.Dispose();
+                driver.Dispose();
+            }
         }
 
-        private IWebDriver GetChromeDriver()
+        private (DriverService, IWebDriver) GetChromeDriver()
         {
             var options = new ChromeOptions();
             options.SetLoggingPreference(LogType.Browser, SeleniumLogLevel.All);
+
+            // Enable this for more debugging info
+            // options.SetLoggingPreference(LogType.Driver, SeleniumLogLevel.All);
+
             options.AddArguments(new List<string>(_arguments.BrowserArgs)
             {
                 "--incognito",
                 "--headless"
             });
 
-            return new ChromeDriver(options);
+            var driverService = ChromeDriverService.CreateDefaultService();
+
+            // We want to explicitly specify a timeout here. This is for for the
+            // driver commands, like getLog. The default is 60s, which ends up
+            // timing out when getLog() is waiting, and doesn't receive anything
+            // for 60s.
+            //
+            // Since, we almost all the output gets written via the websocket,
+            // the actual getLog() might not see anything for long durations!
+            //
+            // So -> use a larger timeout!
+            return (driverService, new ChromeDriver(driverService, options, _arguments.Timeout));
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.0.0-alpha05" />
   </ItemGroup>
 


### PR DESCRIPTION
We use selenium to get the console logs from the browser, via
`chromedriver`. But in case of some test libraries (eg.
`System.Memory`), we get too many messages written to `console.log`,
which seems to stall the whole thing (probably, chrome is rate limiting
it).

Instead, we switch to using a websocket, which the test page connects
to, and redirects all the messages to that. (thanks to @lewing for the suggestion)

- So, the test page can connect to `ws://<server>/console`
- We also continue to check selenium for any other messages, or errors
that might show up

This allows the test output to show up much faster, and longer running
tests work fine.

Issues:

- If we exceed the timeout, then we want to shutdown the tests, but
selenium doesn't seem to be able to close the browser correctly
	- it takes a long time
	- and, leaves child chrome processes around

	- So, for this *specific* case, we kill the process tree
	manually

Fixes issues: dotnet/runtime#41269, and dotnet/runtime#41160 .