### PR TITLE
[wasm] Log browser level errors, instead of interrupting the

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -213,6 +213,15 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         {
                             if (logEntry.Level == SeleniumLogLevel.Severe)
                             {
+                                // These are errors from the browser, some of which might be
+                                // thrown as part of tests. So, we can't differentiate when
+                                // it is an error that we can ignore, vs one that should stop
+                                // the execution completely.
+                                //
+                                // Note: these could be received out-of-order as compared to
+                                // console messages via the websocket.
+                                //
+                                // (see commit message for more info)
                                 _logger.LogError($"[out of order message from the {logType}]: {logEntry.Message}");
                                 continue;
                             }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -213,9 +213,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         {
                             if (logEntry.Level == SeleniumLogLevel.Severe)
                             {
-                                // throw on driver errors, or other errors that show up
-                                // in the console log
-                                throw new ArgumentException(logEntry.Message);
+                                _logger.LogError($"[out of order message from the {logType}]: {logEntry.Message}");
+                                continue;
                             }
 
                             var match = s_consoleLogRegex.Match(Regex.Unescape(logEntry.Message));


### PR DESCRIPTION
.. tests by throwing an exception.

Errors like:

`http://bla/ - Failed to load resource: net::ERR_NAME_NOT_RESOLVED)`

Note: I wasn't able to capture these in js itself, to pipe through the
console websocket. So, we get these from Selenium, and that can be out
of sync with the messages from the console websocket.

This was seen in tests for `System.XmlSchemaSet.Tests`. These errors
would get logged, but since we were throwing exceptions for them, the
result of all the tests would marked as `GENERAL_FAILURE`.

Note: In this case the errors are expected, but I'm not sure how to
differentiate these from other browser level errors that mean that the
whole thing has failed.