### PR TITLE
[wasm][tests] Identify tests that throw PNSE

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -163,8 +163,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     if (result.EndOfMessage)
                     {
                         var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
-                        line += Environment.NewLine;
-
                         _processLogMessage(line);
 
                         // the test runner writes this as the last line,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     _xmlResultsFileWriter = null;
                     return;
                 }
-                _xmlResultsFileWriter.Write(_hasWasmStdoutPrefix ? line.Substring(6) : line);
+                _xmlResultsFileWriter.WriteLine(_hasWasmStdoutPrefix ? line.Substring(6) : line);
             }
         }
     }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Xml.Linq;
@@ -41,13 +42,14 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             var testCasesToRun = discoverySink.TestCases.Where(filters.Filter).ToList();
             Console.WriteLine($"Discovery finished.");
 
-            var summarySink = new DelegatingExecutionSummarySink(testSink, () => false, (completed, summary) => { Console.WriteLine($"Tests run: {summary.Total}, Errors: 0, Failures: {summary.Failed}, Skipped: {summary.Skipped}. Time: {TimeSpan.FromSeconds((double)summary.Time).TotalSeconds}s"); });
+            var delegatingSummarySink = new DelegatingExecutionSummarySink(testSink, () => false, null);
+            var summarySink = new WasmExecutionSummarySink(delegatingSummarySink, () => false, (completed, summary) => { Console.WriteLine($"Tests run: {summary.Total}, Errors: 0, Failures: {summary.Failed}, PNSE: {summary.PNSE}, Skipped: {summary.Skipped}. Time: {TimeSpan.FromSeconds((double)summary.Time).TotalSeconds}s"); });
             var resultsXmlAssembly = new XElement("assembly");
             var resultsSink = new DelegatingXmlCreationSink(summarySink, resultsXmlAssembly);
 
             testSink.Execution.TestPassedEvent += args => { Console.WriteLine($"[PASS] {args.Message.Test.DisplayName}"); };
             testSink.Execution.TestSkippedEvent += args => { Console.WriteLine($"[SKIP] {args.Message.Test.DisplayName}"); };
-            testSink.Execution.TestFailedEvent += args => { Console.WriteLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}"); };
+            testSink.Execution.TestFailedEvent += (MessageHandlerArgs<ITestFailed> args) => HandleTestFailed(args);
 
             testSink.Execution.TestAssemblyStartingEvent += args => { Console.WriteLine($"Running tests for {args.Message.TestAssembly.Assembly}"); };
             testSink.Execution.TestAssemblyFinishedEvent += args => { Console.WriteLine($"Finished {args.Message.TestAssembly.Assembly}{Environment.NewLine}"); };
@@ -71,6 +73,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             if (printXml)
             {
+                FixupFailedTestResultsForPNSE(resultsXmlAssembly);
                 Console.WriteLine($"STARTRESULTXML");
                 var resultsXml = new XElement("assemblies");
                 resultsXml.Add(resultsXmlAssembly);
@@ -82,6 +85,32 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             var failed = resultsSink.ExecutionSummary.Failed > 0 || resultsSink.ExecutionSummary.Errors > 0;
             return failed ? 1 : 0;
         }
+
+        void FixupFailedTestResultsForPNSE(XElement resultsXmlAssembly)
+        {
+            var pnse_tests = resultsXmlAssembly.Elements("collection").Descendants("test")
+                .Where(test => test.Attributes("result").Any(r => string.Compare((string)r, "fail", StringComparison.OrdinalIgnoreCase) == 0))
+                .Where(test => test.Descendants("failure").Any(f => IsTestFailurePNSE(f)));
+
+            foreach (var test in pnse_tests)
+                test.SetAttributeValue("result", "PNSE");
+
+            bool IsTestFailurePNSE(XElement failure)
+            {
+                return failure.Attributes("exception-type")
+                            .Any(attr => string.Compare((string)attr, "System.PlatformNotSupportedException", StringComparison.OrdinalIgnoreCase) == 0);
+                        //|| failure.Descendants("message").Any(msg => ((string)msg).Contains("System.PlatformNotSupportedException"));
+            }
+        }
+
+        void HandleTestFailed(MessageHandlerArgs<ITestFailed> args)
+        {
+            bool isPNSE = IsPNSE(args.Message);
+            Console.WriteLine($"[{(isPNSE ? "PNSE" : "FAIL")}] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}");
+        }
+
+        public static bool IsPNSE(ITestFailed failedTestMessage)
+            => failedTestMessage.ExceptionTypes.Any(type => type == "System.PlatformNotSupportedException");
     }
 
     internal class ThreadlessXunitDiscoverer : global::Xunit.Sdk.XunitTestFrameworkDiscoverer
@@ -120,5 +149,70 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             return true;
         }
+    }
+
+    internal class WasmExecutionSummarySink : LongLivedMarshalByRefObject, IExecutionSink
+    {
+        bool _disposed;
+        IExecutionSink _innerSink;
+        Action<string, WasmExecutionSummary>? _completionCallback;
+        int _pnse;
+        WasmExecutionSummary _wasmExecutionSummary = new WasmExecutionSummary();
+
+        public WasmExecutionSummarySink(
+            IExecutionSink innerSink,
+            Func<bool>? cancelThunk = null,
+            Action<string, WasmExecutionSummary>? completionCallback = null)
+        {
+            this._innerSink = innerSink;
+            this._completionCallback = completionCallback;
+        }
+
+        public ExecutionSummary ExecutionSummary => _wasmExecutionSummary;
+
+        public ManualResetEvent Finished => _innerSink.Finished;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
+            _disposed = true;
+
+            Finished.Dispose();
+        }
+
+        public bool OnMessageWithTypes(
+            IMessageSinkMessage message,
+            HashSet<string>? messageTypes)
+        {
+            return message.Dispatch<ITestFailed>(messageTypes, HandleTestFailed)
+                    && message.Dispatch<ITestAssemblyFinished>(messageTypes, HandleTestAssemblyFinished)
+                    && _innerSink.OnMessageWithTypes(message, messageTypes);
+        }
+
+        private void HandleTestFailed(MessageHandlerArgs<ITestFailed> args)
+        {
+            if (ThreadlessXunitTestRunner.IsPNSE(args.Message))
+                _pnse++;
+        }
+
+        private void HandleTestAssemblyFinished(MessageHandlerArgs<ITestAssemblyFinished> args)
+        {
+            _wasmExecutionSummary.PNSE = _pnse;
+            _wasmExecutionSummary.Total = args.Message.TestsRun;
+            _wasmExecutionSummary.Failed = args.Message.TestsFailed - _pnse;
+            _wasmExecutionSummary.Skipped = args.Message.TestsSkipped;
+            _wasmExecutionSummary.Time = args.Message.ExecutionTime;
+
+            _completionCallback?.Invoke(Path.GetFileNameWithoutExtension(args.Message.TestAssembly.Assembly.AssemblyPath), (ExecutionSummary as WasmExecutionSummary)!);
+
+            Finished.Set();
+        }
+    }
+
+    internal class WasmExecutionSummary : ExecutionSummary
+    {
+        public int PNSE { get; set; }
     }
 }


### PR DESCRIPTION
- These tests show up as

`[PNSE] System.Net.Http.Functional.Tests.SocketsHttpHandler_Connect_Test.ConnectMethod_Success`

And the test results show:
`Tests run: 1774, Errors: 0, Failures: 13, PNSE: 1226, Skipped: 71.  Time: 10.198805s`

Here `PNSE:` shows the count for tests that throw PNSE.
And `Failures` *do not* include PNSE failures.

In the xml report, such tests are shown with `result="PNSE"`:

```xml
<test
	name="System.Net.Http.Functional.Tests.SyncHttpHandler_Connect_Test.ConnectMethod_Success"
	type="System.Net.Http.Functional.Tests.SyncHttpHandler_Connect_Test"
	method="ConnectMethod_Success" time="0.000525"
	result="PNSE">
```

.. instead of `result="Fail"`.

To detect these, we look for exception-type==PNSE .
This still misses cases where the exception might be wrapped in others.
We could check the messages xml element to get those too, but that might give us false positives.

Eg problem case: `System.Net.Http.Functional.Tests.HttpClientTest.CancelAllPending_AllPendingOperationsCanceled`
	- this uses `Assert.All`, so you get bunch of exceptions wrapped in
	`Xunit.Sdk.AllException`.