### PR TITLE
[wasm][tests] Remove extra newline from output, making it a bit tighter 

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -163,8 +163,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     if (result.EndOfMessage)
                     {
                         var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
-                        line += Environment.NewLine;
-
                         _processLogMessage(line);
 
                         // the test runner writes this as the last line,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     _xmlResultsFileWriter = null;
                     return;
                 }
-                _xmlResultsFileWriter.Write(_hasWasmStdoutPrefix ? line.Substring(6) : line);
+                _xmlResultsFileWriter.WriteLine(_hasWasmStdoutPrefix ? line.Substring(6) : line);
             }
         }
     }


### PR DESCRIPTION
This changes the output from:

```
dbug: test-browser[0]
      [FAIL] System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpProtocolTests.GetAsync_InvalidStatusLine_ThrowsExceptionOnSocketsHttpHandler(responseString: "HTTP/1.1 200\tOK")

dbug: test-browser[0]
      System.PlatformNotSupportedException : System.Net.Sockets is not supported on this platform.

```

.. to ..

```
dbug: test-browser[0]
      [FAIL] System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpProtocolTests.GetAsync_InvalidStatusLine_ThrowsExceptionOnSocketsHttpHandler(responseString: "HTTP/1.1 200\tOK")
dbug: test-browser[0]
      System.PlatformNotSupportedException : System.Net.Sockets is not supported on this platform.
```