### PR TITLE
Improve wasm test logging

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-rc.1.20451.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -163,6 +163,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     if (result.EndOfMessage)
                     {
                         var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
+                        line += Environment.NewLine;
+
                         _processLogMessage(line);
 
                         // the test runner writes this as the last line,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -40,7 +40,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var xmlResultsFilePath = Path.Combine(_arguments.OutputDirectory, "testResults.xml");
             File.Delete(xmlResultsFilePath);
 
-            var logProcessor = new WasmTestMessagesProcessor (xmlResultsFilePath, logger);
+            var stdoutFilePath = Path.Combine(_arguments.OutputDirectory, "wasm-console.log");
+            File.Delete(stdoutFilePath);
+
+            var logProcessor = new WasmTestMessagesProcessor(xmlResultsFilePath, stdoutFilePath, logger);
             var runner = new WasmBrowserTestRunner(
                                 _arguments,
                                 PassThroughArguments,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -64,9 +64,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var xmlResultsFilePath = Path.Combine(_arguments.OutputDirectory, "testResults.xml");
             File.Delete(xmlResultsFilePath);
 
+            var stdoutFilePath = Path.Combine(_arguments.OutputDirectory, "wasm-console.log");
+            File.Delete(stdoutFilePath);
+
             try
             {
-                var logProcessor = new WasmTestMessagesProcessor (xmlResultsFilePath, logger);
+                var logProcessor = new WasmTestMessagesProcessor(xmlResultsFilePath, stdoutFilePath, logger);
                 var result = await processManager.ExecuteCommandAsync(
                     engineBinary,
                     engineArgs,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using Microsoft.Extensions.Logging;
 
@@ -10,14 +11,16 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
     public class WasmTestMessagesProcessor
     {
         private StreamWriter? _xmlResultsFileWriter;
+        private readonly StreamWriter _stdoutFileWriter;
         private readonly string _xmlResultsFilePath;
-        private bool _hasWasmStdoutPrefix = false;
 
         private readonly ILogger _logger;
 
-        public WasmTestMessagesProcessor(string xmlResultsFilePath, ILogger logger)
+        public WasmTestMessagesProcessor(string xmlResultsFilePath, string stdoutFilePath, ILogger logger)
         {
             this._xmlResultsFilePath = xmlResultsFilePath;
+            this._stdoutFileWriter = File.CreateText(stdoutFilePath);
+            this._stdoutFileWriter.AutoFlush = true;
             this._logger = logger;
         }
 
@@ -28,17 +31,23 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 if (line.Contains("STARTRESULTXML"))
                 {
                     _xmlResultsFileWriter = File.CreateText(_xmlResultsFilePath);
-                    _hasWasmStdoutPrefix = line.StartsWith("WASM: ");
                     return;
                 }
-                else if (line.Contains("Tests run:"))
-                {
-                    _logger.LogInformation(line);
-                }
-                else
+                else if (line.StartsWith("[PASS]") || line.StartsWith("[SKIP]"))
                 {
                     _logger.LogDebug(line);
                 }
+                else if (line.StartsWith("[FAIL]"))
+                {
+                    line = line.Replace("[xharnessnewline]", Environment.NewLine);
+                    _logger.LogError(line);
+                }
+                else
+                {
+                    _logger.LogInformation(line);
+                }
+
+                _stdoutFileWriter.Write(line);
             }
             else
             {
@@ -49,7 +58,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     _xmlResultsFileWriter = null;
                     return;
                 }
-                _xmlResultsFileWriter.WriteLine(_hasWasmStdoutPrefix ? line.Substring(6) : line);
+                _xmlResultsFileWriter.Write(line);
             }
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -39,7 +39,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 }
                 else if (line.StartsWith("[FAIL]"))
                 {
-                    line = line.Replace("[xharnessnewline]", Environment.NewLine);
                     _logger.LogError(line);
                 }
                 else

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs
@@ -130,11 +130,17 @@ namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
         private ILoggerFactory CreateLoggerFactory(LogLevel verbosity) => LoggerFactory.Create(builder =>
         {
             builder
-            .AddConsole(options =>
+            .AddSimpleConsole(options =>
             {
+                options.SingleLine = true;
+
                 if (Environment.GetEnvironmentVariable("XHARNESS_DISABLE_COLORED_OUTPUT")?.ToLower().Equals("true") ?? false)
                 {
-                    options.DisableColors = true;
+                    options.ColorBehavior = Extensions.Logging.Console.LoggerColorBehavior.Disabled;
+                }
+                else
+                {
+                    options.ColorBehavior = Extensions.Logging.Console.LoggerColorBehavior.Enabled;
                 }
 
                 if (Environment.GetEnvironmentVariable("XHARNESS_LOG_WITH_TIMESTAMPS")?.ToLower().Equals("true") ?? false)

--- a/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0-rc.1.20451.14" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -45,9 +45,13 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             var resultsXmlAssembly = new XElement("assembly");
             var resultsSink = new DelegatingXmlCreationSink(summarySink, resultsXmlAssembly);
 
+            if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
+            {
+                testSink.Execution.TestStartingEvent += args => { Console.WriteLine($"[STRT] {args.Message.Test.DisplayName}"); };
+            }
             testSink.Execution.TestPassedEvent += args => { Console.WriteLine($"[PASS] {args.Message.Test.DisplayName}"); };
             testSink.Execution.TestSkippedEvent += args => { Console.WriteLine($"[SKIP] {args.Message.Test.DisplayName}"); };
-            testSink.Execution.TestFailedEvent += args => { Console.WriteLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}"); };
+            testSink.Execution.TestFailedEvent += args => { LogWithEscapedNewLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}"); };
 
             testSink.Execution.TestAssemblyStartingEvent += args => { Console.WriteLine($"Running tests for {args.Message.TestAssembly.Assembly}"); };
             testSink.Execution.TestAssemblyFinishedEvent += args => { Console.WriteLine($"Finished {args.Message.TestAssembly.Assembly}{Environment.NewLine}"); };
@@ -81,6 +85,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             var failed = resultsSink.ExecutionSummary.Failed > 0 || resultsSink.ExecutionSummary.Errors > 0;
             return failed ? 1 : 0;
+        }
+
+        private void LogWithEscapedNewLine(string message)
+        {
+            Console.WriteLine(message.Replace(Environment.NewLine, "[xharnessnewline]"));
         }
     }
 

--- a/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/Microsoft.DotNet.XHarness.SimulatorInstaller.csproj
+++ b/tools/Microsoft.DotNet.XHarness.SimulatorInstaller/Microsoft.DotNet.XHarness.SimulatorInstaller.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
   </ItemGroup>
 


### PR DESCRIPTION
Don't show PASS/SKIP messages by default in the console log, unless verbose logging is enabled in xharness.
We capture all output and store it in the wasm-console.log file in the xharness output directory instead.

---

I got many requests from various dotnet team members to make the default wasm output more similar to the desktop xunit output, which only displays failed tests by default.

The wasm output now looks like this:

```
  info: test[0] Discovering: System.Runtime.Handles.Tests.dll (method display = ClassAndMethod, method display options = None)
  info: test[0] Discovered:  System.Runtime.Handles.Tests.dll (found 14 of 15 test cases)
  info: test[0] Starting:    System.Runtime.Handles.Tests.dll
  fail: test[0] [FAIL] SafeWaitHandleTests.SafeWaitHandle_False
  info: test[0] Assert.False() Failure
  info: test[0] Expected: False
  info: test[0] Actual:   True
  info: test[0]    at SafeWaitHandleTests.SafeWaitHandle_False()
  info: test[0]    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  info: test[0] Finished:    System.Runtime.Handles.Tests.dll
  info: test[0]
  info: test[0] === TEST EXECUTION SUMMARY ===
  info: test[0] Total: 14, Errors: 0, Failed: 1, Skipped: 0, Time: 0.250726s
```