### PR TITLE
[iOS] Ensure that the launch callback is correctly chained.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
     public interface ISimpleListener : IDisposable
     {
-        Task CompletionTask { get; }
-        Task ConnectedTask { get; }
+        Task<bool> CompletionTask { get; }
+        Task<bool> ConnectedTask { get; }
         IFileBackedLog TestLog { get; }
 
         void Cancel();
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         protected abstract void Start();
         protected abstract void Stop();
 
-        public Task ConnectedTask => _connected.Task;
+        public Task<bool> ConnectedTask => _connected.Task;
         public abstract int InitializeAndGetPort();
 
         protected SimpleListener(ILog log, IFileBackedLog testLog)
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public bool WaitForCompletion(TimeSpan ts) => _stopped.Task.Wait(ts);
 
-        public Task CompletionTask => _stopped.Task;
+        public Task<bool> CompletionTask => _stopped.Task;
 
         public void Cancel()
         {

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         {
             // set the listener to return a task that we are not going to complete
             var cancellationTokenSource = new CancellationTokenSource();
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<bool>();
             _listener.Setup(l => l.CompletionTask).Returns(tcs.Task); // will never be set to be completed
 
             // ensure that we do provide the required runlog information so that we know if it was a launch failure or not, we are
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
 
             // set the listener to return a task that we are not going to complete
             var cancellationTokenSource = new CancellationTokenSource();
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<bool>();
             _listener.Setup(l => l.CompletionTask).Returns(tcs.Task); // will never be set to be completed
 
             // empty test file to be returned as the runlog stream
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         public async Task CollectDeviceResultTimeoutTest()
         {
             // set the listener to return a task that we are not going to complete
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<bool>();
             _listener.Setup(l => l.CompletionTask).Returns(tcs.Task); // will never be set to be completed
 
             // ensure that we do provide the required runlog information so that we know if it was a launch failure or not, we are
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         public async Task ParseResultTimeoutTestsTest()
         {
             // more complicated test, we need to fake a process timeout, then ensure that the result is the expected one
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource<bool>();
             _listener.Setup(l => l.CompletionTask).Returns(tcs.Task); // will never be set to be completed
 
             var listenerLog = new Mock<IFileBackedLog>();

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
             _listener = new Mock<ISimpleListener>();
             _listener
                 .SetupGet(x => x.ConnectedTask)
-                .Returns(Task.CompletedTask);
+                .Returns(Task.FromResult(true));
 
             _snapshotReporter = new Mock<ICrashSnapshotReporter>();
 


### PR DESCRIPTION
Ensure that we use a boolean for the connected lambda else we have some
issues when executing on devices.