### PR TITLE
Bump mlaunch to version compatible with Xcode 12

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -13,7 +13,7 @@
 
     <!-- This is a git revision of the xamarin/macios-binaries repo where we get the mlaunch tool from
          If you change the version, please run /eng/download-mlaunch.sh to get this version into your environment -->
-    <MlaunchVersion>3fbdcdb97459ca2c699d47e33028a106b95a7f1f</MlaunchVersion>
+    <MlaunchVersion>5b4f91e14dc18dc57b9ac7978c696883e289f94f</MlaunchVersion>
 
     <!-- When updating these URLs, avoid using 'latest' url as these are redirects and can make the same commit build differently on different days -->
     <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>


### PR DESCRIPTION
This fixes the following issue:

```
error HE0004: Could not load the framework 'IDEKit' (path: /Applications/Xcode.app/Contents/Frameworks/IDEKit.framework/IDEKit):
dlopen(/Applications/Xcode.app/Contents/Frameworks/IDEKit.framework/IDEKit, 1): Library not loaded: @rpath/DVTAnalyticsKit.framework/Versions/A/DVTAnalyticsKit
   Referenced from: /Applications/Xcode.app/Contents/Frameworks/IDEKit.framework/Versions/A/IDEKit 19:26:05.1635280
   Reason: image not found
```