### PR TITLE
Use latest version of ASP.NET Core via FrameworkReference instead of nuget

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,9 +7,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>61cde6e8fb9d5c9790867b279deb41783a780cd8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20474.4">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="5.0.0-beta.20502.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>61cde6e8fb9d5c9790867b279deb41783a780cd8</Sha>
+      <Sha>baebe30c7969b4148a6a3b90cf5f4e3a96d4a11e</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/global.json
+++ b/global.json
@@ -1,14 +1,9 @@
 {
   "tools": {
-    "dotnet": "5.0.100-rc.1.20452.10",
-    "runtimes": {
-      "dotnet": [
-        "2.1.11"
-      ]
-    }
+    "dotnet": "5.0.100-rc.1.20452.10"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20474.4",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20474.4"
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20502.2"
   }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
@@ -18,9 +18,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 {
     public class WasmTestWebServerStartup
     {
-        private readonly IHostingEnvironment s_hostingEnvironment;
+        private readonly IWebHostEnvironment s_hostingEnvironment;
 
-        public WasmTestWebServerStartup(IHostingEnvironment hostingEnvironment)
+        public WasmTestWebServerStartup(IWebHostEnvironment hostingEnvironment)
         {
             this.s_hostingEnvironment = hostingEnvironment;
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -33,9 +33,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.0.0-alpha05" />
   </ItemGroup>
 
@@ -43,6 +40,10 @@
     <ProjectReference Include="..\Microsoft.DotNet.XHarness.Android\Microsoft.DotNet.XHarness.Android.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.XHarness.iOS.Shared\Microsoft.DotNet.XHarness.iOS.Shared.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.XHarness.iOS\Microsoft.DotNet.XHarness.iOS.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <Target Name="DownloadAndroidSdks" BeforeTargets="Build">

--- a/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
@@ -2,10 +2,10 @@
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
 
   <PropertyGroup>
-    <!-- These two settings work around changes from newer MSBuild requiring additional properties set (otherwise gets a weird error about targeting desktop 4.0) --> 
-    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
+    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <HelixType>test/product/</HelixType>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>

--- a/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
@@ -2,10 +2,10 @@
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
 
   <PropertyGroup>
-    <!-- These two settings work around changes from newer MSBuild requiring additional properties set (otherwise gets a weird error about targeting desktop 4.0) --> 
-    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
+    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <HelixType>test/product/</HelixType>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>

--- a/tests/integration-tests/iOS/iOS.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/iOS/iOS.Helix.SDK.Tests.proj
@@ -2,10 +2,10 @@
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
 
   <PropertyGroup>
-    <!-- These two settings work around changes from newer MSBuild requiring additional properties set (otherwise gets a weird error about targeting desktop 4.0) --> 
-    <TargetFrameworkVersion>5.0</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
+    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
     <HelixType>test/product/</HelixType>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
     <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>


### PR DESCRIPTION
We were pulling in Microsoft.AspNetCore 2.2 via a nuget PackageReference, but after upgrading Microsoft.Extensions.Logging in https://github.com/dotnet/xharness/pull/315 we saw the following error when using the "wasm test-browser" command:

```
fail: Microsoft.AspNetCore.Server.Kestrel[0]
      Heartbeat.OnHeartbeat
      System.TypeLoadException: Could not load type 'Microsoft.Extensions.Primitives.InplaceStringBuilder' from assembly 'Microsoft.Extensions.Primitives, Version=5.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
         at Microsoft.Net.Http.Headers.DateTimeFormatter.ToRfc1123String(DateTimeOffset dateTime, Boolean quoted)
         at Microsoft.Net.Http.Headers.HeaderUtilities.FormatDate(DateTimeOffset dateTime, Boolean quoted)
         at Microsoft.Net.Http.Headers.HeaderUtilities.FormatDate(DateTimeOffset dateTime)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.DateHeaderValueManager.SetDateValues(DateTimeOffset value)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.DateHeaderValueManager.OnHeartbeat(DateTimeOffset now)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure.Heartbeat.OnHeartbeat()
```

The reason is that the newer version of Microsoft.Extensions.Primitives removed InplaceStringBuilder.

Instead of using an old ASP.NET we can use the one in the framework instead, which is what's recommended since .NET Core 3.0