### PR TITLE
Target .NET Standard 2.0 instead of 2.1 for code shared with Xamarin

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
@@ -1,11 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  
+  <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
@@ -60,7 +60,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 appName + (extension != null ? ".appex" : ".app"));
 
             string arch = csproj.GetMtouchArch(platform, buildConfiguration);
-            bool supports32 = arch.Contains("ARMv7", StringComparison.InvariantCultureIgnoreCase) || arch.Contains("i386", StringComparison.InvariantCultureIgnoreCase);
+
+            bool supports32 = Contains(arch, "ARMv7") || Contains(arch, "i386");
 
             if (!Directory.Exists(appPath))
             {
@@ -76,7 +77,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
 
         public async Task<AppBundleInformation> ParseFromAppBundle(string appPackagePath, TestTarget target, ILog log, CancellationToken cancellationToken = default)
         {
-            var plistPath = Path.Join(appPackagePath, "Info.plist");
+            var plistPath = Path.Combine(appPackagePath, "Info.plist");
 
             if (!File.Exists(plistPath))
             {
@@ -102,7 +103,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
                 ? Directory.GetDirectories(Path.Combine(appPackagePath, "Watch"), "*.app")[0]
                 : appPackagePath;
 
-            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, supports32.Contains(Armv7, StringComparison.InvariantCultureIgnoreCase), extension: null);
+            return new AppBundleInformation(appName, appPackagePath, bundleIdentifier, launchAppPath, Contains(supports32, Armv7), extension: null);
         }
 
         private async Task<string> GetPlistProperty(string plistPath, string propertyName, ILog log, CancellationToken cancellationToken = default)
@@ -123,6 +124,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
             }
 
             return commandOutput.ToString().Trim();
+        }
+
+        // This method was added because .NET Standard 2.0 doesn't have case ignorant Contains() for String.
+        private static bool Contains(string haystack, string needle)
+        {
+            return haystack.IndexOf(needle, StringComparison.InvariantCultureIgnoreCase) > -1;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_1
+﻿#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
 
 namespace System.Diagnostics.CodeAnalysis
 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
@@ -1,0 +1,32 @@
+﻿#if !NETSTANDARD2_1
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    internal sealed class NullableAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NullableAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+}
+
+#endif

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Compatibility/Nullable.cs
@@ -14,19 +14,6 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets the return value condition.</summary>
         public bool ReturnValue { get; }
     }
-
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true)]
-    internal sealed class NullableAttribute : Attribute
-    {
-        /// <summary>Initializes the attribute with the specified return value condition.</summary>
-        /// <param name="returnValue">
-        /// The return value condition. If the method returns this value, the associated parameter will not be null.
-        /// </param>
-        public NullableAttribute(bool returnValue) => ReturnValue = returnValue;
-
-        /// <summary>Gets the return value condition.</summary>
-        public bool ReturnValue { get; }
-    }
 }
 
 #endif

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="installLog">The installation log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownInstallIssue(IFileBackedLog installLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownInstallIssue(IFileBackedLog installLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the build failure is due to a known issue that the user can act upon.
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="buildLog">The build log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownBuildIssue(IFileBackedLog buildLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownBuildIssue(IFileBackedLog buildLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the run failure is due to a known issue that the user can act upon.
@@ -36,6 +36,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="runLog">The run log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownTestIssue(IFileBackedLog runLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownTestIssue(IFileBackedLog runLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IErrorKnowledgeBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="installLog">The installation log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownInstallIssue(IFileBackedLog installLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownInstallIssue(IFileBackedLog installLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the build failure is due to a known issue that the user can act upon.
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="buildLog">The build log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownBuildIssue(IFileBackedLog buildLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownBuildIssue(IFileBackedLog buildLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
 
         /// <summary>
         /// Identifies via the logs if the run failure is due to a known issue that the user can act upon.
@@ -36,6 +36,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// <param name="runLog">The run log.</param>
         /// <param name="knownFailureMessage">A string message for the user to understand the reason for the failure.</param>
         /// <returns>True if the failure is due to a known reason, false otherwise.</returns>
-        bool IsKnownTestIssue(IFileBackedLog runLog, [NotNullWhen(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
+        bool IsKnownTestIssue(IFileBackedLog runLog, [Nullable(true)] out (string HumanMessage, string? IssueLink)? knownFailureMessage);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
@@ -1,10 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  
+  <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
   </PropertyGroup>
 
+  <!-- Remove files that are only included inside of the packaged iOS app and are not to be compiled as part of this project -->
   <ItemGroup>
     <None Remove="TestImporter\Templates\Managed\Resources\Managed.iOS.csproj.in" />
     <None Remove="TestImporter\Templates\Managed\Resources\Managed.iOS.plist.in" />


### PR DESCRIPTION
We need to consume the Shared library in `xamarin-macios` which targets **.NET Framework 4.7.2**. When creating the project in `dotnet/xharness` we made a mistake and targeted .NET Standard 2.1 instead while 4.7.2 needs 2.0.

Some of the APIs are not available so minor changes are needed.