### PR TITLE
[wasm][tests] Log messages with correct log level

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var runner = new WasmBrowserTestRunner(
                                 _arguments,
                                 PassThroughArguments,
-                                logProcessor.Invoke,
+                                logProcessor,
                                 logger);
 
             var (driverService, driver) = GetChromeDriver();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmLogMessage.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmLogMessage.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
+{
+    class WasmLogMessage
+    {
+        public string? method { get; set; }
+        public string? payload { get; set; }
+    }
+}


### PR DESCRIPTION
This is done by accepting json messages from the test runtime.js, which
are of the form `{ method: 'console.debug', payload: 'foo bar' }`.