### PR TITLE
Add option to set expected exit code for Android instrumentation

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public Dictionary<string, string> InstrumentationArguments { get; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Exit code returned by the instrumentation for a successful run. Defaults to 0.
+        /// </summary>
+        public int ExpectedExitCode { get; set; } = (int)Microsoft.DotNet.XHarness.Common.CLI.ExitCode.SUCCESS;
+
         protected override OptionSet GetTestCommandOptions() => new OptionSet
         {
             { "device-arch=", "If specified, only run on a device with the listed architecture (x86, x86-64, or arm64-v8a).  Otherwise infer from supplied APK",
@@ -50,6 +55,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             },
             { "instrumentation:|i:", "If specified, attempt to run instrumentation with this name instead of the default for the supplied APK.",
                 v => InstrumentationName = v
+            },
+            { "expected-exit-code:", "If specified, sets the expected exit code for a successful instrumentation run.",
+                v => ExpectedExitCode = Convert.ToInt32(v)
             },
             { "package-name=|p=", "Package name contained within the supplied APK",
                 v => PackageName = v

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -180,9 +180,9 @@ Arguments:
                     runner.UninstallApk(apkPackageName);
                 }
 
-                if (instrumentationExitCode != (int)ExitCode.SUCCESS)
+                if (instrumentationExitCode != _arguments.ExpectedExitCode)
                 {
-                    logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}");
+                    logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {_arguments.ExpectedExitCode}");
                 }
                 else
                 {


### PR DESCRIPTION
This is necessary so we can run the runtime tests from dotnet/runtime since they use exit code 100 to signal "success".