### PR TITLE
WasmTestMessagesProcessor: Avoid throwing exception for non-JSON messages

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -32,12 +32,20 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         {
             WasmLogMessage? logMessage = null;
             string line;
-            try
+
+            if (message.StartsWith("{"))
             {
-                logMessage = JsonSerializer.Deserialize<WasmLogMessage>(message);
-                line = logMessage?.payload ?? message.TrimEnd();
+                try
+                {
+                    logMessage = JsonSerializer.Deserialize<WasmLogMessage>(message);
+                    line = logMessage?.payload ?? message.TrimEnd();
+                }
+                catch (JsonException)
+                {
+                    line = message.TrimEnd();
+                }
             }
-            catch (JsonException)
+            else
             {
                 line = message.TrimEnd();
             }


### PR DESCRIPTION
Check first whether the message can be JSON before trying to deserialize it. This avoids throwing a lot of JsonException's for non-JSON messages.

/cc @radical 