### PR TITLE
Correctly use Process.WaitForExit() in AdbProcessManager

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
@@ -67,27 +67,33 @@ namespace Microsoft.DotNet.XHarness.Android.Execution
             p.BeginOutputReadLine();
             p.BeginErrorReadLine();
 
-            // Sleeping 1 second allows the process time to send messages to the above delegates
-            // if the process exits very quickly
-            Thread.Sleep(1000);
-
             bool timedOut = false;
+            int exitCode = -1;
 
             // (int.MaxValue ms is about 24 days).  Large values are effectively timeouts for the outer harness
             if (!p.WaitForExit((int)Math.Min(timeOut.TotalMilliseconds, int.MaxValue)))
             {
                 _log.LogError("Waiting for command timed out: execution may be compromised.");
                 timedOut = true;
+
+                // try to terminate the process
+                try { p.Kill (); } catch { }
+            }
+            else
+            {
+                // we exited normally, call WaitForExit() again to ensure redirected standard output is processed
+                p.WaitForExit();
+                exitCode = p.ExitCode;
             }
 
-            // Lock the stringbuilders used as rarely this can cause concurrency issues
-            // resulting in "Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'chunkLength')"
+            p.Close();
+
             lock (standardOut)
                 lock (standardErr)
                 {
                     return new ProcessExecutionResults()
                     {
-                        ExitCode = p.ExitCode,
+                        ExitCode = exitCode,
                         StandardOutput = standardOut.ToString(),
                         StandardError = standardErr.ToString(),
                         TimedOut = timedOut

--- a/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
@@ -68,13 +68,14 @@ namespace Microsoft.DotNet.XHarness.Android.Execution
             p.BeginErrorReadLine();
 
             bool timedOut = false;
-            int exitCode = -1;
+            int exitCode;
 
             // (int.MaxValue ms is about 24 days).  Large values are effectively timeouts for the outer harness
             if (!p.WaitForExit((int)Math.Min(timeOut.TotalMilliseconds, int.MaxValue)))
             {
                 _log.LogError("Waiting for command timed out: execution may be compromised.");
                 timedOut = true;
+                exitCode = (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT;
 
                 // try to terminate the process
                 try { p.Kill (); } catch { }


### PR DESCRIPTION
We were missing a call to the parameter-less Process.WaitForExit() since the [docs](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netcore-3.1#System_Diagnostics_Process_WaitForExit) state:

> This overload ensures that all processing has been completed, including the handling of asynchronous events for redirected standard output. You should use this overload after a call to the WaitForExit(Int32) overload when standard output has been redirected to asynchronous event handlers.

Should help with https://github.com/dotnet/xharness/issues/338
