### PR TITLE
Run "adb bugreport" when instrumentation process crashes

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -111,6 +111,23 @@ namespace Microsoft.DotNet.XHarness.Android
             }
         }
 
+        public void DumpBugReport(string outputFilePath)
+        {
+            // give some time for bug report to be available
+            Thread.Sleep(3000);
+
+            var result = RunAdbCommand($"bugreport {outputFilePath}", TimeSpan.FromMinutes(5));
+            if (result.ExitCode != 0)
+            {
+                // Could throw here, but it would tear down a possibly otherwise acceptable execution.
+                _log.LogError($"Error getting ADB bugreport:{Environment.NewLine}{result}");
+            }
+            else
+            {
+                _log.LogInformation($"Wrote ADB bugreport to {outputFilePath}");
+            }
+        }
+
         public void WaitForDevice()
         {
             // This command waits for ANY kind of device to be available (emulator or real)

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -79,6 +79,17 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
         }
 
         [Fact]
+        public void DumpBugReport()
+        {
+            var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
+            string pathToDumpBugReport = Path.Join(s_scratchAndOutputPath, $"{Path.GetRandomFileName()}.zip");
+            runner.DumpBugReport(pathToDumpBugReport);
+            _processManager.Verify(pm => pm.Run(s_adbPath, $"bugreport {pathToDumpBugReport}", TimeSpan.FromMinutes(5)), Times.Once);
+
+            Assert.Equal("Sample BugReport Output", File.ReadAllText(pathToDumpBugReport));
+        }
+
+        [Fact]
         public void WaitForDevice()
         {
             var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
@@ -241,6 +252,10 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
                     {
                         stdOut = "Sample LogCat Output";
                     }
+                    break;
+                case "bugreport":
+                    var outputPath = allArgs[argStart + 1];
+                    File.WriteAllText(outputPath, "Sample BugReport Output");
                     break;
                 case "install":
                 case "uninstall":


### PR DESCRIPTION
We've seen a few cases where we get `INSTRUMENTATION_RESULT: shortMsg=Process crashed.` and the adb log shows that the process crashed with a segmentation fault.
Android writes a crashdump into `/data/tombstones` but you can't just pull from there. Instead there's an adb command to create a bugreport which produces a .zip file with all sorts of info about the OS, including the tombstones.

See https://developer.android.com/studio/debug/bug-report.html