### PR TITLE
Wasm make *.Run async.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
@@ -19,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
         protected virtual IEnumerable<string> IncludedMethods { get; set; } = Array.Empty<string>();
         protected virtual IEnumerable<string> IncludedNamespaces { get; set; } = Array.Empty<string>();
 
-        public int Run()
+        public async Task<int> Run()
         {
             var testRunner = new ThreadlessXunitTestRunner();
             var filters = new XunitFilters();
@@ -30,7 +31,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             foreach (var cl in IncludedClasses) filters.IncludedClasses.Add(cl);
             foreach (var me in IncludedMethods) filters.IncludedMethods.Add(me);
 
-            var result = testRunner.Run(TestAssembly, printXml: true, filters);
+            var result = await testRunner.Run(TestAssembly, printXml: true, filters);
 
             return result;
         }


### PR DESCRIPTION
Make make the Run in the threadless runner and WasmApplicationEntry point async so that it can yield back to js to resolve promises correctly.  Depends on https://github.com/dotnet/runtime/pull/44045 helps fix https://github.com/dotnet/runtime/issues/43958