### PR TITLE
[wasm][test-browser] Improve logging, and try to be more resilient to errors

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         }
                         catch (Exception ex) when (_messagesProcessor.WasmExitReceivedTcs.Task.IsCompletedSuccessfully)
                         {
-                            _logger.LogWarning($"Test has return a result already, but message processor threw {ex} while logging message: {line}");
+                            _logger.LogWarning($"Test has returned a result already, but message processor threw {ex} while logging message: {line}");
                         }
                     }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -164,7 +164,14 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
                         line += Environment.NewLine;
 
-                        _messagesProcessor.Invoke(line);
+                        try
+                        {
+                            _messagesProcessor.Invoke(line);
+                        }
+                        catch (Exception ex) when (_messagesProcessor.WasmExitReceivedTcs.Task.IsCompletedSuccessfully)
+                        {
+                            _logger.LogWarning($"Test has return a result already, but message processor threw {ex} while logging message: {line}");
+                        }
                     }
 
                     mem.SetLength(0);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -164,14 +164,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
                         line += Environment.NewLine;
 
-                        try
-                        {
-                            _messagesProcessor.Invoke(line);
-                        }
-                        catch (Exception ex) when (_messagesProcessor.WasmExitReceivedTcs.Task.IsCompletedSuccessfully)
-                        {
-                            _logger.LogWarning($"Test has returned a result already, but message processor threw {ex} while logging message: {line}");
-                        }
+                        _messagesProcessor.Invoke(line);
                     }
 
                     mem.SetLength(0);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -67,9 +67,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var options = new ChromeOptions();
             options.SetLoggingPreference(LogType.Browser, SeleniumLogLevel.All);
 
-            // Enable this for more debugging info
-            options.SetLoggingPreference(LogType.Driver, SeleniumLogLevel.All);
-
             options.AddArguments(new List<string>(_arguments.BrowserArgs)
             {
                 "--incognito",
@@ -92,6 +89,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
             var driverService = ChromeDriverService.CreateDefaultService();
             driverService.EnableVerboseLogging = true;
+            driverService.LogPath = Path.Combine(_arguments.OutputDirectory, "driver.log");
 
             // We want to explicitly specify a timeout here. This is for for the
             // driver commands, like getLog. The default is 60s, which ends up

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -30,6 +30,19 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
         public void Invoke(string message)
         {
+            try
+            {
+                InvokeInternal(message);
+            }
+            catch (Exception ex) when (WasmExitReceivedTcs.Task.IsCompletedSuccessfully)
+            {
+                _logger.LogWarning($"Test has returned a result already, but the message processor threw {ex.GetType()},"
+                                    + $" while logging the message: {message}{Environment.NewLine}{ex}");
+            }
+        }
+
+        private void InvokeInternal(string message)
+        {
             WasmLogMessage? logMessage = null;
             string line;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -79,7 +79,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     }
                 }
 
-                _stdoutFileWriter.WriteLine(line);
+                if (_stdoutFileWriter.BaseStream.CanWrite)
+                    _stdoutFileWriter.WriteLine(line);
             }
             else
             {
@@ -90,7 +91,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     _xmlResultsFileWriter = null;
                     return;
                 }
-                _xmlResultsFileWriter.WriteLine(line);
+
+                if (_xmlResultsFileWriter?.BaseStream.CanWrite == true)
+                    _xmlResultsFileWriter.WriteLine(line);
             }
 
             // the test runner writes this as the last line,


### PR DESCRIPTION
This tries to handle new failures seen on CI after the last update to add verbose logging.

```
[13:08:27] crit: System.AggregateException: One or more errors occurred. (Cannot access a closed file.)
                  ---> System.ObjectDisposedException: Cannot access a closed file.
                    at System.IO.FileStream.ValidateReadWriteArgs(Byte[] array, Int32 offset, Int32 count)
                    at System.IO.FileStream.Write(Byte[] array, Int32 offset, Int32 count)
                    at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
                    at System.IO.StreamWriter.WriteLine(String value)
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestMessagesProcessor.Invoke(String message) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs:line 103
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmBrowserTestRunner.RunSeleniumLogMessagePump(IWebDriver driver, CancellationToken token) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs:line 203
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmBrowserTestRunner.<>c__DisplayClass6_0.<RunTestsWithWebDriver>b__0() in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs:line 72
                    at System.Threading.Tasks.Task.InnerInvoke()
                    at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
                    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
                 --- End of stack trace from previous location where exception was thrown ---
                    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
                    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
                    --- End of inner exception stack trace ---
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmBrowserTestRunner.RunTestsWithWebDriver(DriverService driverService, IWebDriver driver) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs:line 128
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.InvokeInternal(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs:line 56
                    at Microsoft.DotNet.XHarness.Common.CLI.Commands.XHarnessCommand.Invoke(IEnumerable`1 arguments) in /_/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs:line 120
XHarness exit code: 1001
```