### PR TITLE
Improve error message when Xcode is not found

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     {
                         throw new Exception(
                             $"Failed to find Xcode! Version.plist missing at {plistPath}. " +
-                            "Please make sure xcode-select is set up or the path to Xcode is suplied as argument.");
+                            "Please make sure xcode-select is set up, or the path to Xcode is supplied as an argument.");
                     }
                 }
                 return _xcode_version;

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     {
                         throw new Exception(
                             $"Failed to find Xcode! Version.plist missing at {plistPath}. " +
-                            $"Please make sure xcode-select is set up or the path to Xcode is suplied as argument.");
+                            "Please make sure xcode-select is set up or the path to Xcode is suplied as argument.");
                     }
                 }
                 return _xcode_version;

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -40,8 +40,19 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                 if (_xcode_version == null)
                 {
                     var doc = new XmlDocument();
-                    doc.Load(Path.Combine(XcodeRoot, "Contents", "version.plist"));
-                    _xcode_version = Version.Parse(doc.SelectSingleNode("//key[text() = 'CFBundleShortVersionString']/following-sibling::string").InnerText);
+                    var plistPath = Path.Combine(XcodeRoot, "Contents", "version.plist");
+
+                    try
+                    {
+                        doc.Load(plistPath);
+                        _xcode_version = Version.Parse(doc.SelectSingleNode("//key[text() = 'CFBundleShortVersionString']/following-sibling::string").InnerText);
+                    }
+                    catch (IOException)
+                    {
+                        throw new Exception(
+                            $"Failed to find Xcode! Version.plist missing at {plistPath}. " +
+                            $"Please make sure xcode-select is set up or the path to Xcode is suplied as argument.");
+                    }
                 }
                 return _xcode_version;
             }


### PR DESCRIPTION
This improves the experience when `xcode-select` points somewhere bad (like xcode command tools).

https://github.com/dotnet/xharness/issues/337