### PR TITLE
Dont capture entire iOS simulator logs, only during test

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                 var simulatorLog = _captureLogFactory.Create(
                     path: Path.Combine(_logs.Directory, simulator.Name + ".log"),
                     systemLogPath: simulator.SystemLog,
-                    entireFile: true,
+                    entireFile: false,
                     LogType.SystemLog.ToString());
 
                 simulatorLog.StartCapture();
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                     var companionLog = _captureLogFactory.Create(
                         path: Path.Combine(_logs.Directory, companionSimulator.Name + ".log"),
                         systemLogPath: companionSimulator.SystemLog,
-                        entireFile: true,
+                        entireFile: false,
                         LogType.CompanionSystemLog.ToString());
 
                     companionLog.StartCapture();

--- a/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Tests/AppRunnerTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Tests
                 .Setup(x => x.Create(
                    Path.Combine(_logs.Object.Directory, simulator.Object.Name + ".log"),
                    simulator.Object.SystemLog,
-                   true,
+                   false,
                    It.IsAny<string>()))
                 .Returns(captureLog.Object);
 


### PR DESCRIPTION
Full iOS simulator log can have 2+MB while we are interested only in the part when we were running the current app.
We also don't want logs from previous runs of different apps.

Also remove some dead code from device log capturer.