### PR TITLE
Do not log the full XML when listing simulators

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -81,9 +81,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                         $"mlaunch {(result.TimedOut ? "timed out" : "exited")} with {result.ExitCode})");
                 }
 
-                var xmlContent = File.ReadAllText(tmpfile);
-
-                log.WriteLine($"Simulator listing finished ({Math.Ceiling(((double)Encoding.UTF8.GetByteCount(xmlContent)) / 1024)} kB)");
+                log.WriteLine($"Simulator listing finished ({Math.Ceiling(((double)fileInfo.Length) / 1024)} kB)");
 
                 var simulatorData = new XmlDocument();
                 simulatorData.LoadWithoutNetworkAccess(tmpfile);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 
                 var xmlContent = File.ReadAllText(tmpfile);
 
-                log.WriteLine("Simulator listing returned:" + Environment.NewLine + xmlContent);
+                log.WriteLine($"Simulator listing finished ({Math.Ceiling(((double)Encoding.UTF8.GetByteCount(xmlContent)) / 1024)} kB)");
 
                 var simulatorData = new XmlDocument();
                 simulatorData.LoadWithoutNetworkAccess(tmpfile);


### PR DESCRIPTION
We have this output in a separate file, it is not as important and only clutters the logs. 