### PR TITLE
Log exiting process' name

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -334,7 +334,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             try
             {
                 result.ExitCode = process.ExitCode;
-                log.WriteLine($"Process exited with {result.ExitCode}");
+                log.WriteLine($"Process {Path.GetFileName(process.StartInfo.FileName)} exited with {result.ExitCode}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This makes log more readable for some cases where it wasn't clear what process that was (iOS, mlaunch, lldb...)