### PR TITLE
[wasm][test-browser] Add another case for retrying chromedriver launch

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using OpenQA.Selenium.Chrome;
 using SeleniumLogLevel = OpenQA.Selenium.LogLevel;
 using OpenQA.Selenium;
+using System.Linq;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 {
@@ -101,6 +102,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             //
             // So -> use a larger timeout!
 
+            string[] err_snippets = new []
+            {
+                "exited abnormally",
+                "Cannot start the driver service"
+            };
+
             int max_retries = 3;
             int retry_num = 0;
             while(true)
@@ -109,11 +116,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 {
                     return (driverService, new ChromeDriver(driverService, options, _arguments.Timeout));
                 }
-                catch (WebDriverException wde) when (wde.Message.Contains("exited abnormally") && retry_num < max_retries - 1)
+                catch (WebDriverException wde) when (err_snippets.Any(s => wde.Message.Contains(s)) && retry_num < max_retries - 1)
                 {
                     // chrome can sometimes crash on startup when launching from chromedriver.
                     // As a *workaround*, let's retry that a few times
-                    // Error seen:
+                    // Example error seen:
                     //     [12:41:07] crit: OpenQA.Selenium.WebDriverException: unknown error: Chrome failed to start: exited abnormally.
                     //    (chrome not reachable)
 


### PR DESCRIPTION
In some test runs, launching chromedriver failed
with (https://github.com/dotnet/runtime/issues/44862):

```
Connection refused Connection refused
Connection refused Connection refused
[00:03:37] crit: OpenQA.Selenium.WebDriverException: Cannot start the driver service on http://localhost:37245/
                    at OpenQA.Selenium.DriverService.Start()
                    at OpenQA.Selenium.Remote.DriverServiceCommandExecutor.Execute(Command commandToExecute)
                    at OpenQA.Selenium.Remote.RemoteWebDriver.Execute(String driverCommandToExecute, Dictionary`2 parameters)
                    at OpenQA.Selenium.Remote.RemoteWebDriver.StartSession(ICapabilities desiredCapabilities)
                    at OpenQA.Selenium.Remote.RemoteWebDriver..ctor(ICommandExecutor commandExecutor, ICapabilities desiredCapabilities)
                    at OpenQA.Selenium.Chromium.ChromiumDriver..ctor(ChromiumDriverService service, ChromiumOptions options, TimeSpan commandTimeout)
                    at OpenQA.Selenium.Chrome.ChromeDriver..ctor(ChromeDriverService service, ChromeOptions options, TimeSpan commandTimeout)
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.GetChromeDriver(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs:line 110
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.InvokeInternal(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs:line 53
                    at Microsoft.DotNet.XHarness.Common.CLI.Commands.XHarnessCommand.Invoke(IEnumerable`1 arguments) in /_/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs:line 120
XHarness exit code: 71
```

As a way to handle this, we'll retry if the exception message contains
the string `"Cannot start the driver service"`.