### PR TITLE
Fix target name in logs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppRunner.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.XHarness.iOS
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, crashLogs, isDevice: !isSimulator, deviceName);
 
-            _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target} '{deviceName}' ***");
+            _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{deviceName}' ***");
 
             if (isSimulator)
             {

--- a/src/Microsoft.DotNet.XHarness.iOS/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS/AppTester.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.XHarness.iOS
                 .ContinueWith(testReporter.LaunchCallback)
                 .DoNotAwait();
 
-            _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target} '{deviceName}' ***");
+            _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{deviceName}' ***");
 
             try
             {


### PR DESCRIPTION
Log `ios-simulator-64_13.5` instead of `Microsoft.DotNet.XHarness.iOS.Shared.TestTargetOs`