### PR TITLE
Address https://github.com/dotnet/runtime/issues/45428 

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/Execution/IAdbProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/Execution/IAdbProcessManager.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.Android.Execution
             output.AppendLine($"Standard Output:{Environment.NewLine}{StandardOutput}");
             if (!string.IsNullOrEmpty(StandardError))
             {
-                output.AppendLine($"Standard Error:{Environment.NewLine}{StandardOutput}");
+                output.AppendLine($"Standard Error:{Environment.NewLine}{StandardError}");
             }
             return output.ToString();
         }


### PR DESCRIPTION
There seems to be a mystery state where the install cache is full or something, rebooting device helps.  

Also improve wait-for-device to actually check the boot_completed property (exposed by rebooting devices) and fix standard error logging bug pointed out by @akoeplinger that's been there forever.

Since the state is mysterious, I prototyped an "always reboot the device" version of Xharness and ran it several times [Sample log](https://helixre107v0xdeko0k025g8.blob.core.windows.net/results-6eb79d1a38ae42e59a/xharness-reboot-testing-1/console.f2c8185b.log?sv=2019-07-07&se=2020-12-22T00%3A35%3A55Z&sr=c&sp=rl&sig=9as0prf6CjZ9nJmqpyxlEPszi57R7gV68qs%2B7EZ%2BFEw%3D) to be sure the concept here works (logging has been cleaned up a bit)