### PR TITLE
Fixes for Xharness issues 354(again), 385, and 389

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.XHarness.Android
             }
         }
 
-        public void WaitForDevice()
+        public void WaitForDevice(int timeToWaitForBootCompletionSeconds = 300)
         {
             // This command waits for ANY kind of device to be available (emulator or real)
             // Needed because emulators start up asynchronously and take a while.
@@ -148,16 +148,27 @@ namespace Microsoft.DotNet.XHarness.Android
                 throw new Exception($"Error waiting for Android device/emulator.  Std out:{result.StandardOutput} Std. Err: {result.StandardError}.  Do you need to set the current device?");
             }
 
-            // Once wait-for-device returns, we'll give it up to 30s for 'adb shell getprop sys.boot_completed' to be '1' (as opposed to empty) to make package managers happy
+            // Some users will be installing the emulator and immediately calling xharness, they need to be able to expect the device is ready to load APKs.
+            // Once wait-for-device returns, we'll give it up to timeToWaitForBootCompletionSeconds seconds (default 5 min) for 'adb shell getprop sys.boot_completed'
+            // to be '1' (as opposed to empty) to make subsequent automation happy.
+            var began = DateTimeOffset.UtcNow;
+            var waitingUntil = began.AddSeconds(timeToWaitForBootCompletionSeconds);
             var bootCompleted = RunAdbCommand($"shell getprop {AdbShellPropertyForBootCompletion}");
 
-            int triesLeft = 3;
-            while (!bootCompleted.StandardOutput.Trim().StartsWith("1") && triesLeft > 1)
+            while (!bootCompleted.StandardOutput.Trim().StartsWith("1") && DateTimeOffset.UtcNow < waitingUntil)
             {
                 bootCompleted = RunAdbCommand($"shell getprop {AdbShellPropertyForBootCompletion}");
                 _log.LogDebug($"{AdbShellPropertyForBootCompletion} = '{bootCompleted.StandardOutput.Trim()}'");
                 Thread.Sleep((int)TimeSpan.FromSeconds(10).TotalMilliseconds);
-                triesLeft--;
+            }
+
+            if (bootCompleted.StandardOutput.Trim().StartsWith("1"))
+            {
+                _log.LogDebug($"Waited {DateTimeOffset.UtcNow.Subtract(began).TotalSeconds} seconds for device for {AdbShellPropertyForBootCompletion} to be 1.");
+            }
+            else
+            {
+                _log.LogWarning($"Did not detect boot completion variable on device; variable used ('{AdbShellPropertyForBootCompletion}') may be incorrect or device may be in a bad state");
             }
         }
 
@@ -182,7 +193,6 @@ namespace Microsoft.DotNet.XHarness.Android
 
         public int InstallApk(string apkPath)
         {
-            bool needToRetry = false;
             _log.LogInformation($"Attempting to install {apkPath}: ");
             if (string.IsNullOrEmpty(apkPath))
             {
@@ -206,7 +216,7 @@ namespace Microsoft.DotNet.XHarness.Android
                 result = RunAdbCommand($"install \"{apkPath}\"");
             }
 
-            // 2. Installation cache on device is messed up; restrting the device reliably seems to unblock this (unless the device is actually full, if so this will error the same)
+            // 2. Installation cache on device is messed up; restarting the device reliably seems to unblock this (unless the device is actually full, if so this will error the same)
             if (result.ExitCode != (int)AdbExitCodes.SUCCESS && result.StandardError.Contains(AdbDeviceFullInstallFailureMessage))
             {
                 _log.LogWarning($"It seems the package installation cache may be full on the device.  We'll try to reboot it before trying one more time.{Environment.NewLine}Output:{result}");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -269,8 +269,6 @@ Arguments:
                 logger.LogError($"No devices found with architecture '{apkRequiredArchitecture}'.");
                 return null;
             }
-
-            return null;
         }
 
         private (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(ILogger logger, string stdOut)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.Common.CLI.Commands;
+using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
@@ -95,7 +96,14 @@ Arguments:
 
                     // enumerate the devices attached and their architectures
                     // Tell ADB to only use that one (will always use the present one for systems w/ only 1 machine)
-                    runner.SetActiveDevice(GetDeviceToUse(logger, runner, apkRequiredArchitecture));
+                    var deviceToUse = GetDeviceToUse(logger, runner, apkRequiredArchitecture);
+
+                    if (deviceToUse== null)
+                    {
+                        return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
+                    }
+
+                    runner.SetActiveDevice(deviceToUse);
 
                     // Wait til at least device(s) are ready
                     runner.WaitForDevice();
@@ -120,6 +128,7 @@ Arguments:
                 // No class name = default Instrumentation
                 ProcessExecutionResults? result = runner.RunApkInstrumentation(apkPackageName, _arguments.InstrumentationName, _arguments.InstrumentationArguments, _arguments.Timeout);
                 bool processCrashed = false;
+                bool failurePullingFiles = false;
 
                 using (logger.BeginScope("Post-test copy and cleanup"))
                 {
@@ -136,7 +145,15 @@ Arguments:
                             if (resultValues.ContainsKey(possibleResultKey))
                             {
                                 logger.LogInformation($"Found XML result file: '{resultValues[possibleResultKey]}'(key: {possibleResultKey})");
-                                runner.PullFiles(resultValues[possibleResultKey], _arguments.OutputDirectory);
+                                try
+                                {
+                                    runner.PullFiles(resultValues[possibleResultKey], _arguments.OutputDirectory);
+                                }
+                                catch (Exception toLog)
+                                {
+                                    logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", resultValues[possibleResultKey]);
+                                    failurePullingFiles = true;
+                                }
                             }
                         }
                         if (resultValues.ContainsKey(TestRunSummaryVariableName))
@@ -174,10 +191,18 @@ Arguments:
                     // Optionally copy off an entire folder
                     if (!string.IsNullOrEmpty(_arguments.DeviceOutputFolder))
                     {
-                        var logs = runner.PullFiles(_arguments.DeviceOutputFolder, _arguments.OutputDirectory);
-                        foreach (string log in logs)
+                        try
                         {
-                            logger.LogDebug($"Found output file: {log}");
+                            var logs = runner.PullFiles(_arguments.DeviceOutputFolder, _arguments.OutputDirectory);
+                            foreach (string log in logs)
+                            {
+                                logger.LogDebug($"Found output file: {log}");
+                            }
+                        }
+                        catch (Exception toLog)
+                        {
+                            logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", _arguments.DeviceOutputFolder);
+                            failurePullingFiles = true;
                         }
                     }
 
@@ -195,6 +220,11 @@ Arguments:
                 {
                     logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {_arguments.ExpectedExitCode}");
                 }
+                else if (failurePullingFiles)
+                {
+                    logger.LogError($"Received expected instrumentation exit code ({instrumentationExitCode}), but we hit errors pulling files from the device (see log for details.)");
+                    return Task.FromResult(ExitCode.DEVICE_FILE_COPY_FAILURE);
+                }
                 else
                 {
                     return Task.FromResult(ExitCode.SUCCESS);
@@ -210,22 +240,30 @@ Arguments:
 
         private string? GetDeviceToUse(ILogger logger, AdbRunner runner, string apkRequiredArchitecture)
         {
-            var allDevicesAndTheirArchitectures = runner.GetAttachedDevicesAndArchitectures();
-            if (allDevicesAndTheirArchitectures.Count > 0)
+            try
             {
-                if (allDevicesAndTheirArchitectures.Any(kvp => kvp.Value != null && kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)))
+                var allDevicesAndTheirArchitectures = runner.GetAttachedDevicesAndArchitectures();
+                if (allDevicesAndTheirArchitectures.Count > 0)
                 {
-                    var firstAvailableCompatible = allDevicesAndTheirArchitectures.Where(kvp => kvp.Value != null && kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                    logger.LogInformation($"Using first-found compatible device of {allDevicesAndTheirArchitectures.Count} total- serial: '{firstAvailableCompatible.Key}' - Arch: {firstAvailableCompatible.Value}");
-                    return firstAvailableCompatible.Key;
+                    if (allDevicesAndTheirArchitectures.Any(kvp => kvp.Value != null && kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        var firstAvailableCompatible = allDevicesAndTheirArchitectures.Where(kvp => kvp.Value != null && kvp.Value.Equals(apkRequiredArchitecture, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                        logger.LogInformation($"Using first-found compatible device of {allDevicesAndTheirArchitectures.Count} total- serial: '{firstAvailableCompatible.Key}' - Arch: {firstAvailableCompatible.Value}");
+                        return firstAvailableCompatible.Key;
+                    }
+                    else
+                    {
+                        // In this case, the enumeration worked but nothing matched the APK; fail out.
+                        logger.LogError($"No devices found with architecture '{apkRequiredArchitecture}'.");
+                        return null;
+                    }
                 }
-                else
-                {
-                    logger.LogWarning($"No devices found with architecture '{apkRequiredArchitecture}'.  Just returning first available device; installation will likely fail, but we'll try anyways.");
-                    return allDevicesAndTheirArchitectures.Keys.First();
-                }
+                logger.LogError("No attached device detected");
             }
-            logger.LogError("No attached device detected");
+            catch (Exception toLog)
+            {
+                logger.LogError(toLog, "Exception thrown while trying to find compatible device with architecture [architecture]", apkRequiredArchitecture);
+            }
             return null;
         }
 

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
@@ -51,6 +51,8 @@ namespace Microsoft.DotNet.XHarness.Common.CLI
         DEVICE_NOT_FOUND = 81,
         RETURN_CODE_NOT_SET = 82,
         APP_LAUNCH_FAILURE = 83,
+        DEVICE_FILE_COPY_FAILURE = 84,
+        ADB_DEVICE_ENUMERATION_FAILURE = 85,
 
         #endregion
     }


### PR DESCRIPTION
- Make failure to pull files or enumerate devices fail instead of warning.
- Detect an alternative version of the broken pipe issue (same recourse)
- Fail, and introduce exit code for inability to enumerate devices ; we'll do an infra retry and reboot to recover from this in Arcade.

https://github.com/dotnet/xharness/issues/384
https://github.com/dotnet/xharness/issues/385
https://github.com/dotnet/xharness/issues/389
