### PR TITLE
Add the expected exit code argument to the wasm test command

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -41,6 +41,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 
         public string JSFile { get; set; } = "runtime.js";
 
+        public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
+
         protected override OptionSet GetTestCommandOptions() => new OptionSet{
             { "engine=|e=", "Specifies the JavaScript engine to be used",
                 v => Engine = ParseArgument<JavaScriptEngine>("engine", v)
@@ -50,6 +52,17 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             },
             { "js-file=", "Main JavaScript file to be run on the JavaScript engine. Default is runtime.js",
                 v => JSFile = v
+            },
+            { "expected-exit-code=", "If specified, sets the expected exit code for a successful instrumentation run.",
+                v => {
+                    if (int.TryParse(v, out var number))
+                    {
+                        ExpectedExitCode = number;
+                        return;
+                    }
+
+                    throw new ArgumentException("expected-exit-code must be an integer");
+                }
             },
         };
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -78,8 +78,17 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     stdoutLog: new CallbackLog(logProcessor.Invoke) { Timestamp = false /* we need the plain XML string so disable timestamp */ },
                     stderrLog: new CallbackLog(m => logger.LogError(m)),
                     _arguments.Timeout);
-
-                return result.Succeeded ? ExitCode.SUCCESS : (result.TimedOut ? ExitCode.TIMED_OUT : ExitCode.GENERAL_FAILURE);
+                if (result.ExitCode != _arguments.ExpectedExitCode)
+                {
+                    logger.LogError($"Application has finished with exit code {result.ExitCode} but {_arguments.ExpectedExitCode} was expected");
+                        return ExitCode.GENERAL_FAILURE;
+                    
+                }
+                else
+                {
+                    logger.LogInformation("Application has finished with exit code: " + result.ExitCode);
+                    return ExitCode.SUCCESS;
+                }
             }
             catch (Win32Exception e) when (e.NativeErrorCode == 2)
             {


### PR DESCRIPTION
This pull request adds `--expected-exit-code` argument to the `wasm test` command. It will allow to validate the result of the wasm functional test as we do for other platforms (ios, android). 