### PR TITLE
[wasm] Add support for testing with Safari

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
@@ -17,7 +18,12 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         /// <summary>
         /// Chrome
         /// </summary>
-        Chrome
+        Chrome,
+
+        /// <summary>
+        /// Safari
+        /// </summary>
+        Safari
     }
 
     internal class WasmTestBrowserCommandArguments : TestCommandArguments
@@ -42,6 +48,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public override void Validate()
         {
             base.Validate();
+
+            if (Browser == Browser.Safari && !RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                throw new ArgumentException("Safari is only supported on OSX");
+            }
 
             if (!Directory.Exists(AppPackagePath))
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                         var p = Process.GetProcessById(pid);
                         if (p != null)
                         {
-                            _logger.LogDebug($"Tests timed out. Killing chrome pid {pid}");
+                            _logger.LogDebug($"Tests timed out. Killing driver service pid {pid}");
                             p.Kill(true);
                         }
                     }


### PR DESCRIPTION
Use `--browser=safari`

This uses `safaridriver`, and before the first use, it needs to be enabled with: `safaridriver --enable`.
See: https://developer.apple.com/documentation/webkit/testing_with_webdriver_in_safari