### PR TITLE
[wasm] Add support for testing with Firefox

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -23,7 +23,12 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         /// <summary>
         /// Safari
         /// </summary>
-        Safari
+        Safari,
+
+        /// <summary>
+        /// Firefox
+        /// </summary>
+        Firefox
     }
 
     internal class WasmTestBrowserCommandArguments : TestCommandArguments


### PR DESCRIPTION
Use --browser=firefox

- Requires gecko driver [Github repository of Mozilla](https://github.com/mozilla/geckodriver/releases)

Closes https://github.com/dotnet/runtime/issues/47038