### PR TITLE
Make sure the MacCatalyst app's binary is executable

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
@@ -79,7 +79,17 @@ namespace Microsoft.DotNet.XHarness.Apple
             var binaryPath = Path.Combine(appInfo.AppPath, "Contents", "MacOS", appInfo.BundleExecutable ?? appInfo.AppName);
             var arguments = new List<string>();
 
-            if (!File.Exists(binaryPath))
+            if (File.Exists(binaryPath))
+            {
+                // We need to make the binary executable
+                var result = await _processManager.ExecuteCommandAsync("chmod", new[] { "+x", binaryPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
+
+                if (!result.Succeeded)
+                {
+                    _mainLog.WriteLine($"Failed to make the binary at {binaryPath} executable, the run might fail");
+                }
+            }
+            else
             {
                 _mainLog.WriteLine($"Failed to find an executable binary at {binaryPath}. Trying to run app using `open -W`");
                 binaryPath = "open";


### PR DESCRIPTION
I found this problem when trying to run a runtime-built app on Helix