### PR TITLE
Run MacCatalyst via `open w` and detect exit code from logs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
@@ -76,26 +76,18 @@ namespace Microsoft.DotNet.XHarness.Apple
                 entireFile: false,
                 LogType.SystemLog);
 
+            // We need to make the binary executable
             var binaryPath = Path.Combine(appInfo.AppPath, "Contents", "MacOS", appInfo.BundleExecutable ?? appInfo.AppName);
-            var arguments = new List<string>();
-
             if (File.Exists(binaryPath))
             {
-                // We need to make the binary executable
-                var result = await _processManager.ExecuteCommandAsync("chmod", new[] { "+x", binaryPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
+                await _processManager.ExecuteCommandAsync("chmod", new[] { "+x", binaryPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
+            }
 
-                if (!result.Succeeded)
-                {
-                    _mainLog.WriteLine($"Failed to make the binary at {binaryPath} executable, the run might fail");
-                }
-            }
-            else
+            var arguments = new List<string>
             {
-                _mainLog.WriteLine($"Failed to find an executable binary at {binaryPath}. Trying to run app using `open -W`");
-                binaryPath = "open";
-                arguments.Add("-W");
-                arguments.Add(appInfo.LaunchAppPath);
-            }
+                "-W",
+                appInfo.LaunchAppPath
+            };
 
             arguments.AddRange(appArguments);
 
@@ -107,7 +99,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             try
             {
-                return await _processManager.ExecuteCommandAsync(binaryPath, arguments, _mainLog, timeout, envVars, cancellationToken);
+                return await _processManager.ExecuteCommandAsync("open", arguments, _mainLog, timeout, envVars, cancellationToken);
             }
             finally
             {

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         {
             var appBundleInformation = new AppBundleInformation("HelloiOS", "HelloiOS", "some/path", "some/path", false, null);
 
-            var detector = new ExitCodeDetector();
+            var detector = new iOSExitCodeDetector();
 
             var log = new[]
             {
@@ -36,11 +36,43 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         }
 
         [Fact]
+        public void ExitCodeIsDetectedOnMacCatalystTest()
+        {
+            var appBundleInformation = new AppBundleInformation("System.Buffers.Tests", "net.dot.System.Buffers.Tests", "some/path", "some/path", false, null);
+
+            var detector = new MacCatalystExitCodeDetector();
+
+            var log = new[]
+            {
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - client insert callback function client = 0 type = 17 function = 0x7fff3b262246 local_olny = false",
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - client setup_remote_port",
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - Bootstrap Port: 1799",
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - Remote Port: 56835 (com.apple.CoreDisplay.Notification)",
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - client setup_local_port",
+                "Feb 18 06:40:16 Admins-Mac-Mini System.Buffers.Tests[59229]: CDN - Local Port: 78339",
+                "Feb 18 06:40:16 Admins-Mac-Mini com.apple.xpc.launchd[1] (net.dot.System.Buffers.Tests.15140[59229]): Service exited with abnormal code: 74",
+                "Feb 18 06:40:49 Admins-Mac-Mini com.apple.xpc.launchd[1] (com.apple.mdworker.shared.09000000-0600-0000-0000-000000000000[59231]): Service exited due to SIGKILL | sent by mds[88]",
+                "Feb 18 06:40:58 Admins-Mac-Mini com.apple.xpc.launchd[1] (com.apple.mdworker.shared.02000000-0100-0000-0000-000000000000[59232]): Service exited due to SIGKILL | sent by mds[88]",
+                "Feb 18 06:41:01 Admins-Mac-Mini com.apple.xpc.launchd[1] (com.apple.mdworker.shared.0D000000-0000-0000-0000-000000000000[59237]): Service exited due to SIGKILL | sent by mds[88]",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - client insert callback function client = 0 type = 17 function = 0x7fff3b262246 local_olny = false",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - client setup_remote_port",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - Bootstrap Port: 1799",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - Remote Port: 75271 (com.apple.CoreDisplay.Notification)",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - client setup_local_port",
+                "Feb 18 06:41:23 Admins-Mac-Mini System.Buffers.Tests[59248]: CDN - Local Port: 52995",
+            };
+
+            var exitCode = detector.DetectExitCode(appBundleInformation, GetLogMock(log));
+
+            Assert.Equal(74, exitCode);
+        }
+
+        [Fact]
         public void NegativeExitCodeIsDetectedTest()
         {
             var appBundleInformation = new AppBundleInformation("HelloiOS", "HelloiOS", "some/path", "some/path", false, null);
 
-            var detector = new ExitCodeDetector();
+            var detector = new iOSExitCodeDetector();
 
             var log = new[]
             {
@@ -62,7 +94,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         {
             var appBundleInformation = new AppBundleInformation("HelloiOS", "HelloiOS", "some/path", "some/path", false, null);
 
-            var detector = new ExitCodeDetector();
+            var detector = new iOSExitCodeDetector();
 
             var log = new[]
             {
@@ -109,7 +141,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             captureLog.StopCapture();
 
             var appBundleInformation = new AppBundleInformation("net.dot.HelloiOS", "net.dot.HelloiOS", "some/path", "some/path", false, null);
-            var exitCode = new ExitCodeDetector().DetectExitCode(appBundleInformation, captureLog);
+            var exitCode = new iOSExitCodeDetector().DetectExitCode(appBundleInformation, captureLog);
 
             Assert.Equal(72, exitCode);
         }


### PR DESCRIPTION
Before I dive into the investigations of why we get hangs when running the app's binary directly, we can have this solution that uses `open -w` and works in the Helix environment

This solution requires getting the exit code from the `system.log`

Resolves #462 