### PR TITLE
Wait for MacCatalyst system.log flush

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppRunnerBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             }
             finally
             {
-                systemLog.StopCapture();
+                systemLog.StopCapture(waitIfEmpty: TimeSpan.FromSeconds(10));
             }
         }
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
@@ -29,7 +30,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
     public interface ICaptureLog : IFileBackedLog
     {
         void StartCapture();
-        void StopCapture();
+        void StopCapture(TimeSpan? waitIfEmpty = null);
     }
 
     // A log that captures data written to a separate file between two moments in time
@@ -66,11 +67,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             _started = true;
         }
 
-        public void StopCapture()
+        public void StopCapture(TimeSpan? waitIfEmpty = null)
         {
             if (!_started && !_entireFile)
             {
-                throw new InvalidOperationException("StartCapture most be called before StopCature on when the entire file will be captured.");
+                throw new InvalidOperationException("StartCapture() must be called before StopCature() on when the entire file is being captured.");
             }
 
             if (!File.Exists(CapturePath))
@@ -79,13 +80,18 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
                 return;
             }
 
+            _endPosition = new FileInfo(CapturePath).Length;
+
+            if ((_endPosition == 0 || (_startPosition == _endPosition && !_entireFile)) && waitIfEmpty.HasValue)
+            {
+                Thread.Sleep((int)waitIfEmpty.Value.TotalMilliseconds);
+            }
+
             if (_entireFile)
             {
                 File.Copy(CapturePath, FullPath, true);
                 return;
             }
-
-            _endPosition = new FileInfo(CapturePath).Length;
 
             Capture();
         }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -210,7 +210,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _simulatorLoader.VerifyAll();
 
             captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
-            captureLog.Verify(x => x.StopCapture(), Times.AtLeastOnce);
 
             // When ensureCleanSimulatorState == true
             _mockSimulator.Verify(x => x.PrepareSimulator(_mainLog.Object, AppBundleIdentifier));

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -300,7 +300,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _simulatorLoader.VerifyAll();
 
             captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
-            captureLog.Verify(x => x.StopCapture(), Times.AtLeastOnce);
 
             // When ensureCleanSimulatorState == true
             _mockSimulator.Verify(x => x.PrepareSimulator(_mainLog.Object, AppBundleIdentifier));


### PR DESCRIPTION
I saw the `system.log` being empty which ends up with us not detecting the exit code.
Hopefully, this will go away when we start running the MacCatalyst binary directly and get the exit code directly too