### PR TITLE
[wasm] Search js engines in PATH

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -32,11 +32,9 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         {
         }
 
-        static readonly string[] s_extensions = { ".cmd", ".exe" };
-
-        private static string GetFullPathTo(string engineBinary)
+        private static string FindEngineInPath(string engineBinary)
         {
-            if (Path.IsPathRooted(engineBinary))
+            if (File.Exists (engineBinary) || Path.IsPathRooted(engineBinary))
                 return engineBinary;
 
             var path = Environment.GetEnvironmentVariable("PATH");
@@ -44,17 +42,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             if (path == null)
                 return engineBinary;
 
-            foreach (var folder in path.Split(";"))
+            foreach (var folder in path.Split(Path.PathSeparator))
             {
-                foreach (var ext in s_extensions)
-                {
-                    var fullPath = Path.Combine(folder, engineBinary + ext);
-                    if (File.Exists(fullPath))
-                    {
-                        engineBinary = fullPath;
-                        break;
-                    }
-                }
+                var fullPath = Path.Combine(folder, engineBinary);
+                if (File.Exists(fullPath))
+                    return fullPath;
             }
 
             return engineBinary;
@@ -73,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             };
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                engineBinary = GetFullPathTo(engineBinary);
+                engineBinary = FindEngineInPath(engineBinary + ".cmd");
 
             var engineArgs = new List<string>();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -36,7 +36,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
         private static string GetFullPathTo(string engineBinary)
         {
+            if (Path.IsPathRooted(engineBinary))
+                return engineBinary;
+
             var path = Environment.GetEnvironmentVariable("PATH");
+
             if (path == null)
                 return engineBinary;
 


### PR DESCRIPTION
The `Process.Start` doesn't find our JS engines on Windows when

    process.StartInfo.UseShellExecute = false;

is set. So we need to pass full path to the js engine cmd script on Windows.

Otherwise we endup with errors like this one:

    XHarness command issued: wasm test --app=. --engine=V8 --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js --output-directory=C:\Users\rodo\git\runtime\artifacts\bin\System.Collections.Concurrent.Tests\net6.0-Debug\browser-wasm\AppBundle\xharness-output -- --run WasmTestRunner.dll System.Collections.Concurrent.Tests.dll -notrait category=OuterLoop -notrait category=failing
    info: 22:49:48.1379578 Running v8 --expose_wasm --stack-trace-limit=1000 runtime.js -- --run WasmTestRunner.dll System.Collections.Concurrent.Tests.dll -notrait category=OuterLoop -notrait category=failing
    crit: The engine binary `v8` was not found
    XHarness exit code: 83 (APP_LAUNCH_FAILURE)