### PR TITLE
Add Apple simulator reset option

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppRunner.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<(string, string)> extraEnvVariables,
             string? deviceName = null,
             string? companionDeviceName = null,
-            bool ensureCleanSimulatorState = false,
+            bool resetSimulator = false,
             int verbosity = 1,
             CancellationToken cancellationToken = default)
         {
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     simulator,
                     companionSimulator,
                     extraEnvVariables,
-                    ensureCleanSimulatorState,
+                    resetSimulator,
                     timeout,
                     cancellationToken);
             }
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             ISimulatorDevice simulator,
             ISimulatorDevice? companionSimulator,
             IEnumerable<(string, string)> extraEnvVariables,
-            bool ensureCleanSimulatorState,
+            bool resetSimulator,
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     systemLogs.Add(companionLog);
                 }
 
-                if (ensureCleanSimulatorState)
+                if (resetSimulator)
                 {
                     await simulator.PrepareSimulator(_mainLog, appInformation.BundleIdentifier);
 
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 var result = await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, envVariables, cancellationToken);
 
                 // cleanup after us
-                if (ensureCleanSimulatorState)
+                if (resetSimulator)
                 {
                     await simulator.KillEverything(_mainLog);
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<(string, string)> extraEnvVariables,
             string? deviceName = null,
             string? companionDeviceName = null,
-            bool ensureCleanSimulatorState = false,
+            bool resetSimulator = false,
             int verbosity = 1,
             XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
             string[]? skippedMethods = null,
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                         testReporter,
                         simulator,
                         companionSimulator,
-                        ensureCleanSimulatorState,
+                        resetSimulator,
                         timeout,
                         combinedCancellationToken.Token);
                 }
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             ITestReporter testReporter,
             ISimulatorDevice simulator,
             ISimulatorDevice? companionSimulator,
-            bool ensureCleanSimulatorState,
+            bool resetSimulator,
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     systemLogs.Add(companionLog);
                 }
 
-                if (ensureCleanSimulatorState)
+                if (resetSimulator)
                 {
                     await simulator.PrepareSimulator(_mainLog, appInformation.BundleIdentifier);
 
@@ -299,7 +299,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 await testReporter.CollectSimulatorResult(result);
 
                 // Cleanup after us
-                if (ensureCleanSimulatorState)
+                if (resetSimulator)
                 {
                     await simulator.KillEverything(_mainLog);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
@@ -43,6 +43,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public IReadOnlyCollection<(string, string)> EnvironmentalVariables => _environmentalVariables;
         private readonly List<(string, string)> _environmentalVariables = new List<(string, string)>();
 
+        /// <summary>
+        /// Kills running simulator processes and removes any previous data before running.
+        /// </summary>
+        public bool ResetSimulator { get; set; }
+
         public override IReadOnlyCollection<string> Targets
         {
             get => RunTargets.Select(t => t.AsString()).ToArray();
@@ -94,8 +99,12 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
                     v => DeviceName = v
                 },
                 {
-                    "enable-lldb", "Allow to debug the launched application using lldb.",
+                    "enable-lldb", "Allow to debug the launched application using lldb",
                     v => EnableLldb = v != null
+                },
+                {
+                    "reset-simulator", "Shuts down the simulator and clears all data before running. Shuts it down after the run too",
+                    v => ResetSimulator = v != null
                 },
                 {
                     "set-env", "Environmental variable to set for the application in format key=value. Can be used multiple times",

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -67,6 +67,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 PassThroughArguments,
                 _arguments.EnvironmentalVariables,
                 deviceName,
+                resetSimulator: _arguments.ResetSimulator,
                 verbosity: GetMlaunchVerbosity(_arguments.Verbosity),
                 cancellationToken: cancellationToken);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -77,6 +77,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 PassThroughArguments,
                 _arguments.EnvironmentalVariables,
                 deviceName,
+                resetSimulator: _arguments.ResetSimulator,
                 verbosity: GetMlaunchVerbosity(_arguments.Verbosity),
                 xmlResultJargon: _arguments.XmlResultJargon,
                 cancellationToken: cancellationToken,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 TimeSpan.FromSeconds(30),
                 new[] { "--foo=bar", "--xyz" },
                 new[] { ("appArg1", "value1") },
-                ensureCleanSimulatorState: true);
+                resetSimulator: true);
 
             // Verify
             Assert.Equal(SimulatorDeviceName, deviceName);
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
 
-            // When ensureCleanSimulatorState == true
+            // When resetSimulator == true
             _mockSimulator.Verify(x => x.PrepareSimulator(_mainLog.Object, AppBundleIdentifier));
             _mockSimulator.Verify(x => x.KillEverything(_mainLog.Object));
         }
@@ -246,7 +246,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     TimeSpan.FromSeconds(30),
                     Enumerable.Empty<string>(),
                     Enumerable.Empty<(string, string)>(),
-                    ensureCleanSimulatorState: true));
+                    resetSimulator: true));
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 TimeSpan.FromSeconds(30),
                 new string[] { "--foo=bar", "--xyz" },
                 new[] { ("appArg1", "value1") },
-                ensureCleanSimulatorState: true);
+                resetSimulator: true);
 
             // Verify
             Assert.Equal(SimulatorDeviceName, deviceName);
@@ -299,7 +299,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
 
-            // When ensureCleanSimulatorState == true
+            // When resetSimulator == true
             _mockSimulator.Verify(x => x.PrepareSimulator(_mainLog.Object, AppBundleIdentifier));
             _mockSimulator.Verify(x => x.KillEverything(_mainLog.Object));
         }
@@ -344,7 +344,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     TimeSpan.FromSeconds(30),
                     new[] { "--foo=bar", "--xyz" },
                     new[] { ("appArg1", "value1") },
-                    ensureCleanSimulatorState: true));
+                    resetSimulator: true));
         }
 
         [Theory]
@@ -684,7 +684,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 TimeSpan.FromSeconds(30),
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") },
-                ensureCleanSimulatorState: true);
+                resetSimulator: true);
 
             // Verify
             Assert.Equal(TestExecutingResult.Succeeded, result);


### PR DESCRIPTION
Adds a new option `--reset-simulator` to `apple test` and `apple run` commands that kills the simulator process and erases all of its data before running the application.

Resolves #507