### PR TITLE
Multi-target XHarness at .NET 3.1 and 6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
           - task: ComponentGovernanceComponentDetection@0
             displayName: Component Governance scan
             inputs:
-              ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/netcoreapp3.1/android-tools-unzipped'
+              ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/net6.0/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX

--- a/eng/download-mlaunch.ps1
+++ b/eng/download-mlaunch.ps1
@@ -4,17 +4,21 @@
 
     Revision is cached in a temp dir and re-used for new builds.
 #>
-[CmdletBinding(PositionalBinding=$false)]
+[CmdletBinding(PositionalBinding = $false)]
 Param(
     [ValidateNotNullOrEmpty()]
-    [Parameter(Mandatory=$True)]
+    [Parameter(Mandatory = $True)]
     [string] $Commit,
 
     [ValidateNotNullOrEmpty()]
-    [Parameter(Mandatory=$True)]
+    [Parameter(Mandatory = $True)]
+    [string] $Target,
+
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $True)]
     [string] $TargetDir,
 
-    [switch] $RemoveSymbols=$False
+    [switch] $RemoveSymbols = $False
 )
 
 function Copy-Mlaunch([string] $sourceDir, [string] $targetDir, [bool] $removeSymbols) {
@@ -37,6 +41,8 @@ function Copy-Mlaunch([string] $sourceDir, [string] $targetDir, [bool] $removeSy
 
 New-Item -Path $TargetDir -ItemType Directory -ErrorAction SilentlyContinue
 
+$ErrorActionPreference = 'Stop'
+
 Write-Host "Getting mlaunch revision $commit into $TargetDir"
 
 $tagFile = Join-Path $TargetDir "$commit.tag"
@@ -46,7 +52,7 @@ if (Test-Path $tagFile) {
     ExitWithExitCode 0
 }
 
-$binariesRepo = Join-Path $TempDir "macios-binaries"
+$binariesRepo = Join-Path $TempDir $Target "macios-binaries"
 $tagFileInRepo = Join-Path $binariesRepo "$commit.tag"
 
 if (Test-Path $binariesRepo) {

--- a/eng/download-mlaunch.ps1
+++ b/eng/download-mlaunch.ps1
@@ -12,10 +12,6 @@ Param(
 
     [ValidateNotNullOrEmpty()]
     [Parameter(Mandatory = $True)]
-    [string] $Target,
-
-    [ValidateNotNullOrEmpty()]
-    [Parameter(Mandatory = $True)]
     [string] $TargetDir,
 
     [switch] $RemoveSymbols = $False
@@ -52,7 +48,7 @@ if (Test-Path $tagFile) {
     ExitWithExitCode 0
 }
 
-$binariesRepo = Join-Path $TempDir $Target "macios-binaries"
+$binariesRepo = Join-Path $TempDir "macios-binaries"
 $tagFileInRepo = Join-Path $binariesRepo "$commit.tag"
 
 if (Test-Path $binariesRepo) {

--- a/eng/download-mlaunch.sh
+++ b/eng/download-mlaunch.sh
@@ -42,7 +42,6 @@ copy_mlaunch () {
 }
 
 commit=''
-target=''
 target_dir="$artifacts_dir/mlaunch"
 remove_symbols=false
 
@@ -59,11 +58,6 @@ while (($# > 0)); do
       target_dir=$1
       ;;
 
-    --target)
-      shift
-      target=$1
-      ;;
-
     --remove-symbols)
       remove_symbols=true
       ;;
@@ -77,11 +71,6 @@ done
 
 if [[ -z $commit ]]; then
   echo "Please specify a git commit ID of the xamarin/macios-binaries repository using the --commit option" 1>&2
-  exit 1
-fi
-
-if [[ -z $target ]]; then
-  echo "Please specify target (e.g. net6.0)" 1>&2
   exit 1
 fi
 

--- a/eng/download-mlaunch.sh
+++ b/eng/download-mlaunch.sh
@@ -83,7 +83,7 @@ if [ -f "$tag_file" ]; then
   exit 0
 fi
 
-binaries_repo="$temp_dir/$target/macios-binaries"
+binaries_repo="$temp_dir/macios-binaries"
 tag_file_in_repo="$binaries_repo/$commit.tag"
 
 # Check if the repo was already checked out

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -25,10 +25,11 @@ namespace Microsoft.DotNet.XHarness.Android
         private readonly string _absoluteAdbExePath;
         private readonly ILogger _log;
         private readonly IAdbProcessManager _processManager;
-        private readonly Dictionary<string, string> CommandList = new()
+        private readonly Dictionary<string, string> _commandList = new()
         {
-        { "architecture", "shell getprop ro.product.cpu.abi"},
-        { "app", "shell pm list packages -3"} }; 
+            { "architecture", "shell getprop ro.product.cpu.abi"},
+            { "app", "shell pm list packages -3"}
+        }; 
 
 
         public AdbRunner(ILogger log, string adbExePath = "") : this(log, new AdbProcessManager(log), adbExePath) { }
@@ -200,7 +201,7 @@ namespace Microsoft.DotNet.XHarness.Android
             _log.LogInformation($"Attempting to install {apkPath}: ");
             if (string.IsNullOrEmpty(apkPath))
             {
-                throw new ArgumentNullException($"No value supplied for {nameof(apkPath)} ");
+                throw new ArgumentException($"No value supplied for {nameof(apkPath)} ");
             }
             if (!File.Exists(apkPath))
             {
@@ -331,7 +332,7 @@ namespace Microsoft.DotNet.XHarness.Android
                         }
                         else
                         {
-                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath) ?? throw new ArgumentNullException(nameof(destinationPath)));
+                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath) ?? throw new ArgumentException(nameof(destinationPath)));
                             File.Move(filePath, destinationPath);
                             copiedFiles.Add(destinationPath);
                         }
@@ -350,7 +351,7 @@ namespace Microsoft.DotNet.XHarness.Android
         {
             var devicesAndProperties = new Dictionary<string, string?>();
 
-            string command = CommandList[property];
+            string command = _commandList[property];
 
             var result = RunAdbCommand("devices -l", TimeSpan.FromSeconds(30));
             string[] standardOutputLines = result.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -446,7 +447,7 @@ namespace Microsoft.DotNet.XHarness.Android
         public Dictionary<string, string> GetAllDevicesToUse(ILogger logger, string apkRequiredProperty, string propertyName)
         {
 
-            Dictionary<string, string?> allDevicesAndTheirProperties = new Dictionary<string, string?>();
+            var allDevicesAndTheirProperties = new Dictionary<string, string?>();
             try
             {
                 allDevicesAndTheirProperties = GetAttachedDevicesWithProperties(propertyName);
@@ -467,11 +468,12 @@ namespace Microsoft.DotNet.XHarness.Android
                 .Where(kvp => !string.IsNullOrEmpty(kvp.Value) && kvp.Value.Split().Contains(apkRequiredProperty))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value) as Dictionary<string, string>;
             
-            if (result.Count() == 0)
+            if (result.Count == 0)
             {
                 // In this case, the enumeration worked, we found one or more devices, but nothing matched the APK's architecture; fail out.
                 logger.LogError($"No devices with {propertyName} '{apkRequiredProperty}' was found among attached devices.");
             }
+
             return result;
         }
 

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.XHarness.Android
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
 
             // We need to find ADB.exe somewhere
-            string environmentPath = Environment.GetEnvironmentVariable(AdbEnvironmentVariableName);
+            string? environmentPath = Environment.GetEnvironmentVariable(AdbEnvironmentVariableName);
             if (!string.IsNullOrEmpty(environmentPath))
             {
                 _log.LogDebug($"Using {AdbEnvironmentVariableName} environment variable ({environmentPath}) for ADB path.");
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.XHarness.Android
             }
             else
             {
-                Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath));
+                Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath) ?? throw new ArgumentNullException(nameof(outputFilePath)));
                 File.WriteAllText(outputFilePath, result.StandardOutput);
                 _log.LogInformation($"Wrote current ADB log to {outputFilePath}");
             }
@@ -330,7 +330,7 @@ namespace Microsoft.DotNet.XHarness.Android
                         }
                         else
                         {
-                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
+                            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath) ?? throw new ArgumentNullException(nameof(destinationPath)));
                             File.Move(filePath, destinationPath);
                             copiedFiles.Add(destinationPath);
                         }

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.XHarness.Android
         private readonly string _absoluteAdbExePath;
         private readonly ILogger _log;
         private readonly IAdbProcessManager _processManager;
-        private readonly Dictionary<string, string> CommandList = new Dictionary<string, string>{
+        private readonly Dictionary<string, string> CommandList = new()
+        {
         { "architecture", "shell getprop ro.product.cpu.abi"},
         { "app", "shell pm list packages -3"} }; 
 

--- a/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.XHarness.Android.Execution
             {
                 CreateNoWindow = true,
                 UseShellExecute = false,
-                WorkingDirectory = Path.GetDirectoryName(adbExePath),
+                WorkingDirectory = Path.GetDirectoryName(adbExePath) ?? throw new ArgumentNullException(nameof(adbExePath)),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 FileName = adbExePath,

--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <nullable>enable</nullable>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <nullable>enable</nullable>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <nullable>enable</nullable>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <nullable>enable</nullable>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.Apple/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppRunner.cs
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private MlaunchArguments GetSimulatorArguments(
+        private static MlaunchArguments GetSimulatorArguments(
             AppBundleInformation appInformation,
             ISimulatorDevice simulator,
             IEnumerable<string> extraAppArguments,
@@ -315,7 +315,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private MlaunchArguments GetDeviceArguments(
+        private static MlaunchArguments GetDeviceArguments(
             AppBundleInformation appInformation,
             string deviceName,
             bool isWatchTarget,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             _snapshotReporterFactory = snapshotReporterFactory ?? throw new ArgumentNullException(nameof(snapshotReporterFactory));
             _captureLogFactory = captureLogFactory ?? throw new ArgumentNullException(nameof(captureLogFactory));
             _deviceLogCapturerFactory = deviceLogCapturerFactory ?? throw new ArgumentNullException(nameof(deviceLogCapturerFactory));
-            _testReporterFactory = reporterFactory ?? throw new ArgumentNullException(nameof(_testReporterFactory));
+            _testReporterFactory = reporterFactory ?? throw new ArgumentNullException(nameof(reporterFactory));
             _resultParser = resultParser ?? throw new ArgumentNullException(nameof(resultParser));
             _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
             _logs = logs ?? throw new ArgumentNullException(nameof(logs));

--- a/src/Microsoft.DotNet.XHarness.Apple/ErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/ErrorKnowledgeBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 {
     public class ErrorKnowledgeBase : IErrorKnowledgeBase
     {
-        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_testErrorMaps = new Dictionary<string, (string HumanMessage, string? IssueLink)>
+        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_testErrorMaps = new()
         {
             ["Failed to communicate with the device"] = // Known issue but not a failure.
                 ("Failed to communicate with the device. Please ensure the cable is properly connected, and try rebooting the device", null),
@@ -28,9 +28,9 @@ namespace Microsoft.DotNet.XHarness.Apple
                 ("This application requires a newer version of MacOS", null),
         };
 
-        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_buildErrorMaps = new Dictionary<string, (string HumanMessage, string? IssueLink)>();
+        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_buildErrorMaps = new();
 
-        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_installErrorMaps = new Dictionary<string, (string HumanMessage, string? IssueLink)>
+        private static readonly Dictionary<string, (string HumanMessage, string? IssueLink)> s_installErrorMaps = new()
         {
             ["IncorrectArchitecture"] =
                 ("IncorrectArchitecture: Failed to find matching device arch for the application", null), // known failure, but not an issue

--- a/src/Microsoft.DotNet.XHarness.Apple/ExitCodeDetector.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/ExitCodeDetector.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 var line = reader.ReadLine();
 
-                if (IsSignalLine(appBundleInfo, line))
+                if (!string.IsNullOrEmpty(line) && IsSignalLine(appBundleInfo, line))
                 {
                     var match = ExitCodeRegex.Match(line);
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
+++ b/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>

--- a/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
+++ b/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
+++ b/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>9.0</LangVersion>

--- a/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
+++ b/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public string? DeviceArchitecture { get; set; }
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet
+        protected override OptionSet GetTestCommandOptions() => new()
         {
             { "device-arch=", "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK",
                 v => DeviceArchitecture = v

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -23,8 +23,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public override void Validate()
         {
+            base.Validate();
+
             // Validate this field
-            AppPackagePath = AppPackagePath;
+            _ = AppPackagePath;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     internal class AndroidGetStateCommandArguments : GetStateCommandArguments
     {
-        protected override OptionSet GetCommandOptions() => new OptionSet();
+        protected override OptionSet GetCommandOptions() => new();
 
         public override void Validate()
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public string? DeviceArchitecture { get; set; }
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet
+        protected override OptionSet GetTestCommandOptions() => new()
         {
             { "package-name=|p=", "Package name contained within the supplied APK",
                 v => PackageName = v

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -38,10 +38,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public override void Validate()
         {
+            base.Validate();
+
             // Validate this field
-            PackageName = PackageName;
-            AppPackagePath = AppPackagePath;
-            DeviceId = DeviceId;
+            _ = PackageName;
+            _ = AppPackagePath;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -88,8 +88,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             base.Validate();
 
             // Validate this field
-            PackageName = PackageName;
-            DeviceId = DeviceId;
+            _ = PackageName;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet
+        protected override OptionSet GetTestCommandOptions() => new()
         {
             { "device-out-folder=|dev-out=", "If specified, copy this folder recursively off the device to the path specified by the output directory",
                 v => DeviceOutputFolder = RootPath(v)

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet
+        protected override OptionSet GetTestCommandOptions() => new()
         {
             { "device-arch=", "If specified, only run on a device with the listed architecture (x86, x86_64, arm64-v8a or armeabi-v7a).  Otherwise infer from supplied APK",
                 v => DeviceArchitecture = v

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -91,8 +91,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             base.Validate();
 
             // Validate this field
-            PackageName = PackageName;
-            AppPackagePath = AppPackagePath;
+            _ = PackageName;
+            _ = AppPackagePath;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public string? DeviceId { get; set; }
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet
+        protected override OptionSet GetTestCommandOptions() => new()
         {
             { "package-name=|p=", "Package name contained within the supplied APK",
                 v => PackageName = v

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
@@ -33,8 +33,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         public override void Validate()
         {
             // Validate this field
-            PackageName = PackageName;
-            DeviceId = DeviceId;
+            _ = PackageName;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AppRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AppRunCommandArguments.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
         /// </summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(15);
 
-        protected override OptionSet GetCommandOptions() => new OptionSet
+        protected override OptionSet GetCommandOptions() => new()
         {
             {
                 "app|a=", "Path to already-packaged app",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             {
                 var testTargets = new List<TestTargetOs>();
 
-                foreach (var targetName in value ?? throw new ArgumentNullException("Targets cannot be empty"))
+                foreach (var targetName in value ?? throw new ArgumentException("Targets cannot be empty"))
                 {
                     try
                     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleAppRunArguments.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         /// Environmental variables set when executing the application.
         /// </summary>
         public IReadOnlyCollection<(string, string)> EnvironmentalVariables => _environmentalVariables;
-        private readonly List<(string, string)> _environmentalVariables = new List<(string, string)>();
+        private readonly List<(string, string)> _environmentalVariables = new();
 
         public override IReadOnlyCollection<string> Targets
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 
         public bool UseJson { get; set; } = false;
 
-        protected override OptionSet GetCommandOptions() => new OptionSet
+        protected override OptionSet GetCommandOptions() => new()
         {
             { "mlaunch=", "Path to the mlaunch binary", v => MlaunchPath = RootPath(v) },
             { "include-simulator-uuid", "Include the simulators UUID. Defaults to false.", v => ShowSimulatorsUUID = v != null },

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -29,8 +29,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 
     internal class AppleTestCommandArguments : AppleAppRunArguments
     {
-        private readonly List<string> _singleMethodFilters = new List<string>();
-        private readonly List<string> _classMethodFilters = new List<string>();
+        private readonly List<string> _singleMethodFilters = new();
+        private readonly List<string> _classMethodFilters = new();
 
         /// <summary>
         /// Methods to be included in the test run while all others are ignored.

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
     {
         public IEnumerable<string> Simulators { get; } = new List<string>();
 
-        protected override OptionSet GetAdditionalOptions() => new OptionSet
+        protected override OptionSet GetAdditionalOptions() => new()
         {
             { "s|simulator=", "ID of the Simulator to look for. Repeat multiple times to define more", v => ((IList<string>)Simulators).Add(v) },
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
         public IEnumerable<string> Simulators { get; } = new List<string>();
         public bool Force { get; private set; } = false;
 
-        protected override OptionSet GetAdditionalOptions() => new OptionSet
+        protected override OptionSet GetAdditionalOptions() => new()
         {
             { "s|simulator=", "ID of the Simulator to install. Repeat multiple times to define more", v => ((IList<string>)Simulators).Add(v) },
             { "force", "Install again even if already installed", v => Force = true },

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/ListCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/ListCommandArguments.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
     {
         public bool ListInstalledOnly { get; private set; } = false;
 
-        protected override OptionSet GetAdditionalOptions() => new OptionSet
+        protected override OptionSet GetAdditionalOptions() => new()
         {
             { "installed", "Lists installed simulators only", v => ListInstalledOnly = true },
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/SimulatorsCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/SimulatorsCommandArguments.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
                 if (_xcodeRoot == null)
                 {
                     // Determine it automatically from xcode-select
-                    _xcodeRoot = new MacOSProcessManager().XcodeRoot;
+                    _xcodeRoot = MacOSProcessManager.DetectXcodePath();
                 }
 
                 return _xcodeRoot;
@@ -36,7 +36,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
         {
             var options = GetAdditionalOptions();
 
-            options.Add("xcode=", "Path to where Xcode is located, e.g. /Application/Xcode114.app. If not set, xcode-select is used to determine the location",v => XcodeRoot = RootPath(v));
+            options.Add("xcode=", "Path to where Xcode is located, e.g. /Application/Xcode114.app. If not set, xcode-select is used to determine the location",
+                v => XcodeRoot = RootPath(v));
 
             return options;
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/TestCommandArguments.cs
@@ -9,8 +9,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     internal abstract class TestCommandArguments : AppRunCommandArguments
     {
-        private readonly List<string> _singleMethodFilters = new List<string>();
-        private readonly List<string> _classMethodFilters = new List<string>();
+        private readonly List<string> _singleMethodFilters = new();
+        private readonly List<string> _classMethodFilters = new();
 
         /// <summary>
         /// Methods to be included in the test run while all others are ignored.

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -45,7 +45,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public string HTMLFile { get; set; } = "index.html";
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet{
+        protected override OptionSet GetTestCommandOptions() => new()
+        {
             { "browser=|b=", "Specifies the browser to be used. Default is Chrome",
                 v => Browser = ParseArgument<Browser>("browser", v)
             },

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -43,7 +43,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
 
-        protected override OptionSet GetTestCommandOptions() => new OptionSet{
+        protected override OptionSet GetTestCommandOptions() => new()
+        {
             { "engine=|e=", "Specifies the JavaScript engine to be used",
                 v => Engine = ParseArgument<JavaScriptEngine>("engine", v)
             },

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public override void Validate()
         {
             base.Validate();
-            Engine = Engine;
+            _ = Engine;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
 {
     internal class AndroidGetDeviceCommand : XHarnessCommand
     {
-        private readonly AndroidGetDeviceCommandArguments _arguments = new AndroidGetDeviceCommandArguments();
+        private readonly AndroidGetDeviceCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -84,7 +84,7 @@ Arguments:
                     // otherwise - from test command - apkRequiredArchitecture was set by user or .apk architecture
                     deviceId ??= apkRequiredArchitecture != null
                         ? runner.GetDeviceToUse(logger, apkRequiredArchitecture, "architecture")
-                        : throw new ArgumentNullException("Required architecture not specified");
+                        : throw new ArgumentException("Required architecture not specified");
 
                     if (deviceId == null)
                     {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
     internal class AndroidInstallCommand : XHarnessCommand
     {
 
-        private readonly AndroidInstallCommandArguments _arguments = new AndroidInstallCommandArguments();
+        private readonly AndroidInstallCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -71,7 +71,7 @@ Arguments:
                 runner: runner));
         }
 
-        public ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, AdbRunner runner)
+        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, AdbRunner runner)
         {
             try
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
         private const string ReturnCodeVariableName = "return-code";
         private const string ProcessCrashedShortMessage = "Process crashed";
 
-        private readonly AndroidRunCommandArguments _arguments = new AndroidRunCommandArguments();
+        private readonly AndroidRunCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -90,7 +90,7 @@ Arguments:
                 runner));
         }
 
-        public ExitCode InvokeHelper(
+        public static ExitCode InvokeHelper(
             ILogger logger,
             string apkPackageName,
             string? instrumentationName,
@@ -216,7 +216,7 @@ Arguments:
             return ExitCode.GENERAL_FAILURE;
         }
 
-        private (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(ILogger logger, string stdOut)
+        private static (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(ILogger logger, string stdOut)
         {
             // If ADB.exe's output changes (which we control when we take updates in this repo), we'll need to fix this.
             string resultPrefix = "INSTRUMENTATION_RESULT:";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
     {
         private const string ReturnCodeVariableName = "return-code";
 
-        private readonly AndroidTestCommandArguments _arguments = new AndroidTestCommandArguments();
+        private readonly AndroidTestCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -72,12 +72,9 @@ Arguments:
             string apkPackageName = _arguments.PackageName;
             string appPackagePath = _arguments.AppPackagePath;
 
-            var installer = new AndroidInstallCommand();
-            var testRunner = new AndroidRunCommand();
-
             try
             {
-                installer.InvokeHelper(
+                AndroidInstallCommand.InvokeHelper(
                     logger: logger,
                     apkPackageName: apkPackageName,
                     appPackagePath: appPackagePath,
@@ -85,7 +82,7 @@ Arguments:
                     deviceId: null,
                     runner: runner);
 
-                testRunner.InvokeHelper(
+                AndroidRunCommand.InvokeHelper(
                     logger: logger,
                     apkPackageName: apkPackageName,
                     instrumentationName: _arguments.InstrumentationName,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
 {
     internal class AndroidUninstallCommand : XHarnessCommand
     {
-        private readonly AndroidUninstallCommandArguments _arguments = new AndroidUninstallCommandArguments();
+        private readonly AndroidUninstallCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
         protected static bool IsLldbEnabled() => File.Exists(s_mlaunchLldbConfigFile);
 
-        protected void NotifyUserLldbCommand(ILogger logger, string line)
+        protected static void NotifyUserLldbCommand(ILogger logger, string line)
         {
             if (!line.Contains("mtouch-lldb-prep-cmds"))
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
     {
         protected static readonly string s_mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".mtouch-launch-with-lldb");
 
-        protected readonly ErrorKnowledgeBase ErrorKnowledgeBase = new ErrorKnowledgeBase();
+        protected readonly ErrorKnowledgeBase ErrorKnowledgeBase = new();
         protected override XHarnessCommandArguments Arguments => iOSRunArguments;
         protected abstract AppleAppRunArguments iOSRunArguments { get; }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetStateCommand.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
         private const string SimulatorPrefix = "com.apple.CoreSimulator.SimDeviceType.";
 
-        private readonly AppleGetStateCommandArguments _arguments = new AppleGetStateCommandArguments();
+        private readonly AppleGetStateCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetStateCommand.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
         protected override XHarnessCommandArguments Arguments => _arguments;
 
-        private async Task AsJson(SystemInfo info)
+        private static async Task AsJson(SystemInfo info)
         {
             var options = new JsonSerializerOptions
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
     {
         private const string CommandHelp = "Runs a given iOS/tvOS/watchOS/MacCatalyst application bundle in a target device/simulator and tries to detect exit code (might not work reliably across iOS versions).";
 
-        private readonly AppleRunCommandArguments _arguments = new AppleRunCommandArguments();
+        private readonly AppleRunCommandArguments _arguments = new();
 
         protected override AppleAppRunArguments iOSRunArguments => _arguments;
         protected override string CommandUsage { get; } = "apple run [OPTIONS] [-- [RUNTIME ARGUMENTS]]";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
     {
         private const string CommandHelp = "Runs a given iOS/tvOS/watchOS/MacCatalyst test application bundle containing TestRunner in a target device/simulator";
 
-        private readonly AppleTestCommandArguments _arguments = new AppleTestCommandArguments();
+        private readonly AppleTestCommandArguments _arguments = new();
 
         protected override string CommandUsage { get; } = "apple test [OPTIONS] [-- [RUNTIME ARGUMENTS]]";
         protected override string CommandDescription { get; } = CommandHelp;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/FindCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/FindCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
         protected override string CommandDescription => CommandHelp;
 
-        private readonly FindCommandArguments _arguments = new FindCommandArguments();
+        private readonly FindCommandArguments _arguments = new();
         protected override SimulatorsCommandArguments SimulatorsArguments => _arguments;
 
         public FindCommand() : base(CommandName, CommandHelp)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
         protected override string CommandDescription => CommandHelp;
 
-        private readonly InstallCommandArguments _arguments = new InstallCommandArguments();
+        private readonly InstallCommandArguments _arguments = new();
         protected override SimulatorsCommandArguments SimulatorsArguments => _arguments;
 
         public InstallCommand() : base(CommandName, CommandHelp)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
@@ -6,8 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Threading;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators;
@@ -20,6 +19,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
     {
         private const string CommandName = "install";
         private const string CommandHelp = "Installs given simulators";
+        private static readonly HttpClient s_client = new();
 
         protected override string CommandUsage => CommandName + " [OPTIONS]";
 
@@ -136,41 +136,18 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
             if (download)
             {
-                var downloadDone = new ManualResetEvent(false);
-                var wc = new WebClient();
-                long lastProgress = 0;
                 var watch = Stopwatch.StartNew();
-                wc.DownloadProgressChanged += (sender, progressArgs) =>
+
+                using (var response = await s_client.GetAsync(simulator.Source))
+                using (var fileStream = File.Create(downloadPath))
                 {
-                    var progress = progressArgs.BytesReceived * 100 / simulator.FileSize;
-                    if (progress > lastProgress)
-                    {
-                        lastProgress = progress;
-                        var duration = watch.Elapsed.TotalSeconds;
-                        var speed = progressArgs.BytesReceived / duration;
-                        var timeLeft = TimeSpan.FromSeconds((progressArgs.TotalBytesToReceive - progressArgs.BytesReceived) / speed);
+                    await response.Content.CopyToAsync(fileStream);
+                }
 
-                        Logger.LogDebug($"Downloaded {progressArgs.BytesReceived:N0}/{simulator.FileSize:N0} bytes = " +
-                            $"{progress}% in {duration:N1}s ({speed / 1024.0 / 1024.0:N1} MB/s; approximately " +
-                            $"{new TimeSpan(timeLeft.Days, timeLeft.Hours, timeLeft.Minutes, timeLeft.Seconds)} left)");
-                    }
-                };
+                watch.Stop();
 
-                wc.DownloadFileCompleted += (sender, completedArgs) =>
-                {
-                    Logger.LogInformation($"Download completed in {watch.Elapsed.TotalSeconds}s");
-
-                    if (completedArgs.Error != null)
-                    {
-                        Logger.LogError($"    with error: {completedArgs.Error}");
-                    }
-
-                    downloadDone.Set();
-                };
-
-                await wc.DownloadFileTaskAsync(new Uri(simulator.Source), downloadPath);
-
-                downloadDone.WaitOne();
+                var size = new FileInfo(downloadPath).Length;
+                Logger.LogInformation($"Downloaded {size / 1024.0 / 1024.0:N1} MB in {(int)watch.Elapsed.TotalSeconds}s");
             }
 
             var mount_point = Path.Combine(TempDirectory, filename + "-mount");
@@ -224,7 +201,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
                         // Add the install-location attribute to the pkg-info node
                         var attr = packageInfoDoc.CreateAttribute("install-location");
                         attr.Value = simulator.InstallPrefix;
-                        packageInfoDoc.SelectSingleNode("/pkg-info").Attributes.Append(attr);
+                        packageInfoDoc.SelectSingleNode("/pkg-info")?.Attributes?.Append(attr);
                         packageInfoDoc.Save(packageInfoPath);
 
                         var fixed_path = Path.Combine(Path.GetDirectoryName(downloadPath)!, Path.GetFileNameWithoutExtension(downloadPath) + "-fixed.pkg");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/ListCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/ListCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
         protected override string CommandDescription => CommandHelp;
 
-        private readonly ListCommandArguments _arguments = new ListCommandArguments();
+        private readonly ListCommandArguments _arguments = new();
         protected override SimulatorsCommandArguments SimulatorsArguments => _arguments;
 
         public ListCommand() : base(CommandName, CommandHelp)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
                 dict.Add(IDENTIFIER_PLACEHOLDER, identifier);
 
-                double.TryParse(fileSizeNode?.InnerText, out var parsedFileSize);
+                _  = double.TryParse(fileSizeNode?.InnerText, out var parsedFileSize);
 
                 simulators.Add(new Simulator(
                     name: Replace(nameNode.InnerText, dict),

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Xml;
@@ -28,7 +29,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
         private const string SimulatorIndexUrl = "https://devimages-cdn.apple.com/downloads/xcode/simulators/index-{0}-{1}.dvtdownloadableindex";
 
-        private readonly MacOSProcessManager _processManager = new MacOSProcessManager();
+        private static readonly HttpClient s_client = new();
+        private readonly MacOSProcessManager _processManager = new();
 
         protected ILogger Logger { get; set; } = null!;
 
@@ -98,19 +100,19 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
             var simulators = new List<Simulator>();
 
             var downloadables = doc.SelectNodes("//plist/dict/key[text()='downloadables']/following-sibling::array/dict");
-            foreach (XmlNode? downloadable in downloadables)
+            foreach (XmlNode? downloadable in downloadables!)
             {
                 if (downloadable == null)
                 {
                     continue;
                 }
 
-                var nameNode = downloadable.SelectSingleNode("key[text()='name']/following-sibling::string");
-                var versionNode = downloadable.SelectSingleNode("key[text()='version']/following-sibling::string");
-                var sourceNode = downloadable.SelectSingleNode("key[text()='source']/following-sibling::string");
-                var identifierNode = downloadable.SelectSingleNode("key[text()='identifier']/following-sibling::string");
+                var nameNode = downloadable.SelectSingleNode("key[text()='name']/following-sibling::string") ?? throw new Exception("Name node not found");
+                var versionNode = downloadable.SelectSingleNode("key[text()='version']/following-sibling::string") ?? throw new Exception("Version node not found");
+                var sourceNode = downloadable.SelectSingleNode("key[text()='source']/following-sibling::string") ?? throw new Exception("Source node not found");
+                var identifierNode = downloadable.SelectSingleNode("key[text()='identifier']/following-sibling::string") ?? throw new Exception("Identifier node not found");
                 var fileSizeNode = downloadable.SelectSingleNode("key[text()='fileSize']/following-sibling::integer|key[text()='fileSize']/following-sibling::real");
-                var installPrefixNode = downloadable.SelectSingleNode("key[text()='userInfo']/following-sibling::dict/key[text()='InstallPrefix']/following-sibling::string");
+                var installPrefixNode = downloadable.SelectSingleNode("key[text()='userInfo']/following-sibling::dict/key[text()='InstallPrefix']/following-sibling::string") ?? throw new Exception("InstallPrefix node not found");
 
                 var version = versionNode.InnerText;
                 var versions = version.Split('.');
@@ -163,26 +165,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
             if (!File.Exists(tmpfile))
             {
-                var client = new WebClient();
-                try
-                {
-                    Logger.LogInformation($"Downloading '{uri}'");
-                    client.DownloadFile(uri, tmpfile);
-                }
-                catch (Exception ex)
-                {
-                    // 403 means 404
-                    if (ex is WebException we && (we.Response as HttpWebResponse)?.StatusCode == HttpStatusCode.Forbidden)
-                    {
-                        Logger.LogWarning($"Failed to download {url}: Not found"); // Apple's servers return a 403 if the file doesn't exist, which can be quite confusing, so show a better error.
-                    }
-                    else
-                    {
-                        Logger.LogWarning($"Failed to download {url}: {ex}");
-                    }
-
-                    return null;
-                }
+                await DownloadFile(url, tmpfile);
+            }
+            else
+            {
+                Logger.LogInformation($"File '{tmpfile}' already exists, skipped download");
             }
 
             var (succeeded, xmlResult) = await ExecuteCommand("plutil", TimeSpan.FromSeconds(30), "-convert", "xml1", "-o", "-", tmpfile);
@@ -192,6 +179,33 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
             }
 
             return xmlResult;
+        }
+
+        private async Task DownloadFile(string url, string destinationPath)
+        {
+            try
+            {
+                Logger.LogInformation($"Downloading {url}...");
+
+                var downloadTask = s_client.GetStreamAsync(url);
+                using var fileStream = new FileStream(destinationPath, FileMode.Create);
+                using var bodyStream = await downloadTask;
+                await bodyStream.CopyToAsync(fileStream);
+            }
+            catch (HttpRequestException e)
+            {
+                // 403 means 404
+                if (e.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    Logger.LogWarning($"Failed to download {url}: Not found"); // Apple's servers return a 403 if the file doesn't exist, which can be quite confusing, so show a better error.
+                }
+                else
+                {
+                    Logger.LogWarning($"Failed to download {url}: {e}");
+                }
+
+                throw;
+            }
         }
 
         private async Task<(string XcodeVersion, string XcodeUuid)> GetXcodeInformation()

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorInstallerCommand.cs
@@ -195,12 +195,17 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
             catch (HttpRequestException e)
             {
                 // 403 means 404
+#if NETCOREAPP3_1
+                {
+#else
                 if (e.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    Logger.LogWarning($"Failed to download {url}: Not found"); // Apple's servers return a 403 if the file doesn't exist, which can be quite confusing, so show a better error.
+                    // Apple's servers return a 403 if the file doesn't exist, which can be quite confusing, so show a better error.
+                    Logger.LogWarning($"Failed to download {url}: Not found");
                 }
                 else
                 {
+#endif
                     Logger.LogWarning($"Failed to download {url}: {e}");
                 }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
         // Messages from selenium prepend the url, and location where the message originated
         // Eg. `foo` becomes `http://localhost:8000/xyz.js 0:12 "foo"
-        static readonly Regex s_consoleLogRegex = new Regex(@"^\s*[a-z]*://[^\s]+\s+\d+:\d+\s+""(.*)""\s*$", RegexOptions.Compiled);
+        static readonly Regex s_consoleLogRegex = new(@"^\s*[a-z]*://[^\s]+\s+\d+:\d+\s+""(.*)""\s*$", RegexOptions.Compiled);
 
         public WasmBrowserTestRunner(WasmTestBrowserCommandArguments arguments, IEnumerable<string> passThroughArguments,
                                             WasmTestMessagesProcessor messagesProcessor, ILogger logger)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -43,10 +43,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         public WasmBrowserTestRunner(WasmTestBrowserCommandArguments arguments, IEnumerable<string> passThroughArguments,
                                             WasmTestMessagesProcessor messagesProcessor, ILogger logger)
         {
-            this._arguments = arguments;
-            this._logger = logger;
-            this._passThroughArguments = passThroughArguments;
-            this._messagesProcessor = messagesProcessor;
+            _arguments = arguments;
+            _logger = logger;
+            _passThroughArguments = passThroughArguments;
+            _messagesProcessor = messagesProcessor;
         }
 
         public async Task<ExitCode> RunTestsWithWebDriver(DriverService driverService, IWebDriver driver)
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             foreach (var arg in _passThroughArguments)
             {
                 if (sb.Length > 0)
-                    sb.Append("&");
+                    sb.Append('&');
 
                 sb.Append($"arg={HttpUtility.UrlEncode(arg)}");
             }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -271,10 +271,13 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 .Build();
 
             await host.StartAsync(token);
-            return host.ServerFeatures
-                    .Get<IServerAddressesFeature>()
-                    .Addresses
-                    .First();
+
+            var ipAddress = host.ServerFeatures
+                .Get<IServerAddressesFeature>()?
+                .Addresses
+                .FirstOrDefault();
+
+            return ipAddress ?? throw new InvalidOperationException("Failed to determine web server's IP address");
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -207,8 +207,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     driverService.EnableVerboseLogging = true;
                     driverService.LogPath = Path.Combine(_arguments.OutputDirectory, $"{driverName}-{retry_num}.log");
 
-                    if (!(Activator.CreateInstance(typeof(TDriver), driverService, options, _arguments.Timeout) is TDriver driver))
+                    if (Activator.CreateInstance(typeof(TDriver), driverService, options, _arguments.Timeout) is not TDriver driver)
+                    {
                         throw new ArgumentException($"Failed to create instance of {typeof(TDriver)}");
+                    }
 
                     return (driverService, driver);
                 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
     {
         private const string CommandHelp = "Executes tests on WASM using a browser";
 
-        private readonly WasmTestBrowserCommandArguments _arguments = new WasmTestBrowserCommandArguments();
+        private readonly WasmTestBrowserCommandArguments _arguments = new();
 
         protected TestCommandArguments TestArguments => _arguments;
         protected override string CommandUsage { get; } = "wasm test-browser [OPTIONS] -- [BROWSER OPTIONS]";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestWebServerStartup.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using System;
@@ -18,11 +17,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 {
     public class WasmTestWebServerStartup
     {
-        private readonly IWebHostEnvironment s_hostingEnvironment;
+        private readonly IWebHostEnvironment _hostingEnvironment;
 
         public WasmTestWebServerStartup(IWebHostEnvironment hostingEnvironment)
         {
-            this.s_hostingEnvironment = hostingEnvironment;
+            _hostingEnvironment = hostingEnvironment;
         }
 
         public void Configure(IApplicationBuilder app, IOptionsMonitor<WasmTestWebServerOptions> optionsAccessor)
@@ -37,7 +36,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
             app.UseStaticFiles(new StaticFileOptions
             {
-                FileProvider = new PhysicalFileProvider(s_hostingEnvironment.ContentRootPath),
+                FileProvider = new PhysicalFileProvider(_hostingEnvironment.ContentRootPath),
                 ContentTypeProvider = provider,
                 ServeUnknownFileTypes = true
             });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 JavaScriptEngine.V8 => "v8",
                 JavaScriptEngine.JavaScriptCore => "jsc",
                 JavaScriptEngine.SpiderMonkey => "sm",
-                _ => throw new ArgumentException()
+                _ => throw new ArgumentException("Engine not set")
             };
 
             var engineArgs = new List<string>();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
     {
         private const string CommandHelp = "Executes tests on WASM using a selected JavaScript engine";
 
-        private readonly WasmTestCommandArguments _arguments = new WasmTestCommandArguments();
+        private readonly WasmTestCommandArguments _arguments = new();
 
         protected override XHarnessCommandArguments Arguments => _arguments;
         protected override string CommandUsage { get; } = "wasm test [OPTIONS] -- [ENGINE OPTIONS]";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -22,10 +22,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
         public WasmTestMessagesProcessor(string xmlResultsFilePath, string stdoutFilePath, ILogger logger)
         {
-            this._xmlResultsFilePath = xmlResultsFilePath;
-            this._stdoutFileWriter = File.CreateText(stdoutFilePath);
-            this._stdoutFileWriter.AutoFlush = true;
-            this._logger = logger;
+            _xmlResultsFilePath = xmlResultsFilePath;
+            _stdoutFileWriter = File.CreateText(stdoutFilePath);
+            _stdoutFileWriter.AutoFlush = true;
+            _logger = logger;
         }
 
         public void Invoke(string message)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessHelpCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessHelpCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
             return (int)ExitCode.HELP_SHOWN;
         }
 
-        private void PrintCommandHelp(CommandSet commandSet, string? subcommand)
+        private static void PrintCommandHelp(CommandSet commandSet, string? subcommand)
         {
             if (subcommand != null)
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>xharness</ToolCommandName>
     <RollForward>Major</RollForward>
+    <LangVersion>9.0</LangVersion>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <Target Name="DownloadAdb">
-    <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
+    <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="true" />
     <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(MacOsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(MacOsAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
@@ -68,7 +68,7 @@
     <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
   </Target>
 
-  <Target Name="IncludeAdb" BeforeTargets="_GetPackageFiles" DependsOnTargets="DownloadMlaunch">
+  <Target Name="IncludeAdb" BeforeTargets="_GetPackageFiles" DependsOnTargets="DownloadAdb">
     <ItemGroup>
       <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
       <LinuxAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/linux/platform-tools/adb" />

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
@@ -83,9 +83,9 @@
       <RemoveSymbols Condition=" '$(Configuration)' == 'Release' AND '$(OS)' != 'Windows_NT' ">--remove-symbols</RemoveSymbols>
     </PropertyGroup>
 
-    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target $(TargetFramework) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
+    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
 
-    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -Target $(TargetFramework) -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
+    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
 
     <ItemGroup>
       <Content Include="$(IntermediateOutputPath)/mlaunch/**/*.*">

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -47,13 +47,28 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" Condition=" '$(TargetFramework)' != '' ">
+  <Target Name="DownloadAdb">
     <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(MacOsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(MacOsAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(WindowsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/windows" OverwriteReadOnlyFiles="true" />
     <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(LinuxAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/linux" OverwriteReadOnlyFiles="true" />
     <Unzip SourceFiles="$(IntermediateOutputPath)/android-tools/$(MacOsAndroidSdkFileName)" DestinationFolder="$(IntermediateOutputPath)/android-tools-unzipped/macos" OverwriteReadOnlyFiles="true" />
+  </Target>
+
+  <Target Name="DownloadMlaunch">
+    <PropertyGroup>
+      <RemoveSymbols></RemoveSymbols>
+      <RemoveSymbols Condition=" '$(Configuration)|$(OS)' == 'Release|Windows_NT' ">-RemoveSymbols</RemoveSymbols>
+      <RemoveSymbols Condition=" '$(Configuration)' == 'Release' AND '$(OS)' != 'Windows_NT' ">--remove-symbols</RemoveSymbols>
+    </PropertyGroup>
+
+    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
+
+    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
+  </Target>
+
+  <Target Name="IncludeAdb" BeforeTargets="_GetPackageFiles" DependsOnTargets="DownloadMlaunch">
     <ItemGroup>
       <WindowsAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb*" />
       <LinuxAdbFiles Include="$(IntermediateOutputPath)/android-tools-unzipped/linux/platform-tools/adb" />
@@ -76,17 +91,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DownloadMlaunch" BeforeTargets="Build" Condition=" '$(TargetFramework)' != '' ">
-    <PropertyGroup>
-      <RemoveSymbols></RemoveSymbols>
-      <RemoveSymbols Condition=" '$(Configuration)|$(OS)' == 'Release|Windows_NT' ">-RemoveSymbols</RemoveSymbols>
-      <RemoveSymbols Condition=" '$(Configuration)' == 'Release' AND '$(OS)' != 'Windows_NT' ">--remove-symbols</RemoveSymbols>
-    </PropertyGroup>
-
-    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
-
-    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
-
+  <Target Name="IncludeMlaunch" BeforeTargets="_GetPackageFiles" DependsOnTargets="DownloadMlaunch">
     <ItemGroup>
       <Content Include="$(IntermediateOutputPath)/mlaunch/**/*.*">
         <Pack>true</Pack>
@@ -94,6 +99,5 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
-
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -47,7 +47,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <Target Name="DownloadAndroidSdks" BeforeTargets="Build">
+  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
     <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(MacOsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(MacOsAndroidSdkFileName)" SkipUnchangedFiles="True" />
@@ -76,7 +76,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DownloadMlaunch" BeforeTargets="Build">
+  <Target Name="DownloadMlaunch" BeforeTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
     <PropertyGroup>
       <RemoveSymbols></RemoveSymbols>
       <RemoveSymbols Condition=" '$(Configuration)|$(OS)' == 'Release|Windows_NT' ">-RemoveSymbols</RemoveSymbols>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -47,7 +47,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
+  <Target Name="DownloadAndroidSdks" BeforeTargets="Build" Condition=" '$(TargetFramework)' != '' ">
     <DownloadFile SourceUrl="$(WindowsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(WindowsAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(LinuxAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(LinuxAndroidSdkFileName)" SkipUnchangedFiles="True" />
     <DownloadFile SourceUrl="$(MacOsAndroidSdkUrl)" DestinationFolder="$(IntermediateOutputPath)/android-tools/" DestinationFileName="$(MacOsAndroidSdkFileName)" SkipUnchangedFiles="True" />
@@ -76,16 +76,16 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="DownloadMlaunch" BeforeTargets="Build" Condition="'$(TargetFramework)' == 'net6.0'">
+  <Target Name="DownloadMlaunch" BeforeTargets="Build" Condition=" '$(TargetFramework)' != '' ">
     <PropertyGroup>
       <RemoveSymbols></RemoveSymbols>
       <RemoveSymbols Condition=" '$(Configuration)|$(OS)' == 'Release|Windows_NT' ">-RemoveSymbols</RemoveSymbols>
       <RemoveSymbols Condition=" '$(Configuration)' == 'Release' AND '$(OS)' != 'Windows_NT' ">--remove-symbols</RemoveSymbols>
     </PropertyGroup>
 
-    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
+    <Exec Condition=" '$(OS)' != 'Windows_NT' " Command="chmod 0755 ../../eng/download-mlaunch.sh &amp;&amp; ../../eng/download-mlaunch.sh --commit $(MlaunchVersion) --target $(TargetFramework) --target-dir $(IntermediateOutputPath)mlaunch $(RemoveSymbols)" />
 
-    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
+    <Exec Condition=" '$(OS)' == 'Windows_NT' " Command="powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { .\..\..\eng\download-mlaunch.ps1 -Commit '$(MlaunchVersion)' -Target $(TargetFramework) -TargetDir '$(IntermediateOutputPath)mlaunch' $(RemoveSymbols) } &quot;" />
 
     <ItemGroup>
       <Content Include="$(IntermediateOutputPath)/mlaunch/**/*.*">

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/Commands/XHarnessCommand.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
 
         protected abstract Task<ExitCode> InvokeInternal(ILogger logger);
 
-        private ILoggerFactory CreateLoggerFactory(LogLevel verbosity) => LoggerFactory.Create(builder =>
+        private static ILoggerFactory CreateLoggerFactory(LogLevel verbosity) => LoggerFactory.Create(builder =>
         {
             builder
                 .AddConsoleFormatter<XHarnessConsoleLoggerFormatter, SimpleConsoleFormatterOptions>(options => {

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     try
                     {
                         doc.Load(plistPath);
-                        _xcode_version = Version.Parse(doc.SelectSingleNode("//key[text() = 'CFBundleShortVersionString']/following-sibling::string").InnerText);
+                        _xcode_version = Version.Parse(doc.SelectSingleNode("//key[text() = 'CFBundleShortVersionString']/following-sibling::string")?.InnerText ?? throw new Exception("Failed to find the CFBundleShortVersionString property"));
                     }
                     catch (IOException)
                     {

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     log,
                     stdout,
                     stderr,
-                    (pid, signal) => kill(pid, signal),
+                    (pid, signal) => _ = kill(pid, signal),
                     (log, pid) => GetChildProcessIdsInternal(log, pid),
                     timeout)
                 .GetAwaiter().GetResult();

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -75,9 +75,9 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
 
         #endregion
 
-        #region Private methods
+        #region Static methods
 
-        private static string DetectXcodePath()
+        public static string DetectXcodePath()
         {
             using var process = new Process();
             process.StartInfo.FileName = "xcode-select";

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -253,8 +253,8 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
 
             if (process.StartInfo.EnvironmentVariables != null)
             {
-                var currentEnvironment = Environment.GetEnvironmentVariables().Cast<DictionaryEntry>().ToDictionary(v => v.Key.ToString(), v => v.Value?.ToString(), StringComparer.Ordinal);
-                var processEnvironment = process.StartInfo.EnvironmentVariables.Cast<DictionaryEntry>().ToDictionary(v => v.Key.ToString(), v => v.Value?.ToString(), StringComparer.Ordinal);
+                var currentEnvironment = ToDictionary(Environment.GetEnvironmentVariables());
+                var processEnvironment = ToDictionary(process.StartInfo.EnvironmentVariables);
                 var allVariables = currentEnvironment.Keys.Union(processEnvironment.Keys).Distinct();
 
                 bool headerShown = false;
@@ -392,6 +392,9 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             }
         }
 
-#endregion
+        private static Dictionary<string, string?> ToDictionary(IEnumerable enumerable) =>
+            enumerable.Cast<DictionaryEntry>().ToDictionary(v => v.Key.ToString()!, v => v.Value?.ToString(), StringComparer.Ordinal);
+
+        #endregion
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
         public override void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
 
         public override void Flush()

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ConsoleLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ConsoleLog.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
         public override void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/MemoryLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/MemoryLog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Text;
 
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
         public override void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
 
         public override string ToString() => _captured.ToString();

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
         {
         }
 
-        public void WriteLine(StringBuilder value)
+        public static void WriteLine(StringBuilder value)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/NullLog.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text;
 
 namespace Microsoft.DotNet.XHarness.Common.Logging
@@ -18,6 +19,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
 
         public void Flush()

--- a/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
     <!-- Mono.Options is apparently not strong-name signed -->

--- a/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/DefaultAndroidEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/DefaultAndroidEntryPoint.cs
@@ -28,8 +28,8 @@ namespace Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit
     public class DefaultAndroidEntryPoint : AndroidApplicationEntryPoint
     {
         private readonly string _resultsPath;
-        private readonly string _excludeCategoriesDir;
-        private readonly string _excludeCategoriesFile;
+        private readonly string? _excludeCategoriesDir;
+        private readonly string? _excludeCategoriesFile;
         private readonly Dictionary<string, string> _parsedArguments;
 
         public const string ResultsFileArgumentName = "results-file-name";
@@ -41,8 +41,8 @@ namespace Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit
         public const string ExcludeClassArgumentName = "exclude-class";
         public const string IncludeClassArgumentName = "include-class";
 
-        protected override string IgnoreFilesDirectory => _excludeCategoriesDir;
-        protected override string IgnoredTraitsFilePath => _excludeCategoriesFile;
+        protected override string? IgnoreFilesDirectory => _excludeCategoriesDir;
+        protected override string? IgnoredTraitsFilePath => _excludeCategoriesFile;
 
         public DefaultAndroidEntryPoint(string resultsPath, Dictionary<string, string> optionalBundle)
         {
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit
         {
             var testRunner = base.GetTestRunner(logWriter);
 
-            (string Filter, Action<string, bool> FilterMethod, bool IsExcluded)[] filters =
+            (string? Filter, Action<string, bool> FilterMethod, bool IsExcluded)[] filters =
             {
                 (_parsedArguments.GetValueOrDefault(ExcludeMethodArgumentName), testRunner.SkipMethod, true),
                 (_parsedArguments.GetValueOrDefault(ExcludeClassArgumentName), testRunner.SkipClass, true),

--- a/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/DefaultAndroidEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/DefaultAndroidEntryPoint.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit
         {
         }
 
-        private void ConfigureFilters(string? filter, Action<string, bool> filterMethod, bool isExcluded)
+        private static void ConfigureFilters(string? filter, Action<string, bool> filterMethod, bool isExcluded)
         {
             if (filter != null)
             {

--- a/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <nullable>enable</nullable>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
     <OutputType>Library</OutputType>

--- a/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.InstrumentationBase.Xunit/Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <nullable>enable</nullable>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
     <OutputType>Library</OutputType>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -18,9 +18,9 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
 
     internal class ApplicationOptions
     {
-        public static ApplicationOptions Current = new ApplicationOptions();
-        private readonly List<string> _singleMethodFilters = new List<string>();
-        private readonly List<string> _classMethodFilters = new List<string>();
+        public static ApplicationOptions Current = new();
+        private readonly List<string> _singleMethodFilters = new();
+        private readonly List<string> _classMethodFilters = new();
 
         public ApplicationOptions()
         {

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -6,6 +6,7 @@
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Common</RootNamespace>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Common</RootNamespace>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -3,10 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <LangVersion>9.0</LangVersion>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
-    <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Common</RootNamespace>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <LangVersion>9.0</LangVersion>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Common</RootNamespace>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
@@ -127,11 +127,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
 
         protected void OnInfo(string message) => Logger.OnInfo(message);
 
-        protected static void OnAssemblyStart(Assembly asm)
+        protected void OnAssemblyStart(Assembly asm)
         {
         }
 
-        protected static void OnAssemblyFinish(Assembly asm)
+        protected void OnAssemblyFinish(Assembly asm)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
@@ -127,11 +127,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
 
         protected void OnInfo(string message) => Logger.OnInfo(message);
 
-        protected void OnAssemblyStart(Assembly asm)
+        protected static void OnAssemblyStart(Assembly asm)
         {
         }
 
-        protected void OnAssemblyFinish(Assembly asm)
+        protected static void OnAssemblyFinish(Assembly asm)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/FilterBuilder.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/FilterBuilder.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using NUnit.Engine;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/INUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/INUnitTestRunner.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.DotNet.XHarness.TestRunners.Common;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Nullable>enable</Nullable>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/Microsoft.DotNet.XHarness.TestRunners.NUnit.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
     <Nullable>disable</Nullable>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnit3XmlOutputWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnit3XmlOutputWriter.cs
@@ -10,6 +10,7 @@ using System.Xml;
 using Microsoft.DotNet.XHarness.Common;
 using NUnit.Framework.Internal;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
 {
     /// <summary>
@@ -120,6 +121,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
 
         private void WriteResultElement(IResultSummary result)
         {
+            if (_xmlWriter == null) // should never happen, would mean a programmer's error
+            {
+                throw new InvalidOperationException("Null writer");
+            }
+
             // much simpler than in other writers, we just need to get the child nodes of each of the test-run and write
             // them. NUnit3 already gave us the xml we need to use
             foreach (var testRun in result)
@@ -127,12 +133,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
                 for (var i = 0; i < testRun.Result.ChildNodes.Count; i++)
                 {
                     var node = testRun.Result.ChildNodes[i];
-                    if (node.Name == "environment")
+                    if (node?.Name == "environment")
                     {
                         continue;
                     }
 
-                    node.WriteTo(_xmlWriter);
+                    node?.WriteTo(_xmlWriter);
                 }
             }
         }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnitTestRunner.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.TestRunners.Common;
 using NUnit.Engine;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
 {
     internal class NUnitTestRunner : TestRunner, INUnitTestRunner

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/TestStatusExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/TestStatusExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.NUnit
                 TestStatus.Skipped => "Skip",
                 _ => "Fail",
             },
-            _ => throw new ArgumentOutOfRangeException(),
+            _ => throw new ArgumentOutOfRangeException(nameof(status)),
         };
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
     <Nullable>disable</Nullable>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
     <Nullable>disable</Nullable>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
     <Nullable>disable</Nullable>
     <LangVersion>9.0</LangVersion>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -4,6 +4,7 @@
     <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Microsoft.DotNet.XHarness.TestRunners.Xunit</RootNamespace>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 {
     internal class ThreadlessXunitTestRunner
     {
-        public async Task<int> Run(string assemblyFileName, bool printXml, XunitFilters filters)
+        public static async Task<int> Run(string assemblyFileName, bool printXml, XunitFilters filters)
         {
             var configuration = new TestAssemblyConfiguration() { ShadowCopy = false, ParallelizeAssembly = false, ParallelizeTestCollections = false, MaxParallelThreads = 1, PreEnumerateTheories = false };
             var discoveryOptions = TestFrameworkOptions.ForDiscovery(configuration);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
@@ -22,7 +22,6 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
         public async Task<int> Run()
         {
-            var testRunner = new ThreadlessXunitTestRunner();
             var filters = new XunitFilters();
 
             foreach (var trait in ExcludedTraits) ParseEqualSeparatedArgument(filters.ExcludedTraits, trait);
@@ -31,12 +30,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             foreach (var cl in IncludedClasses) filters.IncludedClasses.Add(cl);
             foreach (var me in IncludedMethods) filters.IncludedMethods.Add(me);
 
-            var result = await testRunner.Run(TestAssembly, printXml: true, filters);
+            var result = await ThreadlessXunitTestRunner.Run(TestAssembly, printXml: true, filters);
 
             return result;
         }
 
-        private void ParseEqualSeparatedArgument(Dictionary<string, List<string>> targetDictionary, string argument)
+        private static void ParseEqualSeparatedArgument(Dictionary<string, List<string>> targetDictionary, string argument)
         {
             var parts = argument.Split('=');
             if (parts.Length != 2 || string.IsNullOrEmpty(parts[0]) || string.IsNullOrEmpty(parts[1]))

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitFilter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitFilter.cs
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             return excluded;
         }
 
-        private bool ReportFilteredAssembly(TestAssemblyInfo assemblyInfo, bool excluded, Action<string>? log = null)
+        private static bool ReportFilteredAssembly(TestAssemblyInfo assemblyInfo, bool excluded, Action<string>? log = null)
         {
             if (log == null)
             {

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitFilter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitFilter.cs
@@ -127,6 +127,8 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
                     {
                         return log(Exclude);
                     }
+
+                    return log(!Exclude);
                 }
 
                 return values.Any(value => value.Equals(SelectorValue, StringComparison.InvariantCultureIgnoreCase)) ?

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
         public int? MaxParallelThreads { get; set; }
 
         private XElement _assembliesElement;
-        private XUnitFiltersCollection _filters = new XUnitFiltersCollection();
+        private XUnitFiltersCollection _filters = new();
 
         public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
         protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -727,7 +727,9 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
         private Action<string> EnsureLogger(Action<string> log) => log ?? OnInfo;
 
+#pragma warning disable IDE0060 // Remove unused parameter
         private void LogTestMethodDetails(IMethodInfo method, Action<string> log = null, StringBuilder sb = null)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
             // log = EnsureLogger(log);
             // log ($"   Test method name: {method.Type.Name}.{method.Name}");

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -728,7 +728,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
         private Action<string> EnsureLogger(Action<string> log) => log ?? OnInfo;
 
 #pragma warning disable IDE0060 // Remove unused parameter
-        private void LogTestMethodDetails(IMethodInfo method, Action<string> log = null, StringBuilder sb = null)
+        private static void LogTestMethodDetails(IMethodInfo method, Action<string> log = null, StringBuilder sb = null)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
             // log = EnsureLogger(log);
@@ -806,7 +806,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             sb?.AppendLine();
         }
 
-        private string GetAssemblyInfo(ITestAssembly assembly)
+        private static string GetAssemblyInfo(ITestAssembly assembly)
         {
             string name = assembly?.Assembly?.Name?.Trim();
             if (string.IsNullOrEmpty(name))

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
@@ -156,7 +156,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 
             IEnumerable<IHardwareDevice> compatibleDevices = ConnectedDevices.Where(v => deviceClasses.Contains(v.DeviceClass) && v.IsUsableForDebugging != false);
             IHardwareDevice device;
-            if (compatibleDevices.Count() == 0)
+            if (!compatibleDevices.Any())
             {
                 throw new NoDeviceFoundException($"Could not find any applicable devices with device class(es): {string.Join(", ", deviceClasses)}");
             }
@@ -185,14 +185,15 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
             await LoadDevices(log, false, false);
 
             var companion = ConnectedDevices.Where((v) => v.DeviceIdentifier == device.CompanionIdentifier);
-            if (companion.Count() == 0)
+            var count = companion.Count();
+            if (count == 0)
             {
                 throw new Exception($"Could not find the companion device for '{device.Name}'");
             }
 
-            if (companion.Count() > 1)
+            if (count > 1)
             {
-                log.WriteLine("Found {0} companion devices for {1}?!?", companion.Count(), device.Name);
+                log.WriteLine("Found {0} companion devices for {1}?!?", count, device.Name);
             }
 
             return companion.First();

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -103,7 +103,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             }
         }
 
-        public virtual void Dispose() => TestLog.Dispose();
+        public virtual void Dispose()
+        {
+            TestLog.Dispose();
+            GC.SuppressFinalize(this);
+        }
     }
 }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -110,6 +110,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             await _tcpTunnelExecutionTask;
         }
 
-        public async ValueTask DisposeAsync() => await Close();
+        public async ValueTask DisposeAsync()
+        {
+            await Close();
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
@@ -73,6 +73,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     await tunnel.DisposeAsync(); // alls close already
                 }
             }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
@@ -55,6 +55,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         {
             _copyTo.Dispose();
             _cancellationSource.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         private void ResetTimer() => _cancellationSource.CancelAfter(TimeSpan.FromMinutes(1));

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
@@ -187,6 +187,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
         public override void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
@@ -86,6 +86,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             }
 
             _disposed = true;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
@@ -87,6 +87,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             {
                 log.Dispose();
             }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-  
+
   <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             TestTarget.Simulator_tvOS => "tvos-simulator",
             TestTarget.Simulator_watchOS => "watchos-simulator",
             TestTarget.MacCatalyst => "maccatalyst",
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(target))
         };
 
         public static string AsString(this TestTargetOs targetOs) =>
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             "maccatalyst" => TestTarget.MacCatalyst,
             null => TestTarget.None,
             "" => TestTarget.None,
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(target))
         };
 
         public static TestTargetOs ParseAsAppRunnerTargetOs(this string targetName)
@@ -67,14 +67,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
         {
             "com.apple.widget-extension" => Extension.TodayExtension,
             "com.apple.watchkit" => Extension.WatchKit2,
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(identifier))
         };
 
         public static string AsNSExtensionPointIdentifier(this Extension extension) => extension switch
         {
             Extension.TodayExtension => "com.apple.widget-extension",
             Extension.WatchKit2 => "com.apple.watchkit",
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(extension))
         };
 
         public static void DoNotAwait(this Task task)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -1212,7 +1212,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             {
                 "MtouchExtraArgs",
             };
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             Func<string, string>? convert = null;
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
             convert = (input) =>
             {
                 if (input.IndexOf(';') >= 0)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/ProjectFileExtensions.cs
@@ -1217,7 +1217,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
 #pragma warning restore IDE0059 // Unnecessary assignment of a value
             convert = (input) =>
             {
-                if (input.IndexOf(';') >= 0)
+                if (input.Contains(';'))
                 {
                     var split = input.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
                     for (var i = 0; i < split.Length; i++)

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -48,7 +48,11 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
                It.IsAny<TimeSpan>())).Returns((string p, string a, TimeSpan t) => CallFakeProcessManager(p, a, t));
         }
 
-        public void Dispose() => Directory.Delete(s_scratchAndOutputPath, true);
+        public void Dispose()
+        {
+            Directory.Delete(s_scratchAndOutputPath, true);
+            GC.SuppressFinalize(this);
+        }
 
         #region Tests
 

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -231,7 +231,7 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
         #region Helper Functions
         // Generates a list of fake devices, one per supported architecture so we can test AdbRunner's parsing of the output.
         // As with most of these tests, if adb.exe changes, this will break (we are locked into specific version) 
-        private Dictionary<Tuple<string, string>, int> InitializeFakeDeviceList()
+        private static Dictionary<Tuple<string, string>, int> InitializeFakeDeviceList()
         {
             var r = new Random();
             var values = new Dictionary<Tuple<string, string>, int>

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppInstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppInstallerTests.cs
@@ -57,7 +57,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 extension: null);
         }
 
-        public void Dispose() => Directory.Delete(s_appPath, true);
+        public void Dispose()
+        {
+            Directory.Delete(s_appPath, true);
+            GC.SuppressFinalize(this);
+        }
 
         [Fact]
         public async Task InstallToSimulatorTest()

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -101,7 +101,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             Directory.CreateDirectory(s_outputPath);
         }
 
-        public void Dispose() => Directory.Delete(s_outputPath, true);
+        public void Dispose()
+        {
+            Directory.Delete(s_outputPath, true);
+            GC.SuppressFinalize(this);
+        }
 
         [Fact]
         public async Task RunOnSimulatorWithNoAvailableSimulatorTest()

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -138,7 +138,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             Directory.CreateDirectory(s_outputPath);
         }
 
-        public void Dispose() => Directory.Delete(s_outputPath, true);
+        public void Dispose()
+        {
+            Directory.Delete(s_outputPath, true);
+            GC.SuppressFinalize(this);
+        }
 
         [Theory]
         [InlineData(false)]

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/ErrorKnowledgeBaseTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/ErrorKnowledgeBaseTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             {
                 File.Delete(_logPath);
             }
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
@@ -152,6 +152,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             {
                 File.Delete(_tempFilename);
             }
+            GC.SuppressFinalize(this);
         }
 
         private static IFileBackedLog GetLogMock(string[] loglines)

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/ExitCodeDetectorTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 {
     public class ExitCodeDetectorTests : IDisposable
     {
-        private string _tempFilename = null;
+        private readonly string _tempFilename = null;
 
         [Fact]
         public void ExitCodeIsDetectedTest()

--- a/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ConsoleLogTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ConsoleLogTest.cs
@@ -49,6 +49,7 @@ namespace Microsoft.DotNet.XHarness.Common.Tests.Logging
             _log.Dispose();
             Console.SetOut(_sdoutWriter); // get back to write to the console
             File.Delete(_testFile);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/NUnit/NUnit3XmlOutputWriterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/NUnit/NUnit3XmlOutputWriterTests.cs
@@ -91,6 +91,10 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Tests.NUnit
             Assert.Equal(1, enviroment.Count);
         }
 
-        public void Dispose() => File.Delete(_tempPath);
+        public void Dispose()
+        {
+            File.Delete(_tempPath);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/AppBundleInformationParserTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/AppBundleInformationParserTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
         {
             Directory.Delete(s_appPath, true);
             Directory.Delete(s_appPath2, true);
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
@@ -45,7 +45,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             File.WriteAllText(Path.Combine(_symbolicatePath, "symbolicatecrash"), "");
         }
 
-        public void Dispose() => Directory.Delete(_tempXcodeRoot, true);
+        public void Dispose()
+        {
+            Directory.Delete(_tempXcodeRoot, true);
+            GC.SuppressFinalize(this);
+        }
 
         [Fact]
         public async Task DeviceCaptureTest()

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             {
                 File.Delete(_path);
             }
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Moq;
@@ -21,7 +22,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         }
 
         [Fact]
-        public void ConstructorAllowsNullTunnelBore() => _ = new SimpleListenerFactory(null); // if it throws, test fails ;)
+        public void ConstructorAllowsNullTunnelBore()
+        {
+            _ = new SimpleListenerFactory(null); // if it throws, test fails ;)
+        }
 
         [Fact]
         public void CreateNotWatchListener()

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         }
 
         [Fact]
-        public void ConstructorAllowsNullTunnelBore() => new SimpleListenerFactory(null); // if it throws, test fails ;)
+        public void ConstructorAllowsNullTunnelBore() => _ = new SimpleListenerFactory(null); // if it throws, test fails ;)
 
         [Fact]
         public void CreateNotWatchListener()

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/CaptureLogTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/CaptureLogTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Logging
             {
                 File.Delete(_filePath);
             }
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/LogFileTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/LogFileTest.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Logging
             {
                 File.Delete(_path);
             }
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/LogsTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Logging/LogsTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Logging
             {
                 Directory.Delete(_directory, true);
             }
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
             {
                 Directory.Delete(_logsDirectory, true);
             }
+            GC.SuppressFinalize(this);
         }
 
         private Stream GetRunLogSample()

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Utilities/ProjectFileExtensionsTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Utilities/ProjectFileExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Utilities
 			return doc;
 		}
 
-        private XmlDocument GetMSBuildProject(string snippet)
+        private static XmlDocument GetMSBuildProject(string snippet)
 		{
 			return CreateDoc($@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project DefaultTargets=""Build"" ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/XmlResultParserTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/XmlResultParserTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
 {
     public class XmlResultParserTests
     {
-        private static readonly Dictionary<XmlResultJargon, Action<string, string, string, string, string, string, string, int>> s_validationMap = new Dictionary<XmlResultJargon, Action<string, string, string, string, string, string, string, int>>
+        private static readonly Dictionary<XmlResultJargon, Action<string, string, string, string, string, string, string, int>> s_validationMap = new()
         {
             [XmlResultJargon.NUnitV2] = ValidateNUnitV2Failure,
             [XmlResultJargon.NUnitV3] = ValidateNUnitV3Failure,


### PR DESCRIPTION
- Adds the .NET 6.0 target to XHarness CLI
  - We need both first so that Helix SDK doesn't break, switch it there and remove 3.1 after
- Changes libraries from `netstandard2.1` to `net6.0` and multitargets to both where needed (Apple, Android)
- Fixes warnings that would break the build
  - WebClient is deprecated
  - Nullability issues
- Resolves most of the build messages to clean the solution
  - Naming
  - Static methods where possible
  - Calling `GC.SuppressFinalize`
  - using `new ()`

#456