### PR TITLE
Accept test targets when working with the simulators command

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
@@ -2,30 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {
     internal class FindCommandArguments : SimulatorsCommandArguments
     {
-        public IEnumerable<string> Simulators { get; } = new List<string>();
-
-        protected override OptionSet GetAdditionalOptions() => new OptionSet
-        {
-            { "s|simulator=", "ID of the Simulator to look for. Repeat multiple times to define more", v => ((IList<string>)Simulators).Add(v) },
-        };
-
-        public override void Validate()
-        {
-            base.Validate();
-
-            if (!Simulators.Any())
-            {
-                throw new ArgumentException("At least one --simulator is expected");
-            }
-        }
+        protected override OptionSet GetAdditionalOptions() => new OptionSet();
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
@@ -2,80 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.DotNet.XHarness.iOS.Shared;
-using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {
     internal class InstallCommandArguments : SimulatorsCommandArguments
     {
-        private readonly List<string> _simulators = new List<string>();
-        public IEnumerable<string> Simulators => _simulators;
         public bool Force { get; private set; } = false;
 
         protected override OptionSet GetAdditionalOptions() => new OptionSet
         {
-            { "s|simulator=",
-                "ID of the Simulator to install (e.g. com.apple.pkg.AppleTVSimulatorSDK14_2). " +
-                "You can also use the format in which you specify apple targets for XHarness tests. " +
-                "Repeat multiple times to define more",
-                v =>
-                {
-                    if (v.StartsWith("com.apple.pkg."))
-                    {
-                        _simulators.Add(v);
-                        return;
-                    }
-
-                    TestTargetOs target;
-                    try
-                    {
-                        target = v.ParseAsAppRunnerTargetOs();
-                    }
-                    catch (ArgumentOutOfRangeException)
-                    {
-                        throw new ArgumentException(
-                            $"Failed to parse simulator '{v}'. Available values are ios-simulator, tvos-simulator and watchos-simulator." +
-                            Environment.NewLine + Environment.NewLine +
-                            "You need to also specify the version. Example: ios-simulator_13.4");
-                    }
-
-                    if (string.IsNullOrEmpty(target.OSVersion))
-                    {
-                        throw new ArgumentException($"Failed to parse simulator '{v}'. " +
-                            $"You need to specify the exact version. Example: ios-simulator_13.4");
-                    }
-
-                    string simulatorName = target.Platform switch
-                    {
-                        TestTarget.Simulator_iOS => "iPhone",
-                        TestTarget.Simulator_tvOS => "AppleTV",
-                        TestTarget.Simulator_watchOS => "Watch",
-                        _ => throw new ArgumentException($"Failed to parse simulator '{v}'. " +
-                            "Available values are ios-simulator, tvos-simulator and watchos-simulator." +
-                            Environment.NewLine + Environment.NewLine +
-                            "You need to also specify the version. Example: ios-simulator_13.4"),
-                    };
-
-                    // e.g. com.apple.pkg.AppleTVSimulatorSDK14_3
-                    _simulators.Add($"com.apple.pkg.{simulatorName}SimulatorSDK{target.OSVersion.Replace(".", "_")}");
-                }
-            },
             { "force", "Install again even if already installed", v => Force = true },
         };
-
-        public override void Validate()
-        {
-            base.Validate();
-
-            if (!Simulators.Any())
-            {
-                throw new ArgumentException("At least one --simulator is expected");
-            }
-        }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
@@ -5,18 +5,66 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {
     internal class InstallCommandArguments : SimulatorsCommandArguments
     {
-        public IEnumerable<string> Simulators { get; } = new List<string>();
+        private readonly List<string> _simulators = new List<string>();
+        public IEnumerable<string> Simulators => _simulators;
         public bool Force { get; private set; } = false;
 
         protected override OptionSet GetAdditionalOptions() => new OptionSet
         {
-            { "s|simulator=", "ID of the Simulator to install. Repeat multiple times to define more", v => ((IList<string>)Simulators).Add(v) },
+            { "s|simulator=",
+                "ID of the Simulator to install (e.g. com.apple.pkg.AppleTVSimulatorSDK14_2). " +
+                "You can also use the format in which you specify apple targets for XHarness tests. " +
+                "Repeat multiple times to define more",
+                v =>
+                {
+                    if (v.StartsWith("com.apple.pkg."))
+                    {
+                        _simulators.Add(v);
+                        return;
+                    }
+
+                    TestTargetOs target;
+                    try
+                    {
+                        target = v.ParseAsAppRunnerTargetOs();
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        throw new ArgumentException(
+                            $"Failed to parse simulator '{v}'. Available values are ios-simulator, tvos-simulator and watchos-simulator." +
+                            Environment.NewLine + Environment.NewLine +
+                            "You need to also specify the version. Example: ios-simulator_13.4");
+                    }
+
+                    if (string.IsNullOrEmpty(target.OSVersion))
+                    {
+                        throw new ArgumentException($"Failed to parse simulator '{v}'. " +
+                            $"You need to specify the exact version. Example: ios-simulator_13.4");
+                    }
+
+                    string simulatorName = target.Platform switch
+                    {
+                        TestTarget.Simulator_iOS => "iPhone",
+                        TestTarget.Simulator_tvOS => "AppleTV",
+                        TestTarget.Simulator_watchOS => "Watch",
+                        _ => throw new ArgumentException($"Failed to parse simulator '{v}'. " +
+                            "Available values are ios-simulator, tvos-simulator and watchos-simulator." +
+                            Environment.NewLine + Environment.NewLine +
+                            "You need to also specify the version. Example: ios-simulator_13.4"),
+                    };
+
+                    // e.g. com.apple.pkg.AppleTVSimulatorSDK14_3
+                    _simulators.Add($"com.apple.pkg.{simulatorName}SimulatorSDK{target.OSVersion.Replace(".", "_")}");
+                }
+            },
             { "force", "Install again even if already installed", v => Force = true },
         };
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/FindCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/FindCommand.cs
@@ -11,19 +11,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 {
-    internal class FindCommand : SimulatorInstallerCommand
+    internal class FindCommand : SimulatorsCommand
     {
         private const string CommandName = "find";
         private const string CommandHelp = "Finds whether given simulators are installed and outputs list of missing ones (returns 0 when none missing)";
 
-        protected override string CommandUsage => CommandName + " [OPTIONS]";
+        protected override string CommandUsage => CommandName + " [OPTIONS] [SIMULATOR] [SIMULATOR] ..";
 
-        protected override string CommandDescription => CommandHelp;
+        protected override string CommandDescription => CommandHelp + Environment.NewLine + Environment.NewLine + SimulatorHelpString;
 
         private readonly FindCommandArguments _arguments = new FindCommandArguments();
         protected override SimulatorsCommandArguments SimulatorsArguments => _arguments;
 
-        public FindCommand() : base(CommandName, CommandHelp)
+        public FindCommand() : base(CommandName, true, CommandHelp)
         {
         }
 
@@ -31,10 +31,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
         {
             Logger = logger;
 
+            var searchedSimulators = ParseSimulatorIds();
+
             var simulators = await GetAvailableSimulators();
             var exitCode = ExitCode.SUCCESS;
 
-            var unknownSimulators = _arguments.Simulators.Where(identifier =>
+            var unknownSimulators = searchedSimulators.Where(identifier =>
                 !simulators.Any(sim => sim.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase)));
 
             if (unknownSimulators.Any())
@@ -60,7 +62,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
             {
                 var installedVersion = await IsInstalled(simulator.Identifier);
 
-                if (installedVersion == null && _arguments.Simulators.Any(identifier => simulator.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase)))
+                if (installedVersion == null && searchedSimulators.Any(identifier => simulator.Identifier.Equals(identifier, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     if (_arguments.Verbosity == LogLevel.Debug)
                     {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/ListCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/ListCommand.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 {
-    internal class ListCommand : SimulatorInstallerCommand
+    internal class ListCommand : SimulatorsCommand
     {
         private const string CommandName = "list";
         private const string CommandHelp = "Lists available simulators";
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
         private readonly ListCommandArguments _arguments = new ListCommandArguments();
         protected override SimulatorsCommandArguments SimulatorsArguments => _arguments;
 
-        public ListCommand() : base(CommandName, CommandHelp)
+        public ListCommand() : base(CommandName, false, CommandHelp)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -194,6 +194,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
                 string simulatorName = target.Platform switch
                 {
                     TestTarget.Simulator_iOS => "iPhone",
+                    TestTarget.Simulator_iOS32 => "iPhone",
+                    TestTarget.Simulator_iOS64 => "iPhone",
                     TestTarget.Simulator_tvOS => "AppleTV",
                     TestTarget.Simulator_watchOS => "Watch",
                     _ => throw new ArgumentException($"Failed to parse simulator '{argument}'. " +

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -15,11 +15,13 @@ using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 {
-    internal abstract class SimulatorInstallerCommand : XHarnessCommand
+    internal abstract class SimulatorsCommand : XHarnessCommand
     {
         private const string MAJOR_VERSION_PLACEHOLDER = "DOWNLOADABLE_VERSION_MAJOR";
         private const string MINOR_VERSION_PLACEHOLDER = "DOWNLOADABLE_VERSION_MINOR";
@@ -27,6 +29,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
         private const string IDENTIFIER_PLACEHOLDER = "DOWNLOADABLE_IDENTIFIER";
 
         private const string SimulatorIndexUrl = "https://devimages-cdn.apple.com/downloads/xcode/simulators/index-{0}-{1}.dvtdownloadableindex";
+
+        protected const string SimulatorHelpString = 
+            "Accepts a list of simulator IDs to install. The ID can be a fully qualified string, " +
+            "e.g. com.apple.pkg.AppleTVSimulatorSDK14_2 or you can use the format in which you specify " +
+            "apple targets for XHarness tests (ios-simulator, tvos-simulator, watchos-simulator).";
 
         private readonly MacOSProcessManager _processManager = new MacOSProcessManager();
 
@@ -36,7 +43,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
 
         protected abstract SimulatorsCommandArguments SimulatorsArguments { get; }
 
-        protected SimulatorInstallerCommand(string name, string help) : base(name, false, help)
+        protected SimulatorsCommand(string name, bool allowsExtraArgs, string help) : base(name, allowsExtraArgs, help)
         {
         }
 
@@ -151,6 +158,55 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators
             var lines = pkgInfo.Split('\n');
             var version = lines.First(v => v.StartsWith("version: ", StringComparison.Ordinal)).Substring("version: ".Length);
             return Version.Parse(version);
+        }
+
+        protected IEnumerable<string> ParseSimulatorIds()
+        {
+            var simulators = new List<string>();
+
+            foreach (string argument in ExtraArguments)
+            {
+                if (argument.StartsWith("com.apple.pkg."))
+                {
+                    simulators.Add(argument);
+                    continue;
+                }
+
+                TestTargetOs target;
+                try
+                {
+                    target = argument.ParseAsAppRunnerTargetOs();
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    throw new ArgumentException(
+                        $"Failed to parse simulator '{argument}'. Available values are ios-simulator, tvos-simulator and watchos-simulator." +
+                        Environment.NewLine + Environment.NewLine +
+                        "You need to also specify the version. Example: ios-simulator_13.4");
+                }
+
+                if (string.IsNullOrEmpty(target.OSVersion))
+                {
+                    throw new ArgumentException($"Failed to parse simulator '{argument}'. " +
+                        $"You need to specify the exact version. Example: ios-simulator_13.4");
+                }
+
+                string simulatorName = target.Platform switch
+                {
+                    TestTarget.Simulator_iOS => "iPhone",
+                    TestTarget.Simulator_tvOS => "AppleTV",
+                    TestTarget.Simulator_watchOS => "Watch",
+                    _ => throw new ArgumentException($"Failed to parse simulator '{argument}'. " +
+                        "Available values are ios-simulator, tvos-simulator and watchos-simulator." +
+                        Environment.NewLine + Environment.NewLine +
+                        "You need to also specify the version. Example: ios-simulator_13.4"),
+                };
+
+                // e.g. com.apple.pkg.AppleTVSimulatorSDK14_3
+                simulators.Add($"com.apple.pkg.{simulatorName}SimulatorSDK{target.OSVersion.Replace(".", "_")}");
+            }
+
+            return simulators;
         }
 
         private async Task<string?> GetSimulatorIndexXml()


### PR DESCRIPTION
XHarness simulators command now also accepts target runtimes in the same format as test targets. These formats are now equivalent:
- `com.apple.pkg.iPhoneSimulatorSDK14_3`
- `ios-simulator_14.3`

There is also a breaking change for the `install` and `find` commands - we now accept the list of simulators as positional arguments instead of `--simulator` arguments. The new usage is this:
```
xharness apple simulators install ios-simulator_14.3 tvos-simulator_11.6
```

Resolves #478 