### PR TITLE
Fix configuration of test filtering in Android application test runner

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.XHarness.TestRunners.Common
@@ -158,7 +157,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
             runner.RunAllTestsByDefault = options.RunAllTestsByDefault;
 
             // Add the provided method and class filters
-            if (options.SingleMethodFilters.Any() || options.ClassMethodFilters.Any())
+            if (options.SingleMethodFilters.Count != 0 || options.ClassMethodFilters.Count != 0)
             {
                 // Having methods/classes explicitly specified means only those methods/classes should be run
                 runner.RunAllTestsByDefault = false;

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.XHarness.TestRunners.Common
@@ -152,18 +153,24 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
             return categories;
         }
 
-        internal static void ConfigureRunner(TestRunner runner, ApplicationOptions options)
+        internal static void ConfigureRunnerFilters(TestRunner runner, ApplicationOptions options)
         {
             runner.RunAllTestsByDefault = options.RunAllTestsByDefault;
-            // add the provided method and class filters
-            foreach (string methodName in options.SingleMethodFilters)
-            {
-                runner.SkipMethod(methodName, !options.RunAllTestsByDefault);
-            }
 
-            foreach (string className in options.ClassMethodFilters)
+            // Add the provided method and class filters
+            if (options.SingleMethodFilters.Any() || options.ClassMethodFilters.Any())
             {
-                runner.SkipClass(className, !options.RunAllTestsByDefault);
+                // Having methods/classes explicitly specified means only those methods/classes should be run
+                runner.RunAllTestsByDefault = false;
+                foreach (string methodName in options.SingleMethodFilters)
+                {
+                    runner.SkipMethod(methodName, isExcluded: false);
+                }
+
+                foreach (string className in options.ClassMethodFilters)
+                {
+                    runner.SkipClass(className, isExcluded: false);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -151,11 +151,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
         /// <summary>
         /// Specify the methods to be ran in the app.
         /// </summary>
-        public IEnumerable<string> SingleMethodFilters => _singleMethodFilters;
+        public ICollection<string> SingleMethodFilters => _singleMethodFilters;
 
         /// <summary>
         /// Specify the test classes to be ran in the app.
         /// </summary>
-        public IEnumerable<string> ClassMethodFilters => _classMethodFilters;
+        public ICollection<string> ClassMethodFilters => _classMethodFilters;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
@@ -28,8 +28,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
         protected override bool IsXunit => true;
 
-        protected override TestRunner GetTestRunner(LogWriter logWriter) =>
-            new XUnitTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
+        protected override TestRunner GetTestRunner(LogWriter logWriter)
+        {
+            var runner = new XUnitTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
+            ConfigureRunnerFilters(runner, ApplicationOptions.Current);
+            return runner;
+        }
 
         public override async Task RunAsync()
         {
@@ -41,8 +45,6 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             logger.MinimumLogLevel = MinimumLogLevel.Info;
 
             var runner = await InternalRunAsync(logger);
-            ConfigureRunner(runner, options);
-
             if (options.EnableXml)
             {
                 if (TestsResultsFinalPath == null)

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -875,7 +875,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             Action<string> log = LogExcludedTests ? (s) => do_log(s) : (Action<string>)null;
             foreach (TestAssemblyInfo assemblyInfo in testAssemblies)
             {
-                if (assemblyInfo == null || assemblyInfo.Assembly == null || _filters.IsExcluded(assemblyInfo, log))
+                if (assemblyInfo == null || assemblyInfo.Assembly == null)
+                {
+                    continue;
+                }
+
+                if (_filters.AssemblyFilters.Any() && _filters.IsExcluded(assemblyInfo, log))
                 {
                     continue;
                 }
@@ -1096,7 +1101,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
                     TotalTests += discoverySink.TestCases.Count;
                     List<ITestCase> testCases;
-                    if (_filters != null && _filters.Count > 0)
+                    if (_filters != null && _filters.TestCaseFilters.Any())
                     {
                         Action<string> log = LogExcludedTests ? (s) => do_log(s) : (Action<string>)null;
                         testCases = discoverySink.TestCases.Where(

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -39,12 +39,6 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
         public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
         protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
 
-        public override bool RunAllTestsByDefault
-        {
-            get => _filters.RunAllTestsByDefault;
-            set => _filters.RunAllTestsByDefault = value;
-        }
-
         public XUnitTestRunner(LogWriter logger) : base(logger)
         {
             _messageSink = new TestMessageSink();

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
@@ -10,8 +10,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 {
     public abstract class iOSApplicationEntryPoint : ApplicationEntryPoint
     {
-        protected override TestRunner GetTestRunner(LogWriter logWriter) =>
-            new XUnitTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
+        protected override TestRunner GetTestRunner(LogWriter logWriter)
+        {
+            var runner = new XUnitTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
+            ConfigureRunnerFilters(runner, ApplicationOptions.Current);
+            return runner;
+        }
 
         protected override bool IsXunit => true;
 
@@ -40,8 +44,6 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             // if we have ignore files, ignore those tests
             var runner = await InternalRunAsync(logger);
-
-            ConfigureRunner(runner, options);
 
             WriteResults(runner, options, logger, writer ?? Console.Out);
 


### PR DESCRIPTION
- Application entry points: configure test runner with current application options
  - Android and iOS application entry points were running the tests and then trying to configure filters for the test run afterwards.
- XUnit test case filtering:
  - Handle different test case filter types separately
  - Use added filters to determine the default for include/exclude
- Add tests for XUnit test case filtering

cc @steveisok @jkoritzinsky 