### PR TITLE
Fix arguments of `android device` command

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -2,20 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
-    internal class AndroidGetDeviceCommandArguments : TestCommandArguments
+    internal class AndroidGetDeviceCommandArguments : XHarnessCommandArguments
     {
+        private string? _appPackagePath = null;
+
+        /// <summary>
+        /// Path to packaged app
+        /// </summary>
+        public string AppPackagePath
+        {
+            get => _appPackagePath ?? throw new ArgumentException("You must provide a path for the app that will be tested.");
+            set => _appPackagePath = value;
+        }
+
         /// <summary>
         /// If specified, attempt to run on a compatible attached device, failing if unavailable.
         /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
         /// </summary>
         public string? DeviceArchitecture { get; set; }
 
-        protected override OptionSet GetTestCommandOptions() => new()
+        protected override OptionSet GetCommandOptions() => new()
         {
+            { "app|a=", "Path to already-packaged app",
+                v => AppPackagePath = RootPath(v)
+            },
             { "device-arch=", "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK",
                 v => DeviceArchitecture = v
             },
@@ -23,8 +39,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public override void Validate()
         {
-            base.Validate();
-
             // Validate this field
             _ = AppPackagePath;
         }


### PR DESCRIPTION
Possibly related to why we see more arguments than we need (#431)