### PR TITLE
[wasm] Add support for running in debugging mode

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -44,6 +44,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public List<string> BrowserArgs { get; set; } = new List<string>();
         public string HTMLFile { get; set; } = "index.html";
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
+        public int? DebuggerPort { get; set; }
+        public bool Incognito { get; set; } = true;
+        public bool Headless { get; set; } = true;
+        public bool QuitAppAtEnd { get; set; } = true;
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -59,18 +63,21 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             { "html-file=", "Main html file to load from the app directory. Default is index.html",
                 v => HTMLFile = v
             },
-            { "expected-exit-code=", "If specified, sets the expected exit code for a successful test run.",
-                v => {
-                    if (int.TryParse(v, out var number))
-                    {
-                        ExpectedExitCode = number;
-                    }
-                    else
-                    {
-                        throw new ArgumentException("expected-exit-code must be an integer");
-                    }
-                }
+            { "debugger=|d=", "Run browser in debug mode, with a port to listen on. Default port number is 9222",
+                v => DebuggerPort = ParseAsIntOrThrow(v, "debugger")
             },
+            { "no-incognito", "Don't run in incognito mode.",
+                v => Incognito = false
+            },
+            { "no-headless", "Don't run in headless mode.",
+                v => Headless = false
+            },
+            { "no-quit", "Don't quit the xharness process after the tests are done running. Implies --no-headless.",
+                v => QuitAppAtEnd = false
+            },
+            { "expected-exit-code=", "If specified, sets the expected exit code for a successful test run.",
+                v => ExpectedExitCode = ParseAsIntOrThrow(v, "expected-exit-code")
+            }
         };
 
         public override void Validate()
@@ -102,6 +109,17 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
                     throw new ArgumentException($"Could not find browser at {BrowserLocation}");
                 }
             }
+
+            if (DebuggerPort != null || !QuitAppAtEnd)
+                Headless = false;
+        }
+
+        private static int ParseAsIntOrThrow(string value, string name)
+        {
+            if (int.TryParse(value, out var number))
+                return number;
+
+            throw new ArgumentException($"{name} must be an integer");
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -236,6 +236,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
         {
             var uriBuilder = new UriBuilder($"{webServerAddr}/{_arguments.HTMLFile}");
             var sb = new StringBuilder();
+
+            if (_arguments.DebuggerPort != null)
+                sb.Append($"arg=--debug");
+
             foreach (var arg in _passThroughArguments)
             {
                 if (sb.Length > 0)


### PR DESCRIPTION
New args:
- `--debugger=N` - translates to `--remote-debugging-port=N` for
  chromium browsers
- `--no-incognito`
- `--no-headless`
- `--no-quit` - doesn't kill the browser, and doesn't exit xharness at
  the end of tests.

Note: tested only with chrome, and vscode