### PR TITLE
Run Component Governance detection only once in PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,11 +76,10 @@ stages:
               testRunTitle: XHarness unit tests - $(Agent.JobName)
             condition: succeededOrFailed()
 
-        - ${{ if eq(variables._RunAsPublic, False) }}:
-          - task: ComponentGovernanceComponentDetection@0
-            displayName: Component Governance scan
-            inputs:
-              ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/net6.0/android-tools-unzipped'
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: Component Governance scan
+          inputs:
+            ignoreDirectories: '$(Build.SourcesDirectory)/.packages,$(Build.SourcesDirectory)/artifacts/obj/Microsoft.DotNet.XHarness.CLI/$(_BuildConfig)/net6.0/android-tools-unzipped'
 
 - ${{ if eq(variables._RunAsPublic, True) }}:
   - stage: Build_OSX


### PR DESCRIPTION
We were not running it in PRs and so it was injected everywhere