### PR TITLE
add android device launch timeout as a parameter

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -95,6 +95,8 @@ namespace Microsoft.DotNet.XHarness.Android
 
         #region Functions
 
+        public int TimeToWaitForBootCompletionSeconds { get; set; } = 300;
+
         public string GetAdbVersion() => RunAdbCommand("version").StandardOutput;
 
         public string GetAdbState() => RunAdbCommand("get-state").StandardOutput;
@@ -139,7 +141,7 @@ namespace Microsoft.DotNet.XHarness.Android
             }
         }
 
-        public void WaitForDevice(int timeToWaitForBootCompletionSeconds = 300)
+        public void WaitForDevice()
         {
             // This command waits for ANY kind of device to be available (emulator or real)
             // Needed because emulators start up asynchronously and take a while.
@@ -154,10 +156,10 @@ namespace Microsoft.DotNet.XHarness.Android
             }
 
             // Some users will be installing the emulator and immediately calling xharness, they need to be able to expect the device is ready to load APKs.
-            // Once wait-for-device returns, we'll give it up to timeToWaitForBootCompletionSeconds seconds (default 5 min) for 'adb shell getprop sys.boot_completed'
+            // Once wait-for-device returns, we'll give it up to TimeToWaitForBootCompletionSeconds seconds (default 5 min) for 'adb shell getprop sys.boot_completed'
             // to be '1' (as opposed to empty) to make subsequent automation happy.
             var began = DateTimeOffset.UtcNow;
-            var waitingUntil = began.AddSeconds(timeToWaitForBootCompletionSeconds);
+            var waitingUntil = began.AddSeconds(TimeToWaitForBootCompletionSeconds);
             var bootCompleted = RunAdbCommand($"shell getprop {AdbShellPropertyForBootCompletion}");
 
             while (!bootCompleted.StandardOutput.Trim().StartsWith("1") && DateTimeOffset.UtcNow < waitingUntil)

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
         #region Functions
 
-        public TimeSpan TimeToWaitForBootCompletionSeconds { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan TimeToWaitForBootCompletion { get; set; } = TimeSpan.FromMinutes(5);
 
         public string GetAdbVersion() => RunAdbCommand("version").StandardOutput;
 
@@ -156,10 +156,10 @@ namespace Microsoft.DotNet.XHarness.Android
             }
 
             // Some users will be installing the emulator and immediately calling xharness, they need to be able to expect the device is ready to load APKs.
-            // Once wait-for-device returns, we'll give it up to TimeToWaitForBootCompletionSeconds seconds (default 5 min) for 'adb shell getprop sys.boot_completed'
+            // Once wait-for-device returns, we'll give it up to TimeToWaitForBootCompletion (default 5 min) for 'adb shell getprop sys.boot_completed'
             // to be '1' (as opposed to empty) to make subsequent automation happy.
             var began = DateTimeOffset.UtcNow;
-            var waitingUntil = began.Add(TimeToWaitForBootCompletionSeconds);
+            var waitingUntil = began.Add(TimeToWaitForBootCompletion);
             var bootCompleted = RunAdbCommand($"shell getprop {AdbShellPropertyForBootCompletion}");
 
             while (!bootCompleted.StandardOutput.Trim().StartsWith("1") && DateTimeOffset.UtcNow < waitingUntil)

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
         #region Functions
 
-        public int TimeToWaitForBootCompletionSeconds { get; set; } = 300;
+        public TimeSpan TimeToWaitForBootCompletionSeconds { get; set; } = TimeSpan.FromMinutes(5);
 
         public string GetAdbVersion() => RunAdbCommand("version").StandardOutput;
 
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.XHarness.Android
             // Once wait-for-device returns, we'll give it up to TimeToWaitForBootCompletionSeconds seconds (default 5 min) for 'adb shell getprop sys.boot_completed'
             // to be '1' (as opposed to empty) to make subsequent automation happy.
             var began = DateTimeOffset.UtcNow;
-            var waitingUntil = began.AddSeconds(TimeToWaitForBootCompletionSeconds);
+            var waitingUntil = began.Add(TimeToWaitForBootCompletionSeconds);
             var bootCompleted = RunAdbCommand($"shell getprop {AdbShellPropertyForBootCompletion}");
 
             while (!bootCompleted.StandardOutput.Trim().StartsWith("1") && DateTimeOffset.UtcNow < waitingUntil)

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -17,6 +17,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             set => _packageName = value;
         }
 
+        /// <summary>
+        /// If specified, attempt to run APK on that device.
+        /// If there are more than one device with required architecture, failing to specify this may cause execution failure.
+        /// </summary>
         public string? DeviceId { get; set; }
 
         /// <summary>
@@ -24,6 +28,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
         /// </summary>
         public string? DeviceArchitecture { get; set; }
+
+        /// <summary>
+        /// Time to wait for boot completion. Defaults to 5 minutes.
+        /// </summary>
+        public int BootTimeoutSeconds { get; set; } = 300;
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -33,6 +42,18 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             {
                 "device-id=", "Device where APK should be installed",
                 v => DeviceId = v
+            },
+            {
+                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
+                v => {
+                    if (int.TryParse(v, out var number))
+                    {
+                        BootTimeoutSeconds = number;
+                        return;
+                    }
+
+                    throw new ArgumentException("timeout must be an integer");
+                }
             },
         };
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot completion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot completion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for the device to boot to complete",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         /// <summary>
         /// If specified, attempt to run APK on that device.
-        /// If there are more than one device with required architecture, failing to specify this may cause execution failure.
+        /// If there is more than one device with required architecture, failing to specify this may cause execution failure.
         /// </summary>
         public string? DeviceId { get; set; }
 
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
+                "boot-timeout=", "Timeout in seconds to wait for a device after boot completion",
                 v => {
                     if (int.TryParse(v, out var number))
                     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// <summary>
         /// Time to wait for boot completion. Defaults to 5 minutes.
         /// </summary>
-        public int BootTimeoutSeconds { get; set; } = 300;
+        public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -44,15 +44,22 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "boot-timeout=", "Timeout in seconds to wait for a device after boot completion",
-                v => {
-                    if (int.TryParse(v, out var number))
+                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                v =>
+                {
+                    if (int.TryParse(v, out var timeout))
                     {
-                        BootTimeoutSeconds = number;
+                        LaunchTimeout = TimeSpan.FromSeconds(timeout);
                         return;
                     }
 
-                    throw new ArgumentException("timeout must be an integer");
+                    if (TimeSpan.TryParse(v, out var timespan))
+                    {
+                        LaunchTimeout = timespan;
+                        return;
+                    }
+
+                    throw new ArgumentException("launch-timeout must be an integer - a number of seconds, or a timespan (00:30:00)");
                 }
             },
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -24,6 +24,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             set => _packageName = value;
         }
 
+        /// <summary>
+        /// If specified, attempt to run APK on that device.
+        /// If there are more than one device with required architecture, failing to specify this may cause execution failure.
+        /// </summary>
         public string? DeviceId { get; set; }
 
         /// <summary>
@@ -31,12 +35,20 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public string? DeviceOutputFolder { get; set; }
 
+        /// <summary>
+        /// Passing these arguments as testing options to a test runner
+        /// </summary>
         public Dictionary<string, string> InstrumentationArguments { get; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Exit code returned by the instrumentation for a successful run. Defaults to 0.
         /// </summary>
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
+
+        /// <summary>
+        /// Time to wait for boot completion. Defaults to 5 minutes.
+        /// </summary>
+        public int BootTimeoutSeconds { get; set; } = 300;
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -63,6 +75,18 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             {
                 "device-id=", "Device where APK should be installed",
                 v => DeviceId = v
+            },
+            {
+                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
+                v => {
+                    if (int.TryParse(v, out var number))
+                    {
+                        BootTimeoutSeconds = number;
+                        return;
+                    }
+
+                    throw new ArgumentException("timeout must be an integer");
+                }
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         /// <summary>
         /// If specified, attempt to run APK on that device.
-        /// If there are more than one device with required architecture, failing to specify this may cause execution failure.
+        /// If there is more than one device with required architecture, failing to specify this may cause execution failure.
         /// </summary>
         public string? DeviceId { get; set; }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// <summary>
         /// Time to wait for boot completion. Defaults to 5 minutes.
         /// </summary>
-        public int BootTimeoutSeconds { get; set; } = 300;
+        public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -77,15 +77,22 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
-                v => {
-                    if (int.TryParse(v, out var number))
+                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                v =>
+                {
+                    if (int.TryParse(v, out var timeout))
                     {
-                        BootTimeoutSeconds = number;
+                        LaunchTimeout = TimeSpan.FromSeconds(timeout);
                         return;
                     }
 
-                    throw new ArgumentException("timeout must be an integer");
+                    if (TimeSpan.TryParse(v, out var timespan))
+                    {
+                        LaunchTimeout = timespan;
+                        return;
+                    }
+
+                    throw new ArgumentException("launch-timeout must be an integer - a number of seconds, or a timespan (00:30:00)");
                 }
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for the device to boot to complete",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot competion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => DeviceId = v
             },
             {
-                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot competion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 }
             },
             {
-                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot competion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 }
             },
             {
-                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for the device to boot to complete",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// <summary>
         /// Time to wait for boot completion. Defaults to 5 minutes.
         /// </summary>
-        public int BootTimeoutSeconds { get; set; } = 300;
+        public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -73,15 +73,22 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 }
             },
             {
-                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
-                v => {
-                    if (int.TryParse(v, out var number))
+                "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for a device after boot competion",
+                v =>
+                {
+                    if (int.TryParse(v, out var timeout))
                     {
-                        BootTimeoutSeconds = number;
+                        LaunchTimeout = TimeSpan.FromSeconds(timeout);
                         return;
                     }
 
-                    throw new ArgumentException("timeout must be an integer");
+                    if (TimeSpan.TryParse(v, out var timespan))
+                    {
+                        LaunchTimeout = timespan;
+                        return;
+                    }
+
+                    throw new ArgumentException("launch-timeout must be an integer - a number of seconds, or a timespan (00:30:00)");
                 }
             },
             { "package-name=|p=", "Package name contained within the supplied APK",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 }
             },
             {
-                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot competion",
+                "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for a device after boot completion",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -35,12 +35,20 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public string? DeviceOutputFolder { get; set; }
 
+        /// <summary>
+        /// Passing these arguments as testing options to a test runner
+        /// </summary>
         public Dictionary<string, string> InstrumentationArguments { get; } = new Dictionary<string, string>();
 
         /// <summary>
         /// Exit code returned by the instrumentation for a successful run. Defaults to 0.
         /// </summary>
         public int ExpectedExitCode { get; set; } = (int)Common.CLI.ExitCode.SUCCESS;
+
+        /// <summary>
+        /// Time to wait for boot completion. Defaults to 5 minutes.
+        /// </summary>
+        public int BootTimeoutSeconds { get; set; } = 300;
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -62,6 +70,18 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                     }
 
                     throw new ArgumentException("expected-exit-code must be an integer");
+                }
+            },
+            {
+                "boot-timeout=", "Timeout in seconds to wait for a device after boot competion",
+                v => {
+                    if (int.TryParse(v, out var number))
+                    {
+                        BootTimeoutSeconds = number;
+                        return;
+                    }
+
+                    throw new ArgumentException("timeout must be an integer");
                 }
             },
             { "package-name=|p=", "Package name contained within the supplied APK",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AppRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AppRunCommandArguments.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
                 v => Targets = v.Split(',')
             },
             {
-                "timeout=", "TimeSpan or number of seconds to wait for instrumentation to complete",
+                "timeout=", "Time span in the form of \"00:00:00\" or number of seconds to wait for instrumentation to complete",
                 v =>
                 {
                     if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             var testOptions = new OptionSet
             {
                 {
-                    "launch-timeout=|lt=", "TimeSpan or number of seconds to wait for the iOS app to start",
+                    "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for the iOS app to start",
                     v =>
                     {
                         if (int.TryParse(v, out var timeout))

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -94,7 +94,7 @@ Arguments:
 
                     runner.SetActiveDevice(deviceId);
 
-                    runner.TimeToWaitForBootCompletionSeconds = bootTimeoutSeconds;
+                    runner.TimeToWaitForBootCompletion = bootTimeoutSeconds;
 
                     // Wait till at least device(s) are ready
                     runner.WaitForDevice();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -68,11 +68,11 @@ Arguments:
                 appPackagePath: _arguments.AppPackagePath,
                 apkRequiredArchitecture: apkRequiredArchitecture,
                 deviceId: _arguments.DeviceId,
-                bootTimeoutSeconds: _arguments.BootTimeoutSeconds,
+                bootTimeoutSeconds: _arguments.LaunchTimeout,
                 runner: runner));
         }
 
-        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, int bootTimeoutSeconds, AdbRunner runner)
+        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, TimeSpan bootTimeoutSeconds, AdbRunner runner)
         {
             try
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -68,10 +68,11 @@ Arguments:
                 appPackagePath: _arguments.AppPackagePath,
                 apkRequiredArchitecture: apkRequiredArchitecture,
                 deviceId: _arguments.DeviceId,
+                bootTimeoutSeconds: _arguments.BootTimeoutSeconds,
                 runner: runner));
         }
 
-        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, AdbRunner runner)
+        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, int bootTimeoutSeconds, AdbRunner runner)
         {
             try
             {
@@ -92,6 +93,8 @@ Arguments:
                     }
 
                     runner.SetActiveDevice(deviceId);
+
+                    runner.TimeToWaitForBootCompletionSeconds = bootTimeoutSeconds;
 
                     // Wait till at least device(s) are ready
                     runner.WaitForDevice();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -70,10 +70,10 @@ Arguments:
 
             runner.SetActiveDevice(deviceId);
 
+            runner.TimeToWaitForBootCompletionSeconds = _arguments.BootTimeoutSeconds;
+
             // Wait til at least device(s) are ready
             runner.WaitForDevice();
-
-            logger.LogDebug($"Working with {runner.GetAdbVersion()}");
 
             return Task.FromResult(InvokeHelper(
                 logger,
@@ -98,8 +98,9 @@ Arguments:
             int expectedExitCode,
             AdbRunner runner)
         {
-
             int instrumentationExitCode = (int)ExitCode.GENERAL_FAILURE;
+
+            logger.LogDebug($"Working with {runner.GetAdbVersion()}");
 
             // Empty log as we'll be uploading the full logcat for this execution
             runner.ClearAdbLog();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -70,7 +70,7 @@ Arguments:
 
             runner.SetActiveDevice(deviceId);
 
-            runner.TimeToWaitForBootCompletionSeconds = _arguments.BootTimeoutSeconds;
+            runner.TimeToWaitForBootCompletionSeconds = _arguments.LaunchTimeout;
 
             // Wait til at least device(s) are ready
             runner.WaitForDevice();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -70,7 +70,7 @@ Arguments:
 
             runner.SetActiveDevice(deviceId);
 
-            runner.TimeToWaitForBootCompletionSeconds = _arguments.LaunchTimeout;
+            runner.TimeToWaitForBootCompletion = _arguments.LaunchTimeout;
 
             // Wait til at least device(s) are ready
             runner.WaitForDevice();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -80,7 +80,7 @@ Arguments:
                     appPackagePath: appPackagePath,
                     apkRequiredArchitecture: apkRequiredArchitecture,
                     deviceId: null,
-                    bootTimeoutSeconds: _arguments.BootTimeoutSeconds,
+                    bootTimeoutSeconds: _arguments.LaunchTimeout,
                     runner: runner);
 
                 if (exitCode == ExitCode.SUCCESS)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -80,6 +80,7 @@ Arguments:
                     appPackagePath: appPackagePath,
                     apkRequiredArchitecture: apkRequiredArchitecture,
                     deviceId: null,
+                    bootTimeoutSeconds: _arguments.BootTimeoutSeconds,
                     runner: runner);
 
                 if (exitCode == ExitCode.SUCCESS)


### PR DESCRIPTION
Resolves #468 
New parameter `launch-timeout` will wait for provided amount of second for device's full boot completion.
Available for commands `android install/test/run` 