### PR TITLE
handle wifi status for android devices

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -105,6 +105,8 @@ namespace Microsoft.DotNet.XHarness.Android
 
         public void ClearAdbLog() => RunAdbCommand("logcat -c");
 
+        public void EnableWifi(bool enable) => RunAdbCommand($"shell svc wifi {(enable ? "enable" : "disable")}");
+
         public void DumpAdbLog(string outputFilePath, string filterSpec = "")
         {
             // Workaround: Doesn't seem to have a flush() function and sometimes it doesn't have the full log on emulators.

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 }
             },
             { "wifi:", "Enable/disable wifi, is not checking by default. If passed without value, 'enable' is assumed.",
-                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v)
+                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v, invalidValues: WifiStatus.Unknown)
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -50,6 +50,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// </summary>
         public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
+        /// <summary>
+        /// Switch on/off wifi on the device.
+        /// </summary>
+        public WifiStatus Wifi { get; set; } = WifiStatus.Unknown;
+
         protected override OptionSet GetTestCommandOptions() => new()
         {
             { "device-out-folder=|dev-out=", "If specified, copy this folder recursively off the device to the path specified by the output directory",
@@ -94,6 +99,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
                     throw new ArgumentException("launch-timeout must be an integer - a number of seconds, or a timespan (00:30:00)");
                 }
+            },
+            { "wifi:", "Enable/disable wifi, is not checking by default. If passed without value, 'enable' is assumed.",
+                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v)
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -110,8 +110,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
                 v => PackageName = v
             },
             {
-                "wifi:", "Enable/disable wifi, is not checking by default. If passed without value, 'enable' is assumed.",
-                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v)
+                "wifi:", "Enable/disable WiFi. WiFi state is ignored by default. If passed without value, 'enable' is assumed.",
+                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v, invalidValues: WifiStatus.Unknown)
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -8,6 +8,16 @@ using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
+
+    internal enum WifiStatus
+    {
+        /// <summary>
+        /// Not checked by default.
+        /// </summary>
+        Unknown,
+        Enable,
+        Disable,
+    }
     internal class AndroidTestCommandArguments : TestCommandArguments
     {
         private string? _packageName;
@@ -49,6 +59,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// Time to wait for boot completion. Defaults to 5 minutes.
         /// </summary>
         public TimeSpan LaunchTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Switch on/off wifi on the device.
+        /// </summary>
+        public WifiStatus Wifi { get; set; } = WifiStatus.Unknown;
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
@@ -93,6 +108,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             },
             { "package-name=|p=", "Package name contained within the supplied APK",
                 v => PackageName = v
+            },
+            {
+                "wifi:", "Enable/disable wifi, is not checking by default. If passed without value, 'enable' is assumed.",
+                v => Wifi = string.IsNullOrEmpty(v) ? WifiStatus.Enable : ParseArgument<WifiStatus>("wifi", v)
             },
             { "arg=", "Argument to pass to the instrumentation, in form key=value", v =>
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -84,6 +84,7 @@ Arguments:
                 _arguments.DeviceOutputFolder,
                 _arguments.Timeout,
                 _arguments.ExpectedExitCode,
+                _arguments.Wifi,
                 runner));
         }
 
@@ -96,6 +97,7 @@ Arguments:
             string? deviceOutputFolder,
             TimeSpan timeout,
             int expectedExitCode,
+            WifiStatus wifi,
             AdbRunner runner)
         {
             int instrumentationExitCode = (int)ExitCode.GENERAL_FAILURE;
@@ -104,6 +106,11 @@ Arguments:
 
             // Empty log as we'll be uploading the full logcat for this execution
             runner.ClearAdbLog();
+
+            if (wifi != WifiStatus.Unknown)
+            {
+                runner.EnableWifi(wifi == WifiStatus.Enable);
+            }
 
             try
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -94,6 +94,7 @@ Arguments:
                         deviceOutputFolder: _arguments.DeviceOutputFolder,
                         timeout: _arguments.Timeout,
                         expectedExitCode: _arguments.ExpectedExitCode,
+                        wifi: _arguments.Wifi,
                         runner: runner);
                 } 
 


### PR DESCRIPTION
Addressed #476 
New parameter `--wifi` introduced:
- `--wifi [enable]` - switching wifi on
- `--wifi disable` - switching wifi off
- without this parameter no additional checks are providing as before