### PR TITLE
Unify how we get the default mlaunch path

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleCommandArguments.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.Common.Execution;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
@@ -21,22 +22,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         /// Path to the mlaunch binary.
         /// Default comes from the NuGet.
         /// </summary>
-        public string MlaunchPath { get; set; }
-
-        protected AppleCommandArguments()
-        {
-            string? pathFromEnv = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.MLAUNCH_PATH);
-            if (!string.IsNullOrEmpty(pathFromEnv))
-            {
-                MlaunchPath = pathFromEnv;
-            }
-            else
-            {
-                // This path is where mlaunch is when the .NET tool is extracted
-                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(AppleTestCommandArguments))?.Location);
-                MlaunchPath = Path.Join(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
-            }
-        }
+        public string MlaunchPath { get; set; } = MacOSProcessManager.DetectMlaunchPath();
 
         protected override OptionSet GetCommandOptions() => new()
         {
@@ -52,14 +38,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         {
             if (!File.Exists(MlaunchPath))
             {
-#if DEBUG
-                string message = $"Failed to find mlaunch at {MlaunchPath}. " +
+                throw new ArgumentException(
+                    $"Failed to find mlaunch at {MlaunchPath}. " +
                     $"Make sure you specify --mlaunch or set the {EnvironmentVariables.Names.MLAUNCH_PATH} env var. " +
-                    $"See README.md for more information";
-#else
-                string message = $"Failed to find mlaunch at {MlaunchPath}";
-#endif
-                throw new ArgumentException(message);
+                    $"See README.md for more information");
             }
 
             if (XcodeRoot != null && !Directory.Exists(XcodeRoot))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.Common.Execution;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
@@ -14,32 +15,15 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
     {
         /// <summary>
         /// Path to the mlaunch binary.
-        /// Default comes from the NuGet.
+        /// Default comes from env variable then from the NuGet package.
         /// </summary>
-        public string MlaunchPath { get; set; } = Path.Join(
-            Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(AppleTestCommandArguments))?.Location),
-            "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
+        public string MlaunchPath { get; set; } = MacOSProcessManager.DetectMlaunchPath();
 
         public bool ShowSimulatorsUUID { get; set; } = false;
 
         public bool ShowDevicesUUID { get; set; } = true;
 
         public bool UseJson { get; set; } = false;
-
-        protected AppleGetStateCommandArguments()
-        {
-            string? pathFromEnv = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.MLAUNCH_PATH);
-            if (!string.IsNullOrEmpty(pathFromEnv))
-            {
-                MlaunchPath = pathFromEnv;
-            }
-            else
-            {
-                // This path is where mlaunch is when the .NET tool is extracted
-                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(AppleTestCommandArguments))?.Location);
-                MlaunchPath = Path.Join(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
-            }
-        }
 
         protected override OptionSet GetCommandOptions() => new()
         {
@@ -53,7 +37,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         {
             if (!File.Exists(MlaunchPath))
             {
-                throw new ArgumentException($"Failed to find mlaunch at {MlaunchPath}");
+                throw new ArgumentException(
+                    $"Failed to find mlaunch at {MlaunchPath}. " +
+                    $"Make sure you specify --mlaunch or set the {EnvironmentVariables.Names.MLAUNCH_PATH} env var. " +
+                    $"See README.md for more information");
             }
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Mono.Options;
 
@@ -24,6 +25,21 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public bool ShowDevicesUUID { get; set; } = true;
 
         public bool UseJson { get; set; } = false;
+
+        protected AppleGetStateCommandArguments()
+        {
+            string? pathFromEnv = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.MLAUNCH_PATH);
+            if (!string.IsNullOrEmpty(pathFromEnv))
+            {
+                MlaunchPath = pathFromEnv;
+            }
+            else
+            {
+                // This path is where mlaunch is when the .NET tool is extracted
+                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(AppleTestCommandArguments))?.Location);
+                MlaunchPath = Path.Join(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
+            }
+        }
 
         protected override OptionSet GetCommandOptions() => new()
         {

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -124,12 +124,10 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             {
                 return pathFromEnv;
             }
-            else
-            {
-                // This path is where mlaunch is when the .NET tool is extracted
-                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(MacOSProcessManager))?.Location);
-               return Path.Combine(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
-            }
+
+            // This path is where mlaunch is when the .NET tool is extracted from the .nupkg
+            var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(MacOSProcessManager))?.Location)!;
+            return Path.Combine(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
         }
 
         #endregion

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
 #nullable enable
@@ -114,6 +115,21 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             // We need /Applications/Xcode114.app only
             // should never be null, if it is return an ""
             return Path.GetDirectoryName(Path.GetDirectoryName(xcodeRoot)) ?? string.Empty;
+        }
+
+        public static string DetectMlaunchPath()
+        {
+            string? pathFromEnv = Environment.GetEnvironmentVariable(EnvironmentVariables.Names.MLAUNCH_PATH);
+            if (!string.IsNullOrEmpty(pathFromEnv))
+            {
+                return pathFromEnv;
+            }
+            else
+            {
+                // This path is where mlaunch is when the .NET tool is extracted
+                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetAssembly(typeof(MacOSProcessManager))?.Location);
+               return Path.Combine(assemblyPath, "..", "..", "..", "runtimes", "any", "native", "mlaunch", "bin", "mlaunch");
+            }
         }
 
         #endregion


### PR DESCRIPTION
Code de-duplication + fix of the `apple state` command wasn't reading the env var