### PR TITLE
Prevent the "Local network access" dialog in iOS 14+

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -569,9 +569,9 @@ namespace Microsoft.DotNet.XHarness.Apple
                 extraAppArguments,
                 extraEnvVariables);
 
-            var ips = string.Join(",", _helpers.GetLocalIpAddresses().Select(ip => ip.ToString()));
-
-            args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, ips));
+            // Using other interfaces than the default loopback addresses will end up in the "local network access" dialog
+            // This is a new privacy feature in iOS 14 and needs to the user to confirm a dialog before any local network connection
+            args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "::1,127.0.0.1"));
             args.Add(new DisableMemoryLimitsArgument());
             args.Add(new DeviceNameArgument(device));
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
@@ -82,9 +82,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _helpers
                 .SetupGet(x => x.Timestamp)
                 .Returns("mocked_timestamp");
-            _helpers
-                .Setup(x => x.GetLocalIpAddresses())
-                .Returns(new[] { IPAddress.Loopback, IPAddress.IPv6Loopback });
 
             Directory.CreateDirectory(s_outputPath);
         }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -513,7 +513,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             "-setenv=NUNIT_XML_VERSION=xUnit " +
             skippedTests +
             extraArgs +
-            "-setenv=NUNIT_HOSTNAME=127.0.0.1,::1 " +
+            "-setenv=NUNIT_HOSTNAME=::1,127.0.0.1 " +
             "--disable-memory-limits " +
             $"--devname {s_mockDevice.DeviceIdentifier} " +
             (useTunnel ? "-setenv=USE_TCP_TUNNEL=true " : null) +


### PR DESCRIPTION
Resolves #555 