### PR TITLE
Shorten the main log (app install + device finding)

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppInstaller.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppInstaller.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             var totalSize = Directory.GetFiles(appBundleInformation.LaunchAppPath, "*", SearchOption.AllDirectories).Select((v) => new FileInfo(v).Length).Sum();
             _mainLog.WriteLine($"Installing '{appBundleInformation.LaunchAppPath}' to '{device.Name}' ({totalSize / 1024.0 / 1024.0:N2} MB)");
 
-            return await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromMinutes(15), cancellationToken: cancellationToken);
+            return await _processManager.ExecuteCommandAsync(args, _mainLog, TimeSpan.FromMinutes(15), verbosity: 2, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             _simulatorLoader = simulatorLoader ?? throw new ArgumentNullException(nameof(simulatorLoader));
         }
 
-        public async Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog mainLog)
+        public async Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog log)
         {
             IDevice? device;
             IDevice? companionDevice = null;
@@ -36,11 +36,11 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 if (deviceName == null)
                 {
-                    (device, companionDevice) = await _simulatorLoader.FindSimulators(target, mainLog, 3);
+                    (device, companionDevice) = await _simulatorLoader.FindSimulators(target, log, 3);
                 }
                 else
                 {
-                    await _simulatorLoader.LoadDevices(mainLog, false);
+                    await _simulatorLoader.LoadDevices(log, false);
 
                     device = _simulatorLoader.AvailableDevices.FirstOrDefault(IsMatchingDevice)
                         ?? throw new NoDeviceFoundException($"Failed to find a simulator '{deviceName}'");
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 // The DeviceLoader.FindDevice will return the fist device of the type, but we want to make sure that
                 // the device we use is of the correct arch, therefore, we will use the LoadDevices and handpick one
-                await _deviceLoader.LoadDevices(mainLog, false, false);
+                await _deviceLoader.LoadDevices(log, false, false);
 
                 if (deviceName == null)
                 {
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
                     if (target.Platform.IsWatchOSTarget() && hardwareDevice != null)
                     {
-                        companionDevice = await _deviceLoader.FindCompanionDevice(mainLog, hardwareDevice);
+                        companionDevice = await _deviceLoader.FindCompanionDevice(log, hardwareDevice);
                     }
 
                     device = hardwareDevice;

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.Apple
 {
@@ -26,7 +27,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase) : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.Apple
 {
@@ -24,11 +25,12 @@ namespace Microsoft.DotNet.XHarness.Apple
             IMlaunchProcessManager processManager,
             IAppBundleInformationParser appBundleInformationParser,
             DeviceFinder deviceFinder,
-            ILogger logger,
+            ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase)
-            : base(processManager, appBundleInformationParser, deviceFinder, logger, logs, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.Apple
 {
@@ -30,8 +31,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase)
-            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -36,13 +36,15 @@ namespace Microsoft.DotNet.XHarness.Apple
             IMlaunchProcessManager processManager,
             IAppBundleInformationParser appBundleInformationParser,
             DeviceFinder deviceFinder,
-            ILogger logger,
+            ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase) : base(processManager, appBundleInformationParser, deviceFinder, logger, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _logger = consoleLogger ?? throw new ArgumentNullException(nameof(consoleLogger));
             _logs = logs ?? throw new ArgumentNullException(nameof(logs));
             _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
             _errorKnowledgeBase = errorKnowledgeBase ?? throw new ArgumentNullException(nameof(errorKnowledgeBase));

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -38,8 +38,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase)
-            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
             _logger = consoleLogger ?? throw new ArgumentNullException(nameof(consoleLogger));

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.Apple
 {
@@ -26,7 +27,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             ILogger consoleLogger,
             ILogs logs,
             IFileBackedLog mainLog,
-            IErrorKnowledgeBase errorKnowledgeBase) : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, mainLog, errorKnowledgeBase)
+            IErrorKnowledgeBase errorKnowledgeBase,
+            IHelpers helpers)
+            : base(processManager, appBundleInformationParser, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, helpers)
         {
         }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleInstallCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
@@ -51,7 +52,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             var args = AppleAppArguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 {
@@ -44,7 +45,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             var args = AppleAppArguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 {
@@ -43,7 +44,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             var args = AppleAppArguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 {
@@ -47,7 +48,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             var args = AppleAppArguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 {
@@ -47,7 +48,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             var args = AppleAppArguments;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleUninstallCommand.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
@@ -54,7 +55,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 new ConsoleLogger(logger),
                 logs,
                 mainLog,
-                ErrorKnowledgeBase);
+                ErrorKnowledgeBase,
+                new Helpers());
 
             return orchestrator.OrchestrateAppUninstall(
                 target,

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/IMlaunchProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/IMlaunchProcessManager.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 
 #nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
@@ -18,9 +17,44 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
     {
         string MlaunchPath { get; }
 
-        Task<ProcessExecutionResult> ExecuteCommandAsync(MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string>? environmentVariables = null, CancellationToken? cancellationToken = null);
-        Task<ProcessExecutionResult> ExecuteCommandAsync(MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string>? environmentVariables = null, CancellationToken? cancellationToken = null);
-        Task<ProcessExecutionResult> RunAsync(Process process, MlaunchArguments args, ILog log, TimeSpan? timeout = null, Dictionary<string, string>? environmentVariables = null, CancellationToken? cancellationToken = null, bool? diagnostics = null);
-        Task<ProcessExecutionResult> RunAsync(Process process, MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan? timeout = null, Dictionary<string, string>? environmentVariables = null, CancellationToken? cancellationToken = null, bool? diagnostics = null);
+        Task<ProcessExecutionResult> ExecuteCommandAsync(
+            MlaunchArguments args,
+            ILog log,
+            TimeSpan timeout,
+            Dictionary<string, string>? environmentVariables = null,
+            int verbosity = 5,
+            CancellationToken? cancellationToken = null);
+
+        Task<ProcessExecutionResult> ExecuteCommandAsync(
+            MlaunchArguments args,
+            ILog log,
+            ILog stdoutLog,
+            ILog stderrLog,
+            TimeSpan timeout,
+            Dictionary<string, string>? environmentVariables = null,
+            int verbosity = 5,
+            CancellationToken? cancellationToken = null);
+
+        Task<ProcessExecutionResult> RunAsync(
+            Process process,
+            MlaunchArguments args,
+            ILog log,
+            TimeSpan? timeout = null,
+            Dictionary<string, string>? environmentVariables = null,
+            int verbosity = 5,
+            CancellationToken? cancellationToken = null,
+            bool? diagnostics = null);
+
+        Task<ProcessExecutionResult> RunAsync(
+            Process process,
+            MlaunchArguments args,
+            ILog log,
+            ILog stdoutLog,
+            ILog stderrLog,
+            TimeSpan? timeout = null,
+            Dictionary<string, string>? environmentVariables = null,
+            int verbosity = 5,
+            CancellationToken? cancellationToken = null,
+            bool? diagnostics = null);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                     new ListSimulatorsArgument(tmpfile),
                     new XmlOutputFormatArgument());
 
-                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(6), verbosity: 1);
+                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(6));
 
                 if (!result.Succeeded)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
                     new ListSimulatorsArgument(tmpfile),
                     new XmlOutputFormatArgument());
 
-                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(6));
+                var result = await _processManager.ExecuteCommandAsync(arguments, log, timeout: TimeSpan.FromMinutes(6), verbosity: 1);
 
                 if (!result.Succeeded)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/Logs.cs
@@ -21,13 +21,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             Directory = directory ?? throw new ArgumentNullException(nameof(directory));
         }
 
-        // Create a new log backed with a file
-        public IFileBackedLog Create(string filename, string name, bool? timestamp = null) => Create(Directory, filename, name, timestamp);
-
-        private LogFile Create(string directory, string filename, string name, bool? timestamp = null)
+        public IFileBackedLog Create(string filename, string name, bool? timestamp = null)
         {
-            System.IO.Directory.CreateDirectory(directory);
-            var rv = new LogFile(name, Path.GetFullPath(Path.Combine(directory, filename)));
+            System.IO.Directory.CreateDirectory(Directory);
+            var rv = new LogFile(name, Path.GetFullPath(Path.Combine(Directory, filename)));
             if (timestamp.HasValue)
             {
                 rv.Timestamp = timestamp.Value;

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppInstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppInstallerTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                _mainLog.Object,
                It.IsAny<TimeSpan>(),
                null,
+               It.IsAny<int>(),
                It.IsAny<CancellationToken>()));
         }
 
@@ -92,6 +93,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                _mainLog.Object,
                It.IsAny<TimeSpan>(),
                null,
+               It.IsAny<int>(),
                It.IsAny<CancellationToken>()));
         }
     }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        _mainLog.Object,
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 
@@ -131,6 +132,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -140,6 +140,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        _mainLog.Object,
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 
@@ -234,6 +235,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.Is<Dictionary<string, string>>(d => d["appArg1"] == "value1"),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 
@@ -329,6 +331,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 
@@ -415,6 +418,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
+                       It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppUninstallerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppUninstallerTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                _mainLog.Object,
                It.IsAny<TimeSpan>(),
                null,
+               It.IsAny<int>(),
                It.IsAny<CancellationToken>()));
         }
     }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
@@ -102,6 +102,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
                     _log.Object,
                     TimeSpan.FromMinutes(1),
                     null,
+                    It.IsAny<int>(),
                     null),
                 Times.Exactly(2));
 
@@ -116,6 +117,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests
                     _log.Object,
                     TimeSpan.FromMinutes(1),
                     null,
+                    It.IsAny<int>(),
                     null),
                 Times.Once);
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
@@ -40,8 +40,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             MlaunchArguments passedArguments = null;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
-            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) =>
+            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
+                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, int, CancellationToken?, bool?>((p, args, log, t, env, verbosity, token, d) =>
                 {
                     // we are going set the used args to validate them later, will always return an error from this method
                     processPath = p.StartInfo.FileName;
@@ -77,8 +77,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             MlaunchArguments passedArguments = null;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
-            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) =>
+            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
+                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, int, CancellationToken?, bool?>((p, args, log, t, env, verbosity, token, d) =>
                 {
                     processPath = p.StartInfo.FileName;
                     passedArguments = args;
@@ -130,8 +130,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             var calls = 0;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
-            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
-                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, CancellationToken?, bool?>((p, args, log, t, env, token, d) => {
+            _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
+                .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, int, CancellationToken?, bool?>((p, args, log, t, env, verbosity, token, d) =>
+                {
                     calls++;
 
                     if (calls == 1)

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     // we are going set the used args to validate them later, will always return an error from this method
                     passedArguments = args;
@@ -92,8 +92,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             MlaunchArguments passedArguments = null;
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
-            _processManager.Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+            _processManager.Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     passedArguments = args;
 
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
                 .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
                 {
                     passedArguments = args;
@@ -170,8 +170,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     passedArguments = args;
 
@@ -199,8 +199,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     passedArguments = args;
 
@@ -227,8 +227,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         {
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     // We get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
                     var tempPath = args.Where(a => a is ListSimulatorsArgument).First().AsCommandLineArgument();
@@ -249,8 +249,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
         {
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     // We get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
                     var tempPath = args.Where(a => a is ListSimulatorsArgument).First().AsCommandLineArgument();
@@ -281,8 +281,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
 
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     // we get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
                     var tempPath = args.Where(a => a is ListSimulatorsArgument).First().AsCommandLineArgument();
@@ -308,8 +308,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             var calls = 0;
 
             _processManager
-                .Setup(p => p.ExecuteCommandAsync(It.Is<MlaunchArguments>(args => args.Any(a => a is ListSimulatorsArgument)), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Setup(p => p.ExecuteCommandAsync(It.Is<MlaunchArguments>(args => args.Any(a => a is ListSimulatorsArgument)), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     calls++;
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Hardware
             // moq It.Is is not working as nicelly as we would like it, we capture data and use asserts
             _processManager
                 .Setup(p => p.ExecuteCommandAsync(It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>()))
-                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, CancellationToken?>((args, log, t, env, token) =>
+                .Returns<MlaunchArguments, ILog, TimeSpan, Dictionary<string, string>, int, CancellationToken?>((args, log, t, env, verbosity, token) =>
                 {
                     passedArguments = args;
 


### PR DESCRIPTION
- Do not log copy progress when installing app on a real device (20k+ lines)
- Log the output from device finding into a separate file

Resolves #540 