### PR TITLE
centrally control csharp version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
-
+  <PropertyGroup>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
     <Copyright>$(CopyrightNetFoundation)</Copyright>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
+++ b/src/Microsoft.DotNet.XHarness.Android/Microsoft.DotNet.XHarness.Android.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <nullable>enable</nullable>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
+++ b/src/Microsoft.DotNet.XHarness.Apple/Microsoft.DotNet.XHarness.Apple.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -8,7 +8,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>xharness</ToolCommandName>
     <RollForward>Major</RollForward>
-    <LangVersion>9.0</LangVersion>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
 

--- a/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.Common/Microsoft.DotNet.XHarness.Common.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/Microsoft.DotNet.XHarness.TestRunners.Common.csproj
@@ -5,7 +5,6 @@
     <IsPackable>true</IsPackable>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Nullable>disable</Nullable>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/Microsoft.DotNet.XHarness.Android.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/Microsoft.DotNet.XHarness.Android.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Microsoft.DotNet.XHarness.Apple.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Microsoft.DotNet.XHarness.Apple.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.DotNet.XHarness.Common.Tests/Microsoft.DotNet.XHarness.Common.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.Common.Tests/Microsoft.DotNet.XHarness.Common.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
     <!-- Mono.Options is apparently not strong-name signed -->
     <NoWarn>CS8002;</NoWarn>
   </PropertyGroup>

--- a/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/Microsoft.DotNet.XHarness.TestRunners.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/Microsoft.DotNet.XHarness.TestRunners.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Each project had its own property for the C# language.
It was a mix of C# 8 and 9. With a few projects not specifying the version at all (and hence taking the default for the SDK version).

This PR sets the C# version to 9.0 on the project's root `Directory.Build.props` and removes any other definition. This way the version can be controlled at a single location, and all projects are aligned.