### PR TITLE
Improve logging when tunnel fails to connect to any hostname

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
@@ -77,6 +77,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                 evt.WaitOne();
             }
 
+            if (result == null)
+            {
+                throw new InvalidOperationException("Couldn't connect to any of the hostnames.");
+            }
+
             return result;
         }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     try
                     {
                         _client = new TcpClient("localhost", Port);
-                        Log.WriteLine("Test log server listening on: {0}:{1}", Address, Port);
+                        Log.WriteLine("Test log server listening on: {0}:{1}", "localhost", Port);
                         // let the device know we are ready!
                         var stream = _client.GetStream();
                         var ping = Encoding.UTF8.GetBytes("ping");


### PR DESCRIPTION
Before we were getting an `ArgumentNullException` since we returned null from `SelectHostName()`.