### PR TITLE
Fix TCP tunnel

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             var runMode = target.Platform.ToRunMode();
             var isSimulator = target.Platform.IsSimulator();
 
-            var deviceListenerLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: true);
+            var deviceListenerLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
 
             var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
                 runMode,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -313,7 +313,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     await tunnel.Started;
                 }
 
-                _mainLog.WriteLine("Starting test run");
+                _mainLog.WriteLine("Starting the application");
 
                 var envVars = new Dictionary<string, string>();
                 AddExtraEnvVars(envVars, extraEnvVariables);
@@ -344,7 +344,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             // Upload the system log
             if (File.Exists(deviceSystemLog.FullPath))
             {
-                _mainLog.WriteLine("A capture of the device log is: {0}", deviceSystemLog.FullPath);
+                _mainLog.WriteLine("Device log captured in {0}", deviceSystemLog.FullPath);
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -294,6 +294,8 @@ namespace Microsoft.DotNet.XHarness.Apple
             CancellationToken cancellationToken)
         {
             var deviceSystemLog = _logs.Create($"device-{device.Name}-{_helpers.Timestamp}.log", LogType.SystemLog.ToString());
+            deviceSystemLog.Timestamp = false;
+
             var deviceLogCapturer = _deviceLogCapturerFactory.Create(_mainLog, deviceSystemLog, device.Name);
             deviceLogCapturer.StartCapture();
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppTester.cs
@@ -571,7 +571,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             // Using other interfaces than the default loopback addresses will end up in the "local network access" dialog
             // This is a new privacy feature in iOS 14 and needs to the user to confirm a dialog before any local network connection
-            args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "::1,127.0.0.1"));
+            args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "127.0.0.1"));
             args.Add(new DisableMemoryLimitsArgument());
             args.Add(new DeviceNameArgument(device));
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 // Pipe the execution log to the debug output of XHarness effectively making "-v" turn this on
                 CallbackLog debugLog = new(message => logger.LogDebug(message.Trim()));
                 mainLog = Log.CreateReadableAggregatedLog(mainLog, debugLog);
+                mainLog.Timestamp = true;
 
                 var exitCodeForRun = await InvokeInternal(processManager, appBundleInformationParser, deviceFinder, logger, target, logs, mainLog, cts.Token);
                 if (exitCodeForRun != ExitCode.SUCCESS)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -51,10 +51,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
                 // Create main log file for the run
                 string logFileName = $"{Name}-{target.AsString()}{(AppleAppArguments.DeviceName != null ? "-" + AppleAppArguments.DeviceName : null)}.log";
+                IFileBackedLog mainLog = logs.Create(logFileName, LogType.ExecutionLog.ToString(), timestamp: true);
 
-                IFileBackedLog mainLog = Log.CreateReadableAggregatedLog(
-                    logs.Create(logFileName, LogType.ExecutionLog.ToString(), true),
-                    new CallbackLog(message => logger.LogDebug(message.Trim())));
+                // Pipe the execution log to the debug output of XHarness effectively making "-v" turn this on
+                CallbackLog debugLog = new(message => logger.LogDebug(message.Trim()));
+                mainLog = Log.CreateReadableAggregatedLog(mainLog, debugLog);
 
                 var exitCodeForRun = await InvokeInternal(processManager, appBundleInformationParser, deviceFinder, logger, target, logs, mainLog, cts.Token);
                 if (exitCodeForRun != ExitCode.SUCCESS)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
                 IFileBackedLog mainLog = Log.CreateReadableAggregatedLog(
                     logs.Create(logFileName, LogType.ExecutionLog.ToString(), true),
-                    new CallbackLog(message => logger.LogDebug(message.Trim())) { Timestamp = false });
+                    new CallbackLog(message => logger.LogDebug(message.Trim())));
 
                 var exitCodeForRun = await InvokeInternal(processManager, appBundleInformationParser, deviceFinder, logger, target, logs, mainLog, cts.Token);
                 if (exitCodeForRun != ExitCode.SUCCESS)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     engineBinary,
                     engineArgs,
                     log: new CallbackLog(m => logger.LogInformation(m)),
-                    stdoutLog: new CallbackLog(logProcessor.Invoke) { Timestamp = false /* we need the plain XML string so disable timestamp */ },
+                    stdoutLog: new CallbackLog(logProcessor.Invoke),
                     stderrLog: new CallbackLog(m => logger.LogError(m)),
                     _arguments.Timeout);
                 if (result.ExitCode != _arguments.ExpectedExitCode)

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/AggregatedLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/AggregatedLog.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
             public AggregatedLog(params ILog[] logs)
             {
                 _logs.AddRange(logs);
+                Timestamp = false;
             }
 
             protected override void WriteImpl(string value)
@@ -67,6 +68,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
                 _defaultLog = defaultLog ?? throw new ArgumentNullException(nameof(defaultLog));
                 // make sure that we also write in the default log
                 _logs.Add(defaultLog);
+                Timestamp = false;
             }
 
             public StreamReader GetReader() => _defaultLog.GetReader();

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
             : base("Callback log")
         {
             _onWrite = onWrite;
+            Timestamp = false;
         }
 
         public override void Dispose()

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                 EnableXml = b;
             }
 
+            if (bool.TryParse(Environment.GetEnvironmentVariable(EnviromentVariables.UseTcpTunnel), out b))
+            {
+                UseTunnel = b;
+            }
+
             var xml_version = Environment.GetEnvironmentVariable(EnviromentVariables.XmlVersion);
             if (!string.IsNullOrEmpty(xml_version))
             {
@@ -76,6 +81,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                 { "autostart", "If the app should automatically start running the tests", v => AutoStart = true },
                 { "hostname=", "Comma-separated list of host names or IP address to (try to) connect to", v => HostName = v },
                 { "hostport=", "HTTP/TCP port to connect to", v => HostPort = int.Parse (v) },
+                { "tcp-tunnel", "Use a TCP tunnel for communication between the app and XHarness", v => UseTunnel = true },
                 { "enablexml", "Enable the xml reported", v => EnableXml = false },
                 { "xmlversion", "The XML format", v => XmlVersion = (XmlResultJargon) Enum.Parse (typeof (XmlResultJargon), v, false) },
                 { "run-all-tests:", "Run all the tests found in the assembly, defaults to true", v =>
@@ -127,6 +133,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
         /// Return the test results as xml.
         /// </summary>
         public bool EnableXml { get; private set; } = true; // always true by default
+
+        /// <summary>
+        /// Use a TCP tunnel for communication between the app and XHarness.
+        /// </summary>
+        public bool UseTunnel { get; private set; }
 
         /// <summary>
         /// The name of the host that has the device plugged.

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -18,6 +19,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
     internal class TcpTextWriter : TextWriter
     {
         private readonly TcpClient _client;
+        private readonly TcpListener _server;
         private readonly StreamWriter _writer;
 
         private static string SelectHostName(string[] names, int port)
@@ -80,22 +82,50 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
             return result;
         }
 
-        public TcpTextWriter(string hostName, int port)
+        public TcpTextWriter(string hostName, int port, bool isTunnel = false)
         {
             if ((port < 0) || (port > ushort.MaxValue))
             {
                 throw new ArgumentOutOfRangeException(nameof(port), $"Port must be between 0 and {ushort.MaxValue}");
             }
 
-            if (hostName == null)
+            if (!isTunnel && hostName == null)
             {
                 throw new ArgumentNullException(nameof(hostName));
             }
 
-            HostName = SelectHostName(hostName.Split(','), port);
+            if (!isTunnel)
+            {
+                HostName = SelectHostName(hostName.Split(','), port);
+            }
+
             Port = port;
 
-            _client = new TcpClient(HostName, port);
+            if (isTunnel)
+            {
+                _server = new TcpListener(IPAddress.Any, Port);
+                _server.Server.ReceiveTimeout = 5000;
+                _server.Start();
+
+                _client = _server.AcceptTcpClient();
+
+                // Block until we have the ping from the client side
+                byte[] buffer = new byte[16 * 1024];
+                var stream = _client.GetStream();
+                while ((_ = stream.Read(buffer, 0, buffer.Length)) != 0)
+                {
+                    var message = Encoding.UTF8.GetString(buffer);
+                    if (message.Contains("ping"))
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                _client = new TcpClient(HostName, port);
+            }
+
             _writer = new StreamWriter(_client.GetStream());
         }
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             {
                 try
                 {
-                    writer = new TcpTextWriter(options.HostName, options.HostPort);
+                    writer = new TcpTextWriter(options.HostName, options.HostPort, options.UseTunnel);
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -151,6 +151,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         // Give up after 2 minutes.
                         if (watch.Elapsed > _timeoutAfter)
                         {
+                            Log.WriteLine(
+                                $"TCP connection hasn't started in time ({})...");
                             throw ex;
                         }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                     }
                     catch (SocketException ex)
                     {
-                        // Give up after 2 minutes.
+                        // Give up after some time
                         if (watch.Elapsed > _timeoutAfter)
                         {
                             Log.WriteLine($"TCP connection hasn't started in time ({_timeoutAfter:hh\\:mm\\:ss}). Stopped listening.");
@@ -159,11 +159,14 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         if (timeout == _retryPeriod && watch.Elapsed > _increaseAfter)
                         {
                             timeout = _retryPeriodIncreased;
-                        }
+                            Log.WriteLine(
+                                $"TCP tunnel still has not connected. " +
+                                $"Increasing retry period from {(int)_retryPeriod.TotalMilliseconds} ms " +
+                                $"to {(int)_retryPeriodIncreased.TotalMilliseconds} ms");
 
-                        if ((++logCounter) % 10 == 0)
+                        } else if ((++logCounter) % 100 == 0)
                         {
-                            Log.WriteLine($"TCP tunnel not connected yet, retrying every {(int)timeout.TotalMilliseconds} ms...");
+                            Log.WriteLine($"TCP tunnel still has not connected");
                         }
 
                         Thread.Sleep(timeout);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -151,8 +151,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         // Give up after 2 minutes.
                         if (watch.Elapsed > _timeoutAfter)
                         {
-                            Log.WriteLine(
-                                $"TCP connection hasn't started in time ({})...");
+                            Log.WriteLine($"TCP connection hasn't started in time ({_timeoutAfter:hh\\:mm\\:ss}). Stopped listening.");
                             throw ex;
                         }
 
@@ -164,9 +163,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
                         if ((++logCounter) % 10 == 0)
                         {
-                            Log.WriteLine(
-                                $"Could not connect to the TCP tunnel on {address}:{Port}. " +
-                                $"Retrying in {(int)timeout.TotalMilliseconds} ms periods...");
+                            Log.WriteLine($"TCP tunnel not connected yet, retrying every {(int)timeout.TotalMilliseconds} ms...");
                         }
 
                         Thread.Sleep(timeout);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -68,20 +68,20 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                 // launch app, but do not await for the result, since we need to create the tunnel
                 var tcpArgs = new MlaunchArguments
                 {
-                    new TcpTunnelArgument (simpleListener.Port),
-                    new DeviceNameArgument (device),
+                    new TcpTunnelArgument(simpleListener.Port),
+                    new DeviceNameArgument(device),
                 };
 
                 // use a cancelation token, later will be used to kill the tcp tunnel process
                 _cancellationToken = new CancellationTokenSource();
-                mainLog.WriteLine($"Starting tcp tunnel between mac port: {simpleListener.Port} and devie port {simpleListener.Port}.");
+                mainLog.WriteLine($"Starting TCP tunnel between mac port: {simpleListener.Port} and device port {simpleListener.Port}");
                 Port = simpleListener.Port;
                 var tunnelbackLog = new CallbackLog((line) =>
                 {
-                    mainLog.WriteLine($"The tcp tunnel output is {line}");
+                    mainLog.WriteLine($"[TCP tunnel] {line}");
                     if (line.Contains("Tcp tunnel started on device"))
                     {
-                        mainLog.Write($"Tcp tunnel created on port {simpleListener.Port}");
+                        mainLog.Write($"TCP tunnel created on port {simpleListener.Port}");
                         startedCompletionSource.TrySetResult(true);
                         simpleListener.TunnelHoleThrough.TrySetResult(true);
                     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -85,7 +85,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         startedCompletionSource.TrySetResult(true);
                         simpleListener.TunnelHoleThrough.TrySetResult(true);
                     }
-                });
+                })
+                {
+                    Timestamp = false
+                };
                 // do not await since we are going to be running the process in parallel
                 _tcpTunnelExecutionTask = _processManager.ExecuteCommandAsync(tcpArgs, tunnelbackLog, timeout, cancellationToken: _cancellationToken.Token);
                 _tcpTunnelExecutionTask.ContinueWith(delegate (Task<ProcessExecutionResult> task)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -85,10 +85,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         startedCompletionSource.TrySetResult(true);
                         simpleListener.TunnelHoleThrough.TrySetResult(true);
                     }
-                })
-                {
-                    Timestamp = false
-                };
+                });
                 // do not await since we are going to be running the process in parallel
                 _tcpTunnelExecutionTask = _processManager.ExecuteCommandAsync(tcpArgs, tunnelbackLog, timeout, cancellationToken: _cancellationToken.Token);
                 _tcpTunnelExecutionTask.ContinueWith(delegate (Task<ProcessExecutionResult> task)


### PR DESCRIPTION
- The port wasn't opened on the device so the tunnel was never connected properly
- Fixing multiple timestamps in logs (cascades of callback/aggregated logs)
- Fixing how we log details when waiting for connections

Resolves #570

Testing showed that mlaunch doesn't quit when app is finished though (#574)