### PR TITLE
Handle exceptions when trying to write CData sections.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Extensions.cs
@@ -5,7 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 
 #nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
@@ -112,6 +114,21 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
         {
             var rv = System.Web.HttpUtility.HtmlEncode(inString);
             return rv.Replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;").Replace("\n", "<br/>\n");
+        }
+
+        // XmlWriter.WriteCData will throw for some characters. This method will catch that exception, and write a base64 encoded string instead (which should always be safe).
+        public static void WriteCDataSafe(this XmlWriter writer, string text)
+        {
+            try
+            {
+                writer.WriteCData(text);
+            }
+            catch (ArgumentException)
+            {
+                var utf8 = Encoding.UTF8.GetBytes(text);
+                var base64 = Convert.ToBase64String(utf8);
+                writer.WriteCData("Base64 encoded UTF8 string: " + base64);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/NUnitV2TestReportGenerator.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/NUnitV2TestReportGenerator.cs
@@ -159,10 +159,10 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.XmlResults
             );
             writer.WriteStartElement("failure");
             writer.WriteStartElement("message");
-            writer.WriteCData(message);
+            writer.WriteCDataSafe(message);
             writer.WriteEndElement(); // message
             writer.WriteStartElement("stack-trace");
-            writer.WriteCData(stderr.ReadToEnd());
+            writer.WriteCDataSafe(stderr.ReadToEnd());
             writer.WriteEndElement(); // stack-trace
             writer.WriteEndElement(); // failure
             writer.WriteEndElement(); // test-case

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TestReportGenerator.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TestReportGenerator.cs
@@ -5,6 +5,8 @@
 using System.IO;
 using System.Xml;
 
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
+
 #nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.XmlResults
 {
@@ -33,12 +35,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.XmlResults
         {
             writer.WriteStartElement("failure");
             writer.WriteStartElement("message");
-            writer.WriteCData(message);
+            writer.WriteCDataSafe(message);
             writer.WriteEndElement(); // message
             if (stderr != null)
             {
                 writer.WriteStartElement("stack-trace");
-                writer.WriteCData(stderr.ReadToEnd());
+                writer.WriteCDataSafe(stderr.ReadToEnd());
                 writer.WriteEndElement(); //stack trace
             }
             writer.WriteEndElement(); // failure


### PR DESCRIPTION
This will hopefully not make xharness fail horribly like this:

    Harness exception for 'Tests for 54A12529-0251-4766-82CA-349C3EDC1DA8': System.ArgumentException: '', hexadecimal value 0x01, is an invalid character.
        at System.Xml.XmlEncodedRawTextWriter.InvalidXmlChar (System.Int32 ch, System.Char* pDst, System.Boolean entitize) [0x00026] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1420
        at System.Xml.XmlEncodedRawTextWriter.WriteCDataSection (System.String text) [0x00251] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1370
        at System.Xml.XmlEncodedRawTextWriter.WriteCData (System.String text) [0x0012a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:470
        at System.Xml.XmlEncodedRawTextWriterIndent.WriteCData (System.String text) [0x00007] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlEncodedRawTextWriter.cs:1750
        at System.Xml.XmlWellFormedWriter.WriteCData (System.String text) [0x00029] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/System.Xml/System/Xml/Core/XmlWellFormedWriter.cs:771
        at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.TestReportGenerator.WriteFailure (System.Xml.XmlWriter writer, System.String message, System.IO.TextReader stderr) [0x00031] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TestReportGenerator.cs:41
        at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.NUnitV3TestReportGenerator.GenerateFailure (System.Xml.XmlWriter writer, System.String title, System.String message, System.IO.TextReader stderr) [0x0030e] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/NUnitV3TestReportGenerator.cs:122
        at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.XmlResultParser.GenerateFailureXml (System.String destination, System.String title, System.String message, System.IO.TextReader stderrReader, Microsoft.DotNet.XHarness.Common.XmlResultJargon jargon) [0x00033] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs:226
        at Microsoft.DotNet.XHarness.iOS.Shared.XmlResults.XmlResultParser.GenerateFailure (Microsoft.DotNet.XHarness.iOS.Shared.Logging.ILogs logs, System.String source, System.String appName, System.String variation, System.String title, System.String message, System.IO.TextReader stderrReader, Microsoft.DotNet.XHarness.Common.XmlResultJargon jargon) [0x000a4] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs:248
        at Xharness.Jenkins.TestTasks.RunTest.BuildAsync () [0x00274] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunTest.cs:74
        at Xharness.Jenkins.TestTasks.AggregatedRunSimulatorTask.ExecuteAsync () [0x000d9] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/AggregatedRunSimulatorTask.cs:46
        at Xharness.Jenkins.TestTasks.TestTasks.RunInternalAsync () [0x00226] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/TestTask.cs:283