### PR TITLE
Deduplicate XML and YAML code in E2E tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,31 +147,31 @@ stages:
   - template: eng/e2e-test.yml
     parameters:
       name: E2E_Android
-      displayName: Android E2E Tests
+      displayName: Android - Simulators
       testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
 
   - template: eng/e2e-test.yml
     parameters:
       name: E2E_Android_Manual_Commands
-      displayName: Android E2E Tests - Manual Commands
+      displayName: Android - Manual Commands
       testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
 
   - template: eng/e2e-test.yml
     parameters:
       name: E2E_Apple_Simulators
-      displayName: Apple E2E Simulator Tests
+      displayName: Apple - Simulators
       testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
 
   - template: eng/e2e-test.yml
     parameters:
       name: E2E_SimulatorInstaller
-      displayName: Apple E2E Tests - Simulator Commands
+      displayName: Apple - Simulator Commands
       testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
 
   - template: eng/e2e-test.yml
     parameters:
       name: E2E_WASM
-      displayName: WASM E2E Tests
+      displayName: WASM
       testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
 
 # NuGet publishing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ pr:
     - main
     - xcode/*
 
+# Build
+
 stages:
 - stage: Build_Windows_NT
   displayName: Build Windows
@@ -140,210 +142,39 @@ stages:
                 testRunTitle: XHarness unit tests - $(Agent.JobName)
               condition: succeededOrFailed()
 
-  - stage: Test_CLI_Package_In_Helix_Android
-    displayName: 'CLI Android Integration tests (Helix SDK)'
-    dependsOn: Build_OSX
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        workspace:
-          clean: all
-        jobs:
-        - job: Linux
-          pool:
-            vmimage: ubuntu-latest
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          preSteps:
-          - checkout: self
-            clean: true
-          displayName: Submit Helix Job
-          steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              source: current
-              artifact: Microsoft.DotNet.XHarness.CLI.Debug
-              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
+# E2E tests
 
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Android.Helix.SDK.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: Run Helix Tests
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+  - template: eng/e2e-test.yml
+    parameters:
+      name: E2E_Android
+      displayName: Android E2E Tests
+      testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
 
-  - stage: Test_CLI_Manual_Commands_In_Helix_Android
-    displayName: 'CLI Android Manual Commands Integration tests (Helix SDK)'
-    dependsOn: Build_OSX
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        workspace:
-          clean: all
-        jobs:
-        - job: Linux
-          pool:
-            vmimage: ubuntu-latest
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          preSteps:
-          - checkout: self
-            clean: true
-          displayName: Submit Helix Job
-          steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              source: current
-              artifact: Microsoft.DotNet.XHarness.CLI.Debug
-              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
+  - template: eng/e2e-test.yml
+    parameters:
+      name: E2E_Android_Manual_Commands
+      displayName: Android E2E Tests - Manual Commands
+      testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
 
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Android.CLI.Commands.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: Run Helix Tests
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+  - template: eng/e2e-test.yml
+    parameters:
+      name: E2E_Apple_Simulators
+      displayName: Apple E2E Simulator Tests
+      testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
 
-  - stage: Test_CLI_Package_In_Helix_Apple
-    displayName: 'CLI Apple Integration tests (Helix SDK)'
-    dependsOn: Build_OSX
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        workspace:
-          clean: all
-        jobs:
-        - job: OSX
-          pool:
-            name: Hosted macOS
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          preSteps:
-          - checkout: self
-            clean: true
-          displayName: Submit Helix Job
-          steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              source: current
-              artifact: Microsoft.DotNet.XHarness.CLI.Debug
-              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
+  - template: eng/e2e-test.yml
+    parameters:
+      name: E2E_SimulatorInstaller
+      displayName: Apple E2E Tests - Simulator Commands
+      testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
 
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Apple.Simulator.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: Run Helix Tests
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+  - template: eng/e2e-test.yml
+    parameters:
+      name: E2E_WASM
+      displayName: WASM E2E Tests
+      testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
 
-  - stage: Test_CLI_Package_In_Helix_WASM
-    displayName: 'CLI WASM Integration tests (Helix SDK)'
-    dependsOn: Build_OSX
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        workspace:
-          clean: all
-        jobs:
-        - job: OSX
-          pool:
-            name: Hosted macOS
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          preSteps:
-          - checkout: self
-            clean: true
-          displayName: Submit Helix Job
-          steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              source: current
-              artifact: Microsoft.DotNet.XHarness.CLI.Debug
-              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
-
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/WASM.Helix.SDK.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: Run Helix Tests
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
-
-  - stage: Test_SimulatorInstaller
-    displayName: SimulatorInstaller Integration Tests
-    dependsOn: Build_OSX
-    jobs:
-    - template: /eng/common/templates/jobs/jobs.yml
-      parameters:
-        workspace:
-          clean: all
-        jobs:
-        - job: OSX
-          pool:
-            name: Hosted macOS
-          strategy:
-            matrix:
-              Build_Debug:
-                _BuildConfig: Debug
-          preSteps:
-          - checkout: self
-            clean: true
-          displayName: Submit Helix Job
-          steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              source: current
-              artifact: Microsoft.DotNet.XHarness.CLI.Debug
-              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
-
-          - script: eng/common/build.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              --ci
-              --restore
-              --test
-              --projects $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
-              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/Apple.SimulatorInstaller.Tests.binlog
-              /p:RestoreUsingNuGetTargets=false
-            displayName: Run Helix Tests
-            env:
-              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-              HelixAccessToken: ''
+# NuGet publishing
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -1,0 +1,47 @@
+parameters:
+  # This template tests a given .proj file using the Helix SDK
+  name: ''
+  displayName: ''
+  testProject: ''
+
+stages:
+  - stage: ${{ parameters.name }}
+    displayName: ${{ parameters.displayName }}
+    dependsOn: Build_OSX
+    jobs:
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        workspace:
+          clean: all
+        jobs:
+        - job: Linux
+          pool:
+            vmimage: ubuntu-latest
+          strategy:
+            matrix:
+              Build_Debug:
+                _BuildConfig: Debug
+          preSteps:
+          - checkout: self
+            clean: true
+          displayName: Submit Helix Job
+          steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              source: current
+              artifact: Microsoft.DotNet.XHarness.CLI.Debug
+              path: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/Shipping/
+
+          - script: eng/common/build.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+              --ci
+              --restore
+              --test
+              --projects ${{ parameters.testProject }}
+              /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/${{ parameters.name }}.binlog
+              /p:RestoreUsingNuGetTargets=false
+            displayName: Run E2E Tests in Helix
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+              HelixAccessToken: ''

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -24,7 +24,7 @@ stages:
           preSteps:
           - checkout: self
             clean: true
-          displayName: E2E Tests
+          displayName: Helix Tests
           steps:
           - task: DownloadPipelineArtifact@2
             inputs:

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -6,7 +6,7 @@ parameters:
 
 stages:
   - stage: ${{ parameters.name }}
-    displayName: ${{ parameters.displayName }}
+    displayName: E2E ${{ parameters.displayName }}
     dependsOn: Build_OSX
     jobs:
     - template: /eng/common/templates/jobs/jobs.yml

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -24,7 +24,7 @@ stages:
           preSteps:
           - checkout: self
             clean: true
-          displayName: Submit Helix Job
+          displayName: E2E Tests
           steps:
           - task: DownloadPipelineArtifact@2
             inputs:
@@ -41,7 +41,7 @@ stages:
               --projects ${{ parameters.testProject }}
               /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/${{ parameters.name }}.binlog
               /p:RestoreUsingNuGetTargets=false
-            displayName: Run E2E Tests in Helix
+            displayName: Run tests in Helix
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               HelixAccessToken: ''

--- a/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
+++ b/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
@@ -5,11 +5,11 @@
     <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
   </ItemGroup>
 
-  <Target Name="TestAndroid" BeforeTargets="CoreTest">
-    <PropertyGroup>
-      <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.zip</XHarnessX86TestApkUrl>
-    </PropertyGroup>
+  <PropertyGroup>
+    <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.zip</XHarnessX86TestApkUrl>
+  </PropertyGroup>
 
+  <Target Name="TestAndroid" BeforeTargets="CoreTest">
     <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)apk" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />
     </DownloadFile>

--- a/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
+++ b/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
@@ -1,46 +1,9 @@
 <Project DefaultTargets="Test">
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
+  <Import Project="../Helix.SDK.configuration.props"/>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <!-- Pick up the nupkg from this repo for testing purposes -->
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
-
-  <!-- For non-ci local runs -->
-  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <!-- Required: Configuration that is already needed for the Helix SDK -->
   <ItemGroup>
     <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.zip</XHarnessX86TestApkUrl>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Target Name="TestAndroid" BeforeTargets="CoreTest">
 

--- a/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
+++ b/tests/integration-tests/Android/Android.CLI.Commands.Tests.proj
@@ -6,6 +6,9 @@
   </ItemGroup>
 
   <Target Name="TestAndroid" BeforeTargets="CoreTest">
+    <PropertyGroup>
+      <XHarnessX86TestApkUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/android/test-apk/x86/System.Numerics.Vectors.Tests-x86.zip</XHarnessX86TestApkUrl>
+    </PropertyGroup>
 
     <DownloadFile SourceUrl="$(XHarnessX86TestApkUrl)" DestinationFolder="$(ArtifactsTmpDir)apk" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="DownloadedApkFile" />

--- a/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/Android/Android.Helix.SDK.Tests.proj
@@ -1,40 +1,10 @@
 <Project DefaultTargets="Test">
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <!-- Pick up the nupkg from this repo for testing purposes -->
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-    <XHarnessNupkgPath>$(MSBuildThisFileDirectory)../../../artifacts/packages/$(Configuration)/Shipping/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
+  <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
+    <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
     <XHarnessAndroidProject Include="$(MSBuildThisFileDirectory)Android.TestApks.proj" />
   </ItemGroup>
-
-  <!-- Currently no closed queues for Android testing; runtime team does all testing in public -->
-  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="ubuntu.1804.amd64.android.open"/>
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
 </Project>

--- a/tests/integration-tests/Apple/Device.Tests.proj
+++ b/tests/integration-tests/Apple/Device.Tests.proj
@@ -1,48 +1,14 @@
 <Project DefaultTargets="Test">
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <!-- For non-ci local runs -->
-  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
-
   <ItemGroup>
+    <HelixTargetQueue Include="osx.1015.amd64.iphone.open"/>
+
     <!-- apple run / ios-device -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
       <AdditionalProperties>TestTarget=ios-device;TestAppBundleName=HelloiOS.app;IncludesTestRunner=false;ExpectedExitCode=200</AdditionalProperties>
     </XHarnessAppleProject>
-
-    <HelixTargetQueue Include="osx.1015.amd64.iphone.open"/>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
 </Project>

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,30 +1,9 @@
 <Project DefaultTargets="Test">
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <!-- For non-ci local runs -->
-  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
+  <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
+    <HelixTargetQueue Include="osx.1015.amd64.open"/>
+
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
       <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
@@ -50,25 +29,6 @@
       <AdditionalProperties>TestTarget=tvos-simulator;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="osx.1015.amd64"/>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="osx.1015.amd64.open"/>
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
 </Project>

--- a/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
+++ b/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
@@ -1,55 +1,15 @@
 <Project DefaultTargets="Test">
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <!-- For non-ci local runs -->
-  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)\Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
+  <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
+    <HelixTargetQueue Include="osx.1015.amd64.open"/>
+
     <HelixWorkItem Include="SimulatorInstaller.Tests">
       <PayloadDirectory>$(RepoRoot)\tests\integration-tests\Apple\helix-payloads</PayloadDirectory>
       <Command>./simulatorinstaller-integration-tests.sh</Command>
       <Timeout>00:05:00</Timeout>
     </HelixWorkItem>
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(HelixAccessToken)' != '' ">
-    <HelixTargetQueue Include="osx.1015.amd64"/>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <HelixTargetQueue Include="osx.1015.amd64.open"/>
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
 </Project>

--- a/tests/integration-tests/Helix.SDK.configuration.props
+++ b/tests/integration-tests/Helix.SDK.configuration.props
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
+    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <HelixType>test/product/</HelixType>
+    <IncludeXHarnessCli>true</IncludeXHarnessCli>
+    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
+    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
+    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
+    <!-- Pick up the nupkg from this repo for testing purposes -->
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
+  </PropertyGroup>
+
+  <!-- For non-ci local runs -->
+  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
+    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
+    <IsExternal>true</IsExternal>
+    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
+    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
+  </PropertyGroup>
+
+  <!-- Useless stuff to make Arcade SDK happy -->
+  <PropertyGroup>
+    <Language>msbuild</Language>
+  </PropertyGroup>
+</Project>

--- a/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
@@ -5,6 +5,10 @@
     <HelixTargetQueue Include="ubuntu.2004.amd64.open"/>
   </ItemGroup>
 
+  <PropertyGroup>
+    <TestPayloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/wasm/System.Reflection.Extensions.Tests.zip</TestPayloadUrl>
+  </PropertyGroup>
+
   <Target Name="TestWasm" BeforeTargets="CoreTest">
     <DownloadFile SourceUrl="$(TestPayloadUrl)" DestinationFolder="$(ArtifactsTmpDir)wasm" SkipUnchangedFiles="True" Retries="5">
       <Output TaskParameter="DownloadedFile" ItemName="TestPayloadArchive" />

--- a/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
+++ b/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
@@ -1,45 +1,9 @@
 <Project DefaultTargets="Test">
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.props"/>
-
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <!-- Workaround changes from newer MSBuild requiring additional properties, see https://github.com/dotnet/arcade/pull/5996 -->
-    <TargetFrameworkVersion>3.1</TargetFrameworkVersion>
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <HelixType>test/product/</HelixType>
-    <IncludeXHarnessCli>true</IncludeXHarnessCli>
-    <TestRunNamePrefix>$(AGENT_JOBNAME)</TestRunNamePrefix>
-    <EnableAzurePipelinesReporter>true</EnableAzurePipelinesReporter>
-    <HelixBaseUri>https://helix.dot.net</HelixBaseUri>
-    <!-- Pick up the nupkg from this repo for testing purposes -->
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-ci</MicrosoftDotNetXHarnessCLIVersion>
-    <TestPayloadUrl>https://netcorenativeassets.blob.core.windows.net/resource-packages/external/wasm/System.Reflection.Extensions.Tests.zip</TestPayloadUrl>
-  </PropertyGroup>
-
-  <!-- For non-ci local runs -->
-  <PropertyGroup Condition=" '$(AGENT_JOBNAME)' == '' ">
-    <EnableAzurePipelinesReporter>false</EnableAzurePipelinesReporter>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-dev</MicrosoftDotNetXHarnessCLIVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <XHarnessNupkgPath>$(ArtifactsShippingPackagesDir)/Microsoft.DotNet.XHarness.CLI.$(MicrosoftDotNetXHarnessCLIVersion).nupkg</XHarnessNupkgPath>
-  </PropertyGroup>
+  <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
     <HelixTargetQueue Include="ubuntu.2004.amd64.open"/>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(HelixAccessToken)' == '' ">
-    <IsExternal>true</IsExternal>
-    <Creator>$(BUILD_SOURCEVERSIONAUTHOR)</Creator>
-    <Creator Condition=" '$(Creator)' == '' ">anon</Creator>
-  </PropertyGroup>
-
-  <!-- Useless stuff to make Arcade SDK happy -->
-  <PropertyGroup>
-    <Language>msbuild</Language>
-  </PropertyGroup>
 
   <Target Name="TestWasm" BeforeTargets="CoreTest">
     <DownloadFile SourceUrl="$(TestPayloadUrl)" DestinationFolder="$(ArtifactsTmpDir)wasm" SkipUnchangedFiles="True" Retries="5">


### PR DESCRIPTION
- Add YAML template for E2E test stages
- Pull common Helix SDK configuration into a props file