### PR TITLE
Redirect app output into a separate file for Apple device

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -270,7 +270,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private static MlaunchArguments GetDeviceArguments(
+        private MlaunchArguments GetDeviceArguments(
             AppBundleInformation appInformation,
             IDevice device,
             bool isWatchTarget,
@@ -307,6 +307,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 args.Add(new WaitForExitArgument());
             }
+
+            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}-{_helpers.Timestamp}.log", LogType.ExecutionLog);
+            args.Add(new SetStdoutArgument(appOutputLog));
 
             return args;
         }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -608,6 +608,9 @@ namespace Microsoft.DotNet.XHarness.Apple
                 args.Add(new WaitForExitArgument());
             }
 
+            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}-{_helpers.Timestamp}.log", LogType.ExecutionLog);
+            args.Add(new SetStdoutArgument(appOutputLog));
+
             return args;
         }
     }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 {
     public abstract class AppRunTestBase : IDisposable
     {
-        protected const string AppName = "net.dot.System.Text.Json.Tests";
-        protected const string AppBundleIdentifier = AppName + ".ID";
+        protected const string AppName = "System.Text.Json.Tests.app";
+        protected const string AppBundleIdentifier = "net.dot.System.Text.Json.Tests";
         protected const string SimulatorDeviceName = "Test iPhone simulator";
         protected const string DeviceName = "Test iPhone";
 
@@ -60,7 +60,12 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _snapshotReporter = new Mock<ICrashSnapshotReporter>();
 
             _logs = new Mock<ILogs>();
-            _logs.SetupGet(x => x.Directory).Returns(Path.Combine(s_outputPath, "logs"));
+            _logs
+                .SetupGet(x => x.Directory)
+                .Returns(Path.Combine(s_outputPath, "logs"));
+            _logs
+                .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
+                .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
 
             var factory2 = new Mock<ICrashSnapshotReporterFactory>();
             factory2.SetReturnsDefault(_snapshotReporter.Object);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
@@ -213,7 +212,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             "--disable-memory-limits " +
             $"--devname {s_mockDevice.DeviceIdentifier} " +
             $"--launchdevbundleid {AppBundleIdentifier} " +
-            "--wait-for-exit";
+            "--wait-for-exit " +
+            $"--stdout=./{AppBundleIdentifier}-mocked_timestamp.log";
 
         private string GetExpectedSimulatorMlaunchArgs() =>
             "-argument=--foo=bar " +

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
@@ -522,7 +521,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             $"--devname {s_mockDevice.DeviceIdentifier} " +
             (useTunnel ? "-setenv=USE_TCP_TUNNEL=true " : null) +
             $"--launchdevbundleid {AppBundleIdentifier} " +
-            "--wait-for-exit";
+            "--wait-for-exit " +
+            $"--stdout=./{AppBundleIdentifier}-mocked_timestamp.log";
 
         private string GetExpectedSimulatorMlaunchArgs() =>
             "-setenv=NUNIT_AUTOEXIT=true " +


### PR DESCRIPTION
There is a bug in mlaunch and the `--stdout` argument doesn't do anything but I will fix it later.
Once it's fixed, we will be ready.