### PR TITLE
Look for devices with any of detected from apk architectures

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -420,7 +420,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
 
 
-        public string? GetDeviceToUse(ILogger logger, string apkRequiredProperty, string propertyName)
+        public string? GetDeviceToUse(ILogger logger, IEnumerable<string> apkRequiredProperty, string propertyName)
         {
             var allDevicesAndTheirProperties = GetAllDevicesToUse(logger, apkRequiredProperty, propertyName);
             if (allDevicesAndTheirProperties.Count > 0)
@@ -434,7 +434,7 @@ namespace Microsoft.DotNet.XHarness.Android
 
         public string? GetUniqueDeviceToUse(ILogger logger, string apkRequiredProperty, string propertyName)
         {
-            var devices = GetAllDevicesToUse(logger, apkRequiredProperty, propertyName);
+            var devices = GetAllDevicesToUse(logger, new[]{ apkRequiredProperty}, propertyName);
             if (devices.Count == 0)
             {
                 logger.LogError($"Cannot find a device with {propertyName}={apkRequiredProperty}, please check that a device is attached");
@@ -448,7 +448,7 @@ namespace Microsoft.DotNet.XHarness.Android
             return devices.Keys.First();
         }
 
-        public Dictionary<string, string> GetAllDevicesToUse(ILogger logger, string apkRequiredProperty, string propertyName)
+        public Dictionary<string, string> GetAllDevicesToUse(ILogger logger, IEnumerable<string> apkRequiredProperty, string propertyName)
         {
 
             var allDevicesAndTheirProperties = new Dictionary<string, string?>();
@@ -469,13 +469,13 @@ namespace Microsoft.DotNet.XHarness.Android
             }
 
             var result = allDevicesAndTheirProperties
-                .Where(kvp => !string.IsNullOrEmpty(kvp.Value) && kvp.Value.Split().Contains(apkRequiredProperty))
+                .Where(kvp => !string.IsNullOrEmpty(kvp.Value) && kvp.Value.Split().Intersect(apkRequiredProperty).Count() != 0)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value) as Dictionary<string, string>;
 
             if (result.Count == 0)
             {
                 // In this case, the enumeration worked, we found one or more devices, but nothing matched the APK's architecture; fail out.
-                logger.LogError($"No devices with {propertyName} '{apkRequiredProperty}' was found among attached devices.");
+                logger.LogError($"No devices with {propertyName} '" + string.Join(", ", apkRequiredProperty) + "' was found among attached devices.");
             }
 
             return result;

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -469,13 +469,15 @@ namespace Microsoft.DotNet.XHarness.Android
             }
 
             var result = allDevicesAndTheirProperties
-                .Where(kvp => !string.IsNullOrEmpty(kvp.Value) && kvp.Value.Split().Intersect(apkRequiredProperty).Count() != 0)
+                .Where(kvp => !string.IsNullOrEmpty(kvp.Value) && kvp.Value.Split().Intersect(apkRequiredProperty).Any())
+
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value) as Dictionary<string, string>;
 
             if (result.Count == 0)
             {
                 // In this case, the enumeration worked, we found one or more devices, but nothing matched the APK's architecture; fail out.
-                logger.LogError($"No devices with {propertyName} '" + string.Join(", ", apkRequiredProperty) + "' was found among attached devices.");
+                logger.LogError($"No devices with {propertyName} '{ string.Join("', '", apkRequiredProperty) }' was found among attached devices.");
+
             }
 
             return result;

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidArchitecture.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidArchitecture.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
+{
+    internal enum AndroidArchitecture
+    {
+        X86,
+        X86_64,
+        Arm64_v8a,
+        Armeabi_v7a
+    }
+
+    internal static class AndroidArchitectureHelper
+    {
+        public static AndroidArchitecture ParseAsAndroidArchitecture(this string target) => target switch
+        {
+            "x86" => AndroidArchitecture.X86,
+            "x86_64" => AndroidArchitecture.X86_64,
+            "arm64-v8a" => AndroidArchitecture.Arm64_v8a,
+            "armeabi-v7a" => AndroidArchitecture.Armeabi_v7a,
+            _ => throw new ArgumentOutOfRangeException(nameof(target))
+        };
+
+        public static string AsString(this AndroidArchitecture arch) => arch switch
+        {
+            AndroidArchitecture.X86 => "x86",
+            AndroidArchitecture.X86_64 => "x86_64",
+            AndroidArchitecture.Arm64_v8a => "arm64-v8a",
+            AndroidArchitecture.Armeabi_v7a => "armeabi-v7a",
+            _ => throw new ArgumentOutOfRangeException(nameof(arch))
+        };
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -44,6 +44,20 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         public override void Validate()
         {
+
+            foreach (var archName in _deviceArchitecture ?? throw new ArgumentException("architecture cannot be empty"))
+            {
+                try
+                {
+                    AndroidArchitectureHelper.ParseAsAndroidArchitecture(archName);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    throw new ArgumentException(
+                        $"Failed to parse architecture '{archName}'. Available architectures are:" +
+                        GetAllowedValues<AndroidArchitecture>(t => t.AsString()));
+                }
+            }
             // Validate this field
             _ = AppPackagePath;
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Mono.Options;
 
@@ -11,6 +12,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
     internal class AndroidGetDeviceCommandArguments : XHarnessCommandArguments
     {
         private string? _appPackagePath = null;
+        private readonly List<string> _deviceArchitecture = new();
 
         /// <summary>
         /// Path to packaged app
@@ -25,15 +27,18 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// If specified, attempt to run on a compatible attached device, failing if unavailable.
         /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
         /// </summary>
-        public string? DeviceArchitecture { get; set; }
+        public IEnumerable<string> DeviceArchitecture => _deviceArchitecture;
 
         protected override OptionSet GetCommandOptions() => new()
         {
             { "app|a=", "Path to already-packaged app",
                 v => AppPackagePath = RootPath(v)
             },
-            { "device-arch=", "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK",
-                v => DeviceArchitecture = v
+            {
+                "device-arch=",
+                "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK. " +
+                "Can be used more than once.",
+                v => _deviceArchitecture.Add(v)
             },
         };
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
@@ -10,6 +11,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
     internal class AndroidInstallCommandArguments : TestCommandArguments
     {
         private string? _packageName;
+        private readonly List<string> _deviceArchitecture = new();
 
         public string PackageName
         {
@@ -27,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// If specified, attempt to run on a compatible attached device, failing if unavailable.
         /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
         /// </summary>
-        public string? DeviceArchitecture { get; set; }
+        public IEnumerable<string> DeviceArchitecture => _deviceArchitecture;
 
         /// <summary>
         /// Time to wait for boot completion. Defaults to 5 minutes.
@@ -42,6 +44,12 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
             {
                 "device-id=", "Device where APK should be installed",
                 v => DeviceId = v
+            },
+            {
+                "device-arch=",
+                "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK. " +
+                "Can be used more than once.",
+                v => _deviceArchitecture.Add(v)
             },
             {
                 "launch-timeout=|lt=", "Time span in the form of \"00:00:00\" or number of seconds to wait for the device to boot to complete",

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -76,6 +76,20 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         {
             base.Validate();
 
+            foreach (var archName in _deviceArchitecture ?? throw new ArgumentException("architecture cannot be empty"))
+            {
+                try
+                {
+                    AndroidArchitectureHelper.ParseAsAndroidArchitecture(archName);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    throw new ArgumentException(
+                        $"Failed to parse architecture '{archName}'. Available architectures are:" +
+                        GetAllowedValues<AndroidArchitecture>(t => t.AsString()));
+                }
+            }
+
             // Validate this field
             _ = PackageName;
             _ = AppPackagePath;

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -140,6 +140,20 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         {
             base.Validate();
 
+            foreach (var archName in _deviceArchitecture ?? throw new ArgumentException("architecture cannot be empty"))
+            {
+                try
+                {
+                    AndroidArchitectureHelper.ParseAsAndroidArchitecture(archName);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    throw new ArgumentException(
+                        $"Failed to parse architecture '{archName}'. Available architectures are:" +
+                        GetAllowedValues<AndroidArchitecture>(t => t.AsString()));
+                }
+            }
+
             // Validate this field
             _ = PackageName;
             _ = AppPackagePath;

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
     internal class AndroidTestCommandArguments : TestCommandArguments
     {
         private string? _packageName;
+        private readonly List<string> _deviceArchitecture = new();
 
         /// <summary>
         /// If specified, attempt to run instrumentation with this name instead of the default for the supplied APK.
@@ -38,7 +39,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
         /// If specified, attempt to run on a compatible attached device, failing if unavailable.
         /// If not specified, we will open the apk using Zip APIs and guess what's usable based off folders found in under /lib
         /// </summary>
-        public string? DeviceArchitecture { get; set; }
+        public IEnumerable<string> DeviceArchitecture => _deviceArchitecture;
 
         /// <summary>
         /// Folder to copy off for output of executing the specified APK
@@ -67,8 +68,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 
         protected override OptionSet GetTestCommandOptions() => new()
         {
-            { "device-arch=", "If specified, only run on a device with the listed architecture (x86, x86_64, arm64-v8a or armeabi-v7a).  Otherwise infer from supplied APK",
-                v => DeviceArchitecture = v
+            {
+                "device-arch=",
+                "If specified, forces running on a device with given architecture (x86, x86_64, arm64-v8a or armeabi-v7a). Otherwise inferred from supplied APK. " +
+                "Can be used more than once.",
+                v => _deviceArchitecture.Add(v)
             },
             { "device-out-folder=|dev-out=", "If specified, copy this folder recursively off the device to the path specified by the output directory",
                 v => DeviceOutputFolder = RootPath(v)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -46,15 +47,15 @@ Arguments:
             }
 
             var runner = new AdbRunner(logger);
-            string apkRequiredArchitecture;
+            IEnumerable<string> apkRequiredArchitecture;
 
-            if (!string.IsNullOrEmpty(_arguments.DeviceArchitecture))
+            if (_arguments.DeviceArchitecture.Count() != 0)
             {
                 apkRequiredArchitecture = _arguments.DeviceArchitecture;
             }
             else
             {
-                apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath).First();
+                apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath);
             }
 
             try

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -49,7 +49,7 @@ Arguments:
             var runner = new AdbRunner(logger);
             IEnumerable<string> apkRequiredArchitecture;
 
-            if (_arguments.DeviceArchitecture.Count() != 0)
+            if (_arguments.DeviceArchitecture.Any())
             {
                 apkRequiredArchitecture = _arguments.DeviceArchitecture;
             }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -53,12 +53,12 @@ Arguments:
                 if (_arguments.DeviceArchitecture.Any())
                 {
                     apkRequiredArchitecture = _arguments.DeviceArchitecture.ToList();
-                    logger.LogInformation("Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
+                    logger.LogInformation($"Will attempt to run device on specified architecture: '{string.Join("', '", apkRequiredArchitecture)}'");
                 }
                 else
                 {
                     apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath);
-                    logger.LogInformation($"Will attempt to run device on detected architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
+                    logger.LogInformation($"Will attempt to run device on detected architecture: '{string.Join("', '", apkRequiredArchitecture)}'");
                 }
             }
 
@@ -90,7 +90,7 @@ Arguments:
 
                     if (deviceId == null)
                     {
-                        throw new Exception($"Failed to find compatible device: {apkRequiredArchitecture}");
+                        throw new Exception($"Failed to find compatible device: {string.Join(", ", apkRequiredArchitecture)}");
                     }
 
                     runner.SetActiveDevice(deviceId);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,20 +45,20 @@ Arguments:
 
             var runner = new AdbRunner(logger);
 
-            string? apkRequiredArchitecture = null;
+            List<string> apkRequiredArchitecture = new();
 
             if (string.IsNullOrEmpty(_arguments.DeviceId))
             {
                 // trying to choose suitable device
-                if (!string.IsNullOrEmpty(_arguments.DeviceArchitecture))
+                if (_arguments.DeviceArchitecture.Count() != 0)
                 {
-                    apkRequiredArchitecture = _arguments.DeviceArchitecture;
-                    logger.LogInformation($"Will attempt to run device on specified architecture: '{apkRequiredArchitecture}'");
+                    apkRequiredArchitecture = _arguments.DeviceArchitecture.ToList();
+                    logger.LogInformation("Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
                 }
                 else
                 {
-                    apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath).First();
-                    logger.LogInformation($"Will attempt to run device on detected architecture: '{apkRequiredArchitecture}'");
+                    apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath);
+                    logger.LogInformation($"Will attempt to run device on detected architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
                 }
             }
 
@@ -72,7 +73,7 @@ Arguments:
                 runner: runner));
         }
 
-        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, string? apkRequiredArchitecture, string? deviceId, TimeSpan bootTimeoutSeconds, AdbRunner runner)
+        public static ExitCode InvokeHelper(ILogger logger, string apkPackageName, string appPackagePath, IEnumerable<string> apkRequiredArchitecture, string? deviceId, TimeSpan bootTimeoutSeconds, AdbRunner runner)
         {
             try
             {
@@ -83,7 +84,7 @@ Arguments:
 
                     // if call via install command device id must be set
                     // otherwise - from test command - apkRequiredArchitecture was set by user or .apk architecture
-                    deviceId ??= apkRequiredArchitecture != null
+                    deviceId ??= apkRequiredArchitecture.Count() != 0
                         ? runner.GetDeviceToUse(logger, apkRequiredArchitecture, "architecture")
                         : throw new ArgumentException("Required architecture not specified");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -50,7 +50,7 @@ Arguments:
             if (string.IsNullOrEmpty(_arguments.DeviceId))
             {
                 // trying to choose suitable device
-                if (_arguments.DeviceArchitecture.Count() != 0)
+                if (_arguments.DeviceArchitecture.Any())
                 {
                     apkRequiredArchitecture = _arguments.DeviceArchitecture.ToList();
                     logger.LogInformation("Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
@@ -84,7 +84,7 @@ Arguments:
 
                     // if call via install command device id must be set
                     // otherwise - from test command - apkRequiredArchitecture was set by user or .apk architecture
-                    deviceId ??= apkRequiredArchitecture.Count() != 0
+                    deviceId ??= apkRequiredArchitecture.Any()
                         ? runner.GetDeviceToUse(logger, apkRequiredArchitecture, "architecture")
                         : throw new ArgumentException("Required architecture not specified");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -61,12 +61,12 @@ Arguments:
             if (_arguments.DeviceArchitecture.Any())
             {
                 apkRequiredArchitecture = _arguments.DeviceArchitecture;
-                logger.LogInformation($"Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
+                logger.LogInformation($"Will attempt to run device on specified architecture: '{string.Join("', '", apkRequiredArchitecture)}'");
             }
             else
             {
                 apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath);
-                logger.LogInformation($"Will attempt to run device on detected architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
+                logger.LogInformation($"Will attempt to run device on detected architecture: '{string.Join("', '", apkRequiredArchitecture)}'");
             }
 
             // Package Name is not guaranteed to match file name, so it needs to be mandatory.

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -58,7 +58,7 @@ Arguments:
             // Assumption: APKs we test will only have one arch for now
             IEnumerable<string> apkRequiredArchitecture;
 
-            if (_arguments.DeviceArchitecture.Count() != 0)
+            if (_arguments.DeviceArchitecture.Any())
             {
                 apkRequiredArchitecture = _arguments.DeviceArchitecture;
                 logger.LogInformation($"Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -55,17 +56,17 @@ Arguments:
             var runner = new AdbRunner(logger);
 
             // Assumption: APKs we test will only have one arch for now
-            string apkRequiredArchitecture;
+            IEnumerable<string> apkRequiredArchitecture;
 
-            if (!string.IsNullOrEmpty(_arguments.DeviceArchitecture))
+            if (_arguments.DeviceArchitecture.Count() != 0)
             {
                 apkRequiredArchitecture = _arguments.DeviceArchitecture;
-                logger.LogInformation($"Will attempt to run device on specified architecture: '{apkRequiredArchitecture}'");
+                logger.LogInformation($"Will attempt to run device on specified architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
             }
             else
             {
-                apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath).First();
-                logger.LogInformation($"Will attempt to run device on detected architecture: '{apkRequiredArchitecture}'");
+                apkRequiredArchitecture = ApkHelper.GetApkSupportedArchitectures(_arguments.AppPackagePath);
+                logger.LogInformation($"Will attempt to run device on detected architecture: '" + string.Join(", ", apkRequiredArchitecture) + "'");
             }
 
             // Package Name is not guaranteed to match file name, so it needs to be mandatory.

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
             var result = runner.GetAttachedDevicesWithProperties("architecture");
             _processManager.Verify(pm => pm.Run(s_adbPath, "devices -l", TimeSpan.FromSeconds(30)), Times.Once);
 
-            // Ensure it called, parsed the three random device names and found all three architectures
+            // Ensure it called, parsed the four random device names and found all four architectures
             foreach (var fakeDeviceInfo in _fakeDeviceList.Keys)
             {
                 _processManager.Verify(pm => pm.Run(s_adbPath, $"-s {fakeDeviceInfo.Item1} shell getprop ro.product.cpu.abi", TimeSpan.FromSeconds(30)), Times.Once);
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.XHarness.Android.Tests
         {
             var requiredArchitecture = "x86_64";
             var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
-            var result = runner.GetDeviceToUse(_mainLog.Object, requiredArchitecture, "architecture");
+            var result = runner.GetDeviceToUse(_mainLog.Object, new[] { requiredArchitecture }, "architecture");
             _processManager.Verify(pm => pm.Run(s_adbPath, "devices -l", TimeSpan.FromSeconds(30)), Times.Once);
             Assert.True(_fakeDeviceList.ContainsKey(new Tuple<string, string>(result, requiredArchitecture)));
         }


### PR DESCRIPTION
The first part of changes for #584. Before we choose only one detected architecture from .apk (if it's not provided explicitely). This PR will allow to continue looking for compatible devices if we detect more then one architecture from APK. Also I make it possible to provide `--device-arch` more than once.