### PR TITLE
Capture application stdout and stderr in log files

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -227,11 +227,19 @@ namespace Microsoft.DotNet.XHarness.Apple
             }
         }
 
-        private static MlaunchArguments GetExtraArguments(
+        private MlaunchArguments GetCommonArguments(
+            AppBundleInformation appInformation,
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var args = new MlaunchArguments();
+            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.log", LogType.ApplicationLog);
+            string appErrorOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.err.log", LogType.ApplicationLog);
+
+            var args = new MlaunchArguments
+            {
+                new SetStdoutArgument(appOutputLog),
+                new SetStderrArgument(appErrorOutputLog),
+            };
 
             // Arguments passed to the iOS app bundle
             args.AddRange(extraAppArguments.Select(arg => new SetAppArgumentArgument(arg)));
@@ -240,13 +248,13 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private static MlaunchArguments GetSimulatorArguments(
+        private MlaunchArguments GetSimulatorArguments(
             AppBundleInformation appInformation,
             ISimulatorDevice simulator,
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var args = GetExtraArguments(extraAppArguments, extraEnvVariables);
+            var args = GetCommonArguments(appInformation, extraAppArguments, extraEnvVariables);
 
             args.Add(new SimulatorUDIDArgument(simulator.UDID));
 
@@ -277,7 +285,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var args = GetExtraArguments(extraAppArguments, extraEnvVariables);
+            var args = GetCommonArguments(appInformation, extraAppArguments, extraEnvVariables);
 
             args.Add(new DisableMemoryLimitsArgument());
             args.Add(new DeviceNameArgument(device));
@@ -307,9 +315,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 args.Add(new WaitForExitArgument());
             }
-
-            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}-{_helpers.Timestamp}.log", LogType.ExecutionLog);
-            args.Add(new SetStdoutArgument(appOutputLog));
 
             return args;
         }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -473,6 +473,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         }
 
         private MlaunchArguments GetCommonArguments(
+            AppBundleInformation appInformation,
             XmlResultJargon xmlResultJargon,
             string[]? skippedMethods,
             string[]? skippedTestClasses,
@@ -482,7 +483,14 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var args = new MlaunchArguments();
+            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.log", LogType.ApplicationLog);
+            string appErrorOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.err.log", LogType.ApplicationLog);
+
+            var args = new MlaunchArguments
+            {
+                new SetStdoutArgument(appOutputLog),
+                new SetStderrArgument(appErrorOutputLog),
+            };
 
             // Environment variables
             var envVariables = GetEnvVariables(
@@ -516,6 +524,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<(string, string)> extraEnvVariables)
         {
             var args = GetCommonArguments(
+                appInformation,
                 xmlResultJargon,
                 skippedMethods,
                 skippedTestClasses,
@@ -562,6 +571,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<(string, string)> extraEnvVariables)
         {
             var args = GetCommonArguments(
+                appInformation,
                 xmlResultJargon,
                 skippedMethods,
                 skippedTestClasses,
@@ -607,9 +617,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 args.Add(new WaitForExitArgument());
             }
-
-            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}-{_helpers.Timestamp}.log", LogType.ExecutionLog);
-            args.Add(new SetStdoutArgument(appOutputLog));
 
             return args;
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogType.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogType.cs
@@ -18,5 +18,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         ExecutionLog,
         TrxLog,
         HtmlLog,
+        ApplicationLog,
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
@@ -49,6 +49,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         protected readonly Mock<IHelpers> _helpers;
 
         protected readonly ICrashSnapshotReporterFactory _snapshotReporterFactory;
+        protected readonly IFileBackedLog _stdoutLog;
+        protected readonly IFileBackedLog _stderrLog;
 
         protected AppRunTestBase()
         {
@@ -59,6 +61,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _snapshotReporter = new Mock<ICrashSnapshotReporter>();
 
+            _stdoutLog = Mock.Of<IFileBackedLog>(
+                x => x.FullPath == $"./{AppBundleIdentifier}.log" && x.Description == LogType.ApplicationLog.ToString());
+            _stderrLog = Mock.Of<IFileBackedLog>(
+                x => x.FullPath == $"./{AppBundleIdentifier}.err.log" && x.Description == LogType.ApplicationLog.ToString());
+
             _logs = new Mock<ILogs>();
             _logs
                 .SetupGet(x => x.Directory)
@@ -66,6 +73,12 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _logs
                 .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
                 .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
+            _logs
+                .Setup(x => x.CreateFile(AppBundleIdentifier + ".log", LogType.ApplicationLog))
+                .Returns(_stdoutLog.FullPath);
+            _logs
+                .Setup(x => x.CreateFile(AppBundleIdentifier + ".err.log", LogType.ApplicationLog))
+                .Returns(_stderrLog.FullPath);
 
             var factory2 = new Mock<ICrashSnapshotReporterFactory>();
             factory2.SetReturnsDefault(_snapshotReporter.Object);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs
-                .Setup(x => x.Create("test-Simulator_tvOS-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
+                .Setup(x => x.Create("test-ios-simulator-64-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
                 .Returns(listenerLogFile);
 
             var captureLog = new Mock<ICaptureLog>();
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs
-                .Setup(x => x.Create("test-Device_iOS-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
+                .Setup(x => x.Create("test-ios-device-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
                 .Returns(listenerLogFile);
 
             _logs
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs
-                .Setup(x => x.Create("test-Device_iOS-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
+                .Setup(x => x.Create("test-ios-device-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
                 .Returns(listenerLogFile);
 
             _logs
@@ -365,7 +365,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
 
             _logs
-                .Setup(x => x.Create("test-Device_iOS-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
+                .Setup(x => x.Create("test-ios-device-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
                 .Returns(listenerLogFile);
 
             _logs
@@ -509,7 +509,9 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
         }
 
-        private static string GetExpectedDeviceMlaunchArgs(string skippedTests = null, bool useTunnel = false, string extraArgs = null) =>
+        private string GetExpectedDeviceMlaunchArgs(string skippedTests = null, bool useTunnel = false, string extraArgs = null) =>
+            $"--stdout={_stdoutLog.FullPath} " +
+            $"--stderr={_stderrLog.FullPath} " +
             "-setenv=NUNIT_AUTOEXIT=true " +
             $"-setenv=NUNIT_HOSTPORT={Port} " +
             "-setenv=NUNIT_ENABLE_XML_OUTPUT=true " +
@@ -521,10 +523,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             $"--devname {s_mockDevice.DeviceIdentifier} " +
             (useTunnel ? "-setenv=USE_TCP_TUNNEL=true " : null) +
             $"--launchdevbundleid {AppBundleIdentifier} " +
-            "--wait-for-exit " +
-            $"--stdout=./{AppBundleIdentifier}-mocked_timestamp.log";
+            "--wait-for-exit";
 
         private string GetExpectedSimulatorMlaunchArgs() =>
+            $"--stdout={_stdoutLog.FullPath} " +
+            $"--stderr={_stderrLog.FullPath} " +
             "-setenv=NUNIT_AUTOEXIT=true " +
             $"-setenv=NUNIT_HOSTPORT={Port} " +
             "-setenv=NUNIT_ENABLE_XML_OUTPUT=true " +


### PR DESCRIPTION
For an application with bundle ID `net.dot.Bundle.ID`, stores the logs in:
- `net.dot.Bundle.ID.log`
- `net.dot.Bundle.ID.err.log`

Since the names are static, user can then cat them if he chooses to.

Resolves #596