### PR TITLE
[wasm] Allow any CORS header from the browser

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -39,6 +39,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
                 })
                 .ConfigureServices((ctx, services) =>
                 {
+                    services.AddCors(o => o.AddPolicy("AnyCors", builder =>
+                        {
+                            builder.AllowAnyOrigin()
+                                .AllowAnyMethod()
+                                .AllowAnyHeader();
+                        }));
                     services.AddRouting();
                     services.AddSingleton<ILogger>(logger);
                     services.Configure<TestWebServerOptions>(ctx.Configuration);
@@ -118,6 +124,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
 
                 var options = optionsAccessor.CurrentValue;
 
+                app.UseCors("AnyCors");
                 app.UseWebSockets();
                 if (options.OnConsoleConnected != null)
                 {


### PR DESCRIPTION
In order to enable testing POST requests with browser. 
For example in `System.Net.Http.Functional.Tests.SyncHttpHandler_PostScenarioTest`

Fixes: `Access to fetch at 'https://127.0.0.1:54065/VerifyUpload.ashx' from origin 'http://127.0.0.1:54064' has been blocked by CORS policy`