### PR TITLE
Run lsregister -f after I/O before running a MacCatalyst app

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -65,6 +65,12 @@ namespace Microsoft.DotNet.XHarness.Apple
                 await _processManager.ExecuteCommandAsync("chmod", new[] { "+x", binaryPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
             }
 
+            // On Big Sur it seems like the launch services database is not updated fast enough after we do some I/O with the app bundle.
+            // Force registration for the app by running
+            // /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /path/to/app.app
+            var lsRegisterPath = @"/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+            await _processManager.ExecuteCommandAsync(lsRegisterPath, new[] {"-f", appInfo.LaunchAppPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
+
             var arguments = new List<string>
             {
                 "-W",


### PR DESCRIPTION
Without this, launching the app fails (observed on arm64 locally, but
also on x64 on dotnet/runtime CI) with

```
The application cannot be opened for an unexpected reason, error=Error Domain=NSOSStatusErrorDomain Code=-10827 "kLSNoExecutableErr: The executable is missing" UserInfo={_LSLine=3691, _LSFunction=_LSOpenStuffCallLocal}
```

Fixes https://github.com/dotnet/xharness/issues/611