### PR TITLE
Fix `IDisposable` pattern on `CaptureLog`, `SimpleListener` and `ILogs`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             ISimulatorDevice? companionSimulator;
 
             var isSimulator = target.Platform.IsSimulator();
-            var crashLogs = new Logs(_logs.Directory);
+            using var crashLogs = new Logs(_logs.Directory);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(
                 _mainLog,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
@@ -146,51 +147,42 @@ namespace Microsoft.DotNet.XHarness.Apple
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
-            var systemLogs = new List<ICaptureLog>();
+            _mainLog.WriteLine("System log for the '{1}' simulator is: {0}", simulator.SystemLog, simulator.Name);
 
-            try
+            var simulatorLog = _captureLogFactory.Create(
+                path: Path.Combine(_logs.Directory, simulator.Name + ".log"),
+                systemLogPath: simulator.SystemLog,
+                entireFile: false,
+                LogType.SystemLog);
+
+            simulatorLog.StartCapture();
+            _logs.Add(simulatorLog);
+
+            using var systemLogs = new DisposableList<ICaptureLog>
             {
-                _mainLog.WriteLine("System log for the '{1}' simulator is: {0}", simulator.SystemLog, simulator.Name);
+                simulatorLog
+            };
 
-                var simulatorLog = _captureLogFactory.Create(
-                    path: Path.Combine(_logs.Directory, simulator.Name + ".log"),
-                    systemLogPath: simulator.SystemLog,
+            if (companionSimulator != null)
+            {
+                _mainLog.WriteLine("System log for the '{1}' companion simulator is: {0}", companionSimulator.SystemLog, companionSimulator.Name);
+
+                var companionLog = _captureLogFactory.Create(
+                    path: Path.Combine(_logs.Directory, companionSimulator.Name + ".log"),
+                    systemLogPath: companionSimulator.SystemLog,
                     entireFile: false,
-                    LogType.SystemLog);
+                    LogType.CompanionSystemLog);
 
-                simulatorLog.StartCapture();
-                _logs.Add(simulatorLog);
-                systemLogs.Add(simulatorLog);
-
-                if (companionSimulator != null)
-                {
-                    _mainLog.WriteLine("System log for the '{1}' companion simulator is: {0}", companionSimulator.SystemLog, companionSimulator.Name);
-
-                    var companionLog = _captureLogFactory.Create(
-                        path: Path.Combine(_logs.Directory, companionSimulator.Name + ".log"),
-                        systemLogPath: companionSimulator.SystemLog,
-                        entireFile: false,
-                        LogType.CompanionSystemLog);
-
-                    companionLog.StartCapture();
-                    _logs.Add(companionLog);
-                    systemLogs.Add(companionLog);
-                }
-
-                await crashReporter.StartCaptureAsync();
-
-                _mainLog.WriteLine("Starting test run");
-
-                return await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
+                companionLog.StartCapture();
+                _logs.Add(companionLog);
+                systemLogs.Add(companionLog);
             }
-            finally
-            {
-                foreach (ICaptureLog? log in systemLogs)
-                {
-                    log.StopCapture();
-                    log.Dispose();
-                }
-            }
+
+            await crashReporter.StartCaptureAsync();
+
+            _mainLog.WriteLine("Starting test run");
+
+            return await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
         }
 
         private async Task<ProcessExecutionResult> RunDeviceApp(

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -139,10 +139,10 @@ namespace Microsoft.DotNet.XHarness.Apple
             var deviceListenerPort = deviceListener.InitializeAndGetPort();
             deviceListener.StartAsync();
 
-            var crashLogs = new Logs(_logs.Directory);
+            using var crashLogs = new Logs(_logs.Directory);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, crashLogs, isDevice: !isSimulator, device.Name);
-            ITestReporter testReporter = _testReporterFactory.Create(_mainLog,
+            using ITestReporter testReporter = _testReporterFactory.Create(_mainLog,
                 _mainLog,
                 _logs,
                 crashReporter,
@@ -368,10 +368,10 @@ namespace Microsoft.DotNet.XHarness.Apple
             var deviceListenerPort = deviceListener.InitializeAndGetPort();
             deviceListener.StartAsync();
 
-            var crashLogs = new Logs(_logs.Directory);
+            using var crashLogs = new Logs(_logs.Directory);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, crashLogs, isDevice: false, null);
-            ITestReporter testReporter = _testReporterFactory.Create(
+            using ITestReporter testReporter = _testReporterFactory.Create(
                 _mainLog,
                 _mainLog,
                 _logs,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
             var simulatorLoader = new SimulatorLoader(processManager);
             var deviceFinder = new DeviceFinder(deviceLoader, simulatorLoader);
 
-            var logs = new Logs(AppleAppArguments.OutputDirectory);
+            using var logs = new Logs(AppleAppArguments.OutputDirectory);
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(AppleAppArguments.Timeout);

--- a/src/Microsoft.DotNet.XHarness.Common/Utilities/DisposableList.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Utilities/DisposableList.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.Common.Utilities
+{
+    public class DisposableList<T> : List<T>, IDisposable where T : IDisposable
+    {
+        public void Dispose()
+        {
+            foreach (var item in this)
+            {
+                item.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Collections/BlockingEnumerableCollection.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Collections/BlockingEnumerableCollection.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Collections
     // delayed until later).
     public class BlockingEnumerableCollection<T> : IEnumerable<T> where T : class
     {
-        private readonly List<T> _list = new List<T>();
+        private readonly List<T> _list = new();
         private TaskCompletionSource<bool> _completed = new TaskCompletionSource<bool>();
 
         public int Count
@@ -30,11 +30,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Collections
 
         public void Add(T device)
         {
-            if (_completed.Task.IsCompleted)
-            {
-                Console.WriteLine("Adding to completed collection!");
-            }
-
             _list.Add(device);
         }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
@@ -12,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
     /// <summary>
     /// Interface that represents a class that knows how to parse test results.
     /// </summary>
-    public interface ITestReporter
+    public interface ITestReporter : IDisposable
     {
         ILog CallbackLog { get; }
         bool? Success { get; }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
         private void Processing()
         {
             Connected("N/A");
-            using (var fs = new BlockingFileStream(Path) { Listener = this })
+            using (var fs = new BlockingFileStream(Path, this))
             {
                 using (var reader = new StreamReader(fs))
                 {
@@ -73,17 +73,18 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         private class BlockingFileStream : FileStream
         {
-            public SimpleFileListener Listener;
+            private readonly SimpleFileListener _listener;
             private long _lastPosition;
 
-            public BlockingFileStream(string path)
+            public BlockingFileStream(string path, SimpleFileListener listener)
                 : base(path, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite)
             {
+                _listener = listener;
             }
 
             public override int Read(byte[] array, int offset, int count)
             {
-                while (_lastPosition == base.Length && !Listener._cancel)
+                while (_lastPosition == base.Length && !_listener._cancel)
                 {
                     Thread.Sleep(25);
                 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -88,10 +88,17 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public void Cancel()
         {
-            _connected.TrySetCanceled();
+            lock (_connected)
+            {
+                if (!_connected.TrySetCanceled())
+                {
+                    return;
+                }
+            }
+
             try
             {
-                // wait a second just in case more data arrives.
+                // Wait a second just in case more data arrives
                 if (!_stopped.Task.Wait(TimeSpan.FromSeconds(1)))
                 {
                     Stop();
@@ -105,7 +112,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
         public virtual void Dispose()
         {
-            TestLog.Dispose();
+            Cancel();
             GC.SuppressFinalize(this);
         }
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -37,11 +37,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             _useTcpTunnel = tunnel;
         }
 
-        public SimpleTcpListener(int port, ILog log, IFileBackedLog testLog, bool autoExit, bool tunnel = false) : this(log, testLog, autoExit, tunnel)
-        {
-            Port = port;
-        }
-
         protected override void Stop()
         {
             _client?.Close();

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/CaptureLog.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         private long _startPosition;
         private long _endPosition;
         private bool _started;
+        private bool _stopped;
 
         public string CapturePath { get; }
         public override string FullPath { get; }
@@ -69,6 +70,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
         public void StopCapture(TimeSpan? waitIfEmpty = null)
         {
+            lock(CapturePath)
+            {
+                if (_stopped)
+                {
+                    return;
+                }
+
+                _stopped = true;
+            }
+
             if (!_started && !_entireFile)
             {
                 throw new InvalidOperationException("StartCapture() must be called before StopCature() on when the entire file is being captured.");
@@ -187,6 +198,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 
         public override void Dispose()
         {
+            StopCapture();
             GC.SuppressFinalize(this);
         }
     }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -689,5 +689,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
 
             return result;
         }
+
+        public void Dispose()
+        {
+            _crashLogs.Dispose();
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -145,7 +145,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _listener.Verify(x => x.InitializeAndGetPort(), Times.AtLeastOnce);
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
-            _listener.Verify(x => x.Cancel(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
             captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
@@ -240,7 +239,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _listener.Verify(x => x.InitializeAndGetPort(), Times.AtLeastOnce);
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
-            _listener.Verify(x => x.Cancel(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
             // verify that we do close the tunnel when it was used
@@ -336,7 +334,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _listener.Verify(x => x.InitializeAndGetPort(), Times.AtLeastOnce);
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
-            _listener.Verify(x => x.Cancel(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
@@ -423,7 +420,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _listener.Verify(x => x.InitializeAndGetPort(), Times.AtLeastOnce);
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
-            _listener.Verify(x => x.Cancel(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
@@ -505,7 +501,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             _listener.Verify(x => x.InitializeAndGetPort(), Times.AtLeastOnce);
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
-            _listener.Verify(x => x.Cancel(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
         }
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Moq;
@@ -76,10 +77,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
                 sourceWriter.Flush();
             }
 
+            Thread.Sleep(200);
+
             // Verify that the expected lines were added
             foreach (var line in lines)
             {
-                _testLog.Verify(l => l.WriteLine(It.Is<string>(ll => ll == line)), Times.AtLeastOnce);
+                _testLog.Verify(l => l.WriteLine(It.Is<string>(ll => ll.Trim() == line.Trim())), Times.AtLeastOnce);
             }
 
             _log.Verify(l => l.WriteLine(It.Is<string>(ll => ll == "Tests have finished executing")), Times.AtLeastOnce);

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             // Verify that the expected lines were added
             foreach (var line in lines)
             {
-                _testLog.Verify(l => l.WriteLine(line), Times.Once);
+                _testLog.Verify(l => l.WriteLine(It.Is<string>(ll => ll == line)), Times.Once);
             }
         }
     }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -40,38 +40,33 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         [Theory]
         [InlineData("Tests run: ", false)]
         [InlineData("<!-- the end -->", true)]
-        public void TestProcess(string endLine, bool isXml)
+        public void FileContentIsCopied(string endLine, bool isXml)
         {
             var lines = new[] { "first line", "second line", "last line" };
-            // set mock expectations
-            _testLog.Setup(l => l.WriteLine("Tests have started executing"));
-            _testLog.Setup(l => l.WriteLine("Tests have finished executing"));
-            foreach (var line in lines)
-            {
-                _testLog.Setup(l => l.WriteLine(line));
-            }
-            // create a listener, set the writer and ensure that what we write in the file is present in the final path
+
+            // Create a listener, set the writer and ensure that what we write in the file is present in the final path
             using (var sourceWriter = new StreamWriter(_path))
             {
-                var listener = new SimpleFileListener(_path, _log.Object, _testLog.Object, isXml);
+                using var listener = new SimpleFileListener(_path, _log.Object, _testLog.Object, isXml);
                 listener.InitializeAndGetPort();
                 listener.StartAsync();
-                // write a number of lines and ensure that those are called in the mock
+
+                // Write a number of lines and ensure that those are called in the mock
                 sourceWriter.WriteLine("[Runner executing:");
                 foreach (var line in lines)
                 {
                     sourceWriter.WriteLine(line);
                     sourceWriter.Flush();
                 }
+
                 sourceWriter.WriteLine(endLine);
-                listener.Cancel();
             }
-            // verify that the expected lines were added
+
+            // Verify that the expected lines were added
             foreach (var line in lines)
             {
                 _testLog.Verify(l => l.WriteLine(line), Times.Once);
             }
         }
-
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleFileListenerTest.cs
@@ -22,15 +22,29 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
             _path = Path.GetTempFileName();
             _testLog = new Mock<IFileBackedLog>();
             _log = new Mock<ILog>();
-            File.Delete(_path);
+
+            try
+            {
+                File.Delete(_path);
+            }
+            finally
+            {
+            }
         }
 
         public void Dispose()
         {
             if (File.Exists(_path))
             {
-                File.Delete(_path);
+                try
+                {
+                    File.Delete(_path);
+                }
+                finally
+                {
+                }
             }
+
             GC.SuppressFinalize(this);
         }
 
@@ -56,17 +70,19 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
                 foreach (var line in lines)
                 {
                     sourceWriter.WriteLine(line);
-                    sourceWriter.Flush();
                 }
 
                 sourceWriter.WriteLine(endLine);
+                sourceWriter.Flush();
             }
 
             // Verify that the expected lines were added
             foreach (var line in lines)
             {
-                _testLog.Verify(l => l.WriteLine(It.Is<string>(ll => ll == line)), Times.Once);
+                _testLog.Verify(l => l.WriteLine(It.Is<string>(ll => ll == line)), Times.AtLeastOnce);
             }
+
+            _log.Verify(l => l.WriteLine(It.Is<string>(ll => ll == "Tests have finished executing")), Times.AtLeastOnce);
         }
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleTcpListenerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests.Listeners
         }
 
         [Fact(Skip = "Test is flaky - https://github.com/dotnet/xharness/issues/52")]
-        public void ProcessTest()
+        public void ContentIsSentOverTcp()
         {
             var tempResult = Path.GetTempFileName();
             // create a stream to be used and write the data there


### PR DESCRIPTION
Resolves #467 