### PR TITLE
Allow CORS response expose headers

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -43,7 +43,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
                         {
                             builder.AllowAnyOrigin()
                                 .AllowAnyMethod()
-                                .AllowAnyHeader();
+                                .AllowAnyHeader()
+                                .WithExposedHeaders("*");
                         }));
                     services.AddRouting();
                     services.AddSingleton<ILogger>(logger);


### PR DESCRIPTION
Allow response headers to be visible in wasm/JS. 
To fix wasm tests https://github.com/dotnet/runtime/issues/53668