### PR TITLE
[wasm] Add scanning test output for error patterns

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -40,6 +40,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
     {
         public Browser Browser { get; set; } = Browser.Chrome;
         public string? BrowserLocation { get; set; } = null;
+        public string? ErrorPatternsFile { get; set; }
 
         public List<string> BrowserArgs { get; set; } = new List<string>();
         public string HTMLFile { get; set; } = "index.html";
@@ -64,6 +65,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             },
             { "debugger=|d=", "Run browser in debug mode, with a port to listen on. Default port number is 9222",
                 v => DebuggerPort = ParseAsIntOrThrow(v, "debugger")
+            },
+            { "error-patterns=|p=", "File containing error patterns. Each line prefixed with '@', or '%' for a simple string, or a .net regex, respectively.",
+                v => ErrorPatternsFile = v
             },
             { "no-incognito", "Don't run in incognito mode.",
                 v => Incognito = false
@@ -96,6 +100,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             if (Path.IsPathRooted (HTMLFile))
             {
                 throw new ArgumentException("--html-file argument must be a relative path");
+            }
+
+            if (ErrorPatternsFile != null && !File.Exists(ErrorPatternsFile))
+            {
+                throw new ArgumentException($"Cannot find error patterns file {ErrorPatternsFile}");
             }
 
             if (!string.IsNullOrEmpty(BrowserLocation))

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
@@ -37,6 +38,8 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             set => _engine = value;
         }
 
+        public string? ErrorPatternsFile { get; set; }
+
         public List<string> EngineArgs { get; set; } = new List<string>();
 
         public string JSFile { get; set; } = "runtime.js";
@@ -50,6 +53,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             },
             { "engine-arg=", "Argument to pass to the JavaScript engine. Can be used more than once.",
                 v => EngineArgs.Add(v)
+            },
+            { "error-patterns=|p=", "File containing error patterns. Each line prefixed with '@', or '%' for a simple string, or a .net regex, respectively.",
+                v => ErrorPatternsFile = v
             },
             { "js-file=", "Main JavaScript file to be run on the JavaScript engine. Default is runtime.js",
                 v => JSFile = v
@@ -71,6 +77,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         {
             base.Validate();
             _ = Engine;
+
+            if (ErrorPatternsFile != null && !File.Exists(ErrorPatternsFile))
+            {
+                throw new ArgumentException($"Cannot find error patterns file {ErrorPatternsFile}");
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var stdoutFilePath = Path.Combine(_arguments.OutputDirectory, "wasm-console.log");
             File.Delete(stdoutFilePath);
 
-            var logProcessor = new WasmTestMessagesProcessor(xmlResultsFilePath, stdoutFilePath, logger);
+            var logProcessor = new WasmTestMessagesProcessor(xmlResultsFilePath, stdoutFilePath, logger, _arguments.ErrorPatternsFile);
             var runner = new WasmBrowserTestRunner(
                                 _arguments,
                                 PassThroughArguments,
@@ -75,6 +75,13 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 {
                     logger.LogError($"Application has finished with exit code {exitCode} but {_arguments.ExpectedExitCode} was expected");
                     return ExitCode.GENERAL_FAILURE;
+                }
+
+                if (logProcessor.LineThatMatchedErrorPattern != null)
+                {
+                    logger.LogError("Application exited with the expected exit code: {exitCode}."
+                                    + $" But found a line matching an error pattern: {logProcessor.LineThatMatchedErrorPattern}");
+                    return ExitCode.APP_CRASH;
                 }
 
                 return ExitCode.SUCCESS;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/ErrorPatternScanner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/ErrorPatternScanner.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+#nullable enable
+
+namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
+{
+    public class ErrorPatternScanner
+    {
+        private readonly ILogger _logger;
+        private readonly List<string> _errorPatternStrings = new();
+        private readonly List<Regex> _errorPatternRegexes = new();
+        private readonly bool _empty;
+
+        public ErrorPatternScanner(string patternsFile, ILogger logger)
+        {
+            _logger = logger;
+            if (string.IsNullOrEmpty(patternsFile))
+                throw new ArgumentNullException(nameof(patternsFile));
+
+            if (!File.Exists(patternsFile))
+                throw new FileNotFoundException(patternsFile);
+
+            foreach (string line in File.ReadAllLines(patternsFile))
+            {
+                if (line.Trim().Length <= 1)
+                    continue;
+
+                char type = line[0];
+                string pattern = line[1..];
+
+                switch(type)
+                {
+                    case '#':
+                        // comment
+                        break;
+
+                    case '@':
+                        _errorPatternStrings.Add(pattern);
+                        break;
+
+                    case '%':
+                        {
+                            try
+                            {
+                                _errorPatternRegexes.Add(new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase));
+                            }
+                            catch (Exception ex) when (ex is ArgumentException || ex is ArgumentNullException || ex is ArgumentOutOfRangeException)
+                            {
+                                _logger.LogWarning($"ErrorPatternScanner: Failed to compile regex error pattern '{pattern}': {ex.Message}");
+                            }
+                        }
+                        break;
+
+                    default:
+                        _logger.LogWarning($"ErrorPatternScanner: Unknown type prefix '{type}' on line '{line}'. Ignoring.");
+                        break;
+                }
+            }
+
+            _empty = _errorPatternRegexes.Count == 0 && _errorPatternStrings.Count == 0;
+        }
+
+        public bool IsError(string line, out string? matchedPattern)
+        {
+            matchedPattern = null;
+            if (_empty)
+                return false;
+
+            string? patternString = _errorPatternStrings.FirstOrDefault(pattern => line.Contains(pattern, StringComparison.InvariantCultureIgnoreCase));
+            if (patternString != null)
+            {
+                matchedPattern = patternString;
+                return true;
+            }
+
+            Regex? matchedRegex = _errorPatternRegexes.FirstOrDefault(regex => regex.IsMatch(line));
+            if (matchedRegex != null)
+            {
+                matchedPattern = matchedRegex.ToString();
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
In some cases, the runtime might crash, for example, due to an
assertion. But the app continues to execute, causing v8/chrome to exit
with the expected exit code. This causes xharness to treat the tests as
passing, even though the runtime had crashed.

To catch such cases, this adds support for scanning the output for some
error patterns, and adds a new argument for `wasm test`, and `wasm
test-browser`:

    `--error-patterns=<file>`

This expects a text file with one pattern per line. The first character
of the line is treated special:

    '@': the rest of the line is a substring to be used as the pattern
         (case insensitive)
    '%': the rest of the line is a .net regex string
    '#': ignore the line completely

Example patterns file:
```
%console.error: Unhandled *[Ee]xception

@== JS stack trace
```

- this ignores whitespace only lines.
- And stops scanning after the first match

Example output:

```
fail: console.error: Unhandled exception in processFetchResponseBuffer Error: FS error

<snip />

info: === TEST EXECUTION SUMMARY ===
info: Total: 119, Errors: 0, Failed: 0, Skipped: 1, Time: 0.343874s

info: Process v8 exited with 0

fail: Application exited with the expected exit code: 0. But found a line matching an error pattern: console.error: Unhandled exception in processFetchResponseBuffer Error: FS error

XHarness exit code: 80 (APP_CRASH)
XHarness artifacts: ./xharness-output
```