### PR TITLE
Allow user to specify whether to search for wireless devices

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 {
     public interface IDeviceFinder
     {
-        Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog log);
+        Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog log, bool includeWirelessDevices = true);
     }
 
     public class DeviceFinder : IDeviceFinder
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             _simulatorLoader = simulatorLoader ?? throw new ArgumentNullException(nameof(simulatorLoader));
         }
 
-        public async Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog log)
+        public async Task<(IDevice Device, IDevice? CompanionDevice)> FindDevice(TestTargetOs target, string? deviceName, ILog log, bool includeWirelessDevices = true)
         {
             IDevice? device;
             IDevice? companionDevice = null;
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 }
                 else
                 {
-                    await _simulatorLoader.LoadDevices(log, false);
+                    await _simulatorLoader.LoadDevices(log, includeLocked: false);
 
                     device = _simulatorLoader.AvailableDevices.FirstOrDefault(IsMatchingDevice)
                         ?? throw new NoDeviceFoundException($"Failed to find a simulator '{deviceName}'");
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 // The DeviceLoader.FindDevice will return the fist device of the type, but we want to make sure that
                 // the device we use is of the correct arch, therefore, we will use the LoadDevices and handpick one
-                await _deviceLoader.LoadDevices(log, false, false);
+                await _deviceLoader.LoadDevices(log, includeLocked: false, forceRefresh: false, includeWirelessDevices: includeWirelessDevices);
 
                 if (deviceName == null)
                 {

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -60,6 +60,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         protected async Task<ExitCode> OrchestrateRun(
             TestTargetOs target,
             string? deviceName,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             AppBundleInformation appBundleInfo,
@@ -128,7 +129,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     $"Looking for available {target.AsString()} {(target.Platform.IsSimulator() ? "simulators" : "devices")}. " +
                     $"Storing logs into {finderLogName}");
 
-                (device, companionDevice) = await _deviceFinder.FindDevice(target, deviceName, finderLog);
+                (device, companionDevice) = await _deviceFinder.FindDevice(target, deviceName, finderLog, includeWirelessDevices);
 
                 _logger.LogInformation($"Found {(target.Platform.IsSimulator() ? "simulator" : "physical")} device '{device.Name}'");
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -85,6 +85,11 @@ namespace Microsoft.DotNet.XHarness.Apple
                 }
             }
 
+            if (includeWirelessDevices && target.Platform.IsSimulator())
+            {
+                _logger.LogWarning("Including wireless devices while targeting a simulator has no effect");
+            }
+
             ExitCode exitCode;
             IDevice device;
             IDevice? companionDevice;

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? deviceName,
             string appPackagePath,
             TimeSpan timeout,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             CancellationToken cancellationToken);
@@ -57,6 +58,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? deviceName,
             string appPackagePath,
             TimeSpan timeout,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             CancellationToken cancellationToken)
@@ -70,7 +72,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             Func<AppBundleInformation, IDevice, IDevice?, Task<ExitCode>> executeApp = (appBundleInfo, device, companionDevice)
                 => Task.FromResult(ExitCode.SUCCESS); // no-op
 
-            return await OrchestrateRun(target, deviceName, resetSimulator, enableLldb, appBundleInfo, executeMacCatalystApp, executeApp, cancellationToken);
+            return await OrchestrateRun(target, deviceName, includeWirelessDevices, resetSimulator, enableLldb, appBundleInfo, executeMacCatalystApp, executeApp, cancellationToken);
         }
 
         protected override Task CleanUpSimulators(IDevice device, IDevice? companionDevice)

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? deviceName,
             TimeSpan timeout,
             int expectedExitCode,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             IReadOnlyCollection<(string, string)> environmentalVariables,
@@ -83,6 +84,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? deviceName,
             TimeSpan timeout,
             int expectedExitCode,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             IReadOnlyCollection<(string, string)> environmentalVariables,
@@ -113,6 +115,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return OrchestrateRun(
                 target,
                 deviceName,
+                includeWirelessDevices,
                 resetSimulator,
                 enableLldb,
                 appBundleInformation,

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             XmlResultJargon xmlResultJargon,
             IEnumerable<string> singleMethodFilters,
             IEnumerable<string> classMethodFilters,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             IReadOnlyCollection<(string, string)> environmentalVariables,
@@ -77,6 +78,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             XmlResultJargon xmlResultJargon,
             IEnumerable<string> singleMethodFilters,
             IEnumerable<string> classMethodFilters,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             IReadOnlyCollection<(string, string)> environmentalVariables,
@@ -115,6 +117,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return OrchestrateRun(
                 target,
                 deviceName,
+                includeWirelessDevices,
                 resetSimulator,
                 enableLldb,
                 appBundleInformation,

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             TestTargetOs target,
             string? deviceName,
             TimeSpan timeout,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             CancellationToken cancellationToken);
@@ -49,6 +50,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             TestTargetOs target,
             string? deviceName,
             TimeSpan timeout,
+            bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
             CancellationToken cancellationToken)
@@ -62,6 +64,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return OrchestrateRun(
                 target,
                 deviceName,
+                includeWirelessDevices,
                 resetSimulator,
                 enableLldb,
                 AppBundleInformation.FromBundleId(bundleIdentifier),

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetDeviceCommandsArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetDeviceCommandsArguments.cs
@@ -9,11 +9,15 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class AppleGetDeviceCommandsArguments : XHarnessCommandArguments
     {
+        public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
+            DeviceName,
+            IncludeWireless,
             XcodeRoot,
             MlaunchPath,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public MlaunchArgument MlaunchPath { get; set; } = new();
         public ShowSimulatorsUUIDArgument ShowSimulatorsUUID { get; set; } = new();
         public ShowDevicesUUIDArgument ShowDevicesUUID { get; set; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public UseJsonArgument UseJson { get; set; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
@@ -19,6 +20,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             MlaunchPath,
             ShowSimulatorsUUID,
             ShowDevicesUUID,
+            IncludeWireless,
             UseJson,
         };
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleInstallCommandArguments.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
@@ -25,6 +26,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             Target,
             OutputDirectory,
             DeviceName,
+            IncludeWireless,
             Timeout,
             XcodeRoot,
             MlaunchPath,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
@@ -29,6 +30,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             Target,
             OutputDirectory,
             DeviceName,
+            IncludeWireless,
             Timeout,
             ExpectedExitCode,
             XcodeRoot,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public CommunicationChannelArgument CommunicationChannel { get; set; } = new();
         public XmlResultJargonArgument XmlResultJargon { get; set; } = new();
         public SingleMethodFilters SingleMethodFilters { get; } = new();
@@ -36,6 +37,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             XcodeRoot,
             MlaunchPath,
             DeviceName,
+            IncludeWireless,
             CommunicationChannel,
             XmlResultJargon,
             SingleMethodFilters,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
@@ -29,6 +30,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             Target,
             OutputDirectory,
             DeviceName,
+            IncludeWireless,
             Timeout,
             ExpectedExitCode,
             XcodeRoot,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
         public CommunicationChannelArgument CommunicationChannel { get; set; } = new();
         public XmlResultJargonArgument XmlResultJargon { get; set; } = new();
         public SingleMethodFilters SingleMethodFilters { get; } = new();
@@ -36,6 +37,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             XcodeRoot,
             MlaunchPath,
             DeviceName,
+            IncludeWireless,
             CommunicationChannel,
             XmlResultJargon,
             SingleMethodFilters,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleUninstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleUninstallCommandArguments.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public XcodeArgument XcodeRoot { get; } = new();
         public MlaunchArgument MlaunchPath { get; } = new();
         public DeviceNameArgument DeviceName { get; } = new();
+        public IncludeWirelessArgument IncludeWireless { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -27,6 +28,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             XcodeRoot,
             MlaunchPath,
             DeviceName,
+            IncludeWireless,
         };
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/IncludeWirelessArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/IncludeWirelessArgument.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
+{
+    /// <summary>
+    /// If enabled, takes longer to list devices and looks for wirelessly connected ones too.
+    /// </summary>
+    internal class IncludeWirelessArgument : SwitchArgument
+    {
+        public IncludeWirelessArgument() : base("wireless:|include-wireless-devices:", "Also look for wirelessly connected devices (takes longer)", false)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/IAppleAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/IAppleAppRunArguments.cs
@@ -8,11 +8,11 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal interface IAppleAppRunArguments : IXHarnessCommandArguments
     {
-        public TargetArgument Target { get; }
-        public OutputDirectoryArgument OutputDirectory { get; }
-        public TimeoutArgument Timeout { get; }
-        public XcodeArgument XcodeRoot { get; }
-        public MlaunchArgument MlaunchPath { get; }
-        public DeviceNameArgument DeviceName { get; }
+        TargetArgument Target { get; }
+        OutputDirectoryArgument OutputDirectory { get; }
+        TimeoutArgument Timeout { get; }
+        XcodeArgument XcodeRoot { get; }
+        MlaunchArgument MlaunchPath { get; }
+        DeviceNameArgument DeviceName { get; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleInstallCommand.cs
@@ -43,6 +43,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 Arguments.DeviceName,
                 Arguments.AppBundlePath,
                 Arguments.Timeout,
+                Arguments.IncludeWireless,
                 Arguments.ResetSimulator,
                 enableLldb: false,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
@@ -35,6 +35,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.DeviceName,
                     Arguments.Timeout,
                     Arguments.ExpectedExitCode,
+                    Arguments.IncludeWireless,
                     Arguments.ResetSimulator,
                     Arguments.EnableLldb,
                     Arguments.EnvironmentalVariables.Value,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.XmlResultJargon,
                     Arguments.SingleMethodFilters.Value,
                     Arguments.ClassMethodFilters.Value,
+                    Arguments.IncludeWireless,
                     Arguments.ResetSimulator,
                     Arguments.EnableLldb,
                     Arguments.EnvironmentalVariables.Value,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -48,6 +48,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 Arguments.DeviceName,
                 Arguments.Timeout,
                 Arguments.ExpectedExitCode,
+                Arguments.IncludeWireless,
                 Arguments.ResetSimulator,
                 Arguments.EnableLldb,
                 Arguments.EnvironmentalVariables.Value,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -53,6 +53,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 Arguments.XmlResultJargon,
                 Arguments.SingleMethodFilters.Value,
                 Arguments.ClassMethodFilters.Value,
+                Arguments.IncludeWireless,
                 Arguments.ResetSimulator,
                 Arguments.EnableLldb,
                 Arguments.EnvironmentalVariables.Value,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleUninstallCommand.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.Target,
                     Arguments.DeviceName,
                     Arguments.Timeout,
+                    Arguments.IncludeWireless,
                     resetSimulator: false,
                     enableLldb: false,
                     cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Arguments.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/Arguments.cs
@@ -29,6 +29,16 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
     }
 
     /// <summary>
+    /// When listing devices, should mlaunch also scan for wireless devices.
+    /// </summary>
+    public sealed class ListWirelessDevicesArgument : SingleValueArgument
+    {
+        public ListWirelessDevicesArgument(bool wirelessEnabled) : base("list-wireless-devices", wirelessEnabled ? "true" : "false", true)
+        {
+        }
+    }
+
+    /// <summary>
     /// Write the syslog from the device to the console.
     /// </summary>
     public sealed class LogDevArgument : OptionArgument

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IDeviceManager.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IDeviceManager.cs
@@ -9,6 +9,6 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 {
     public interface IDeviceLoader
     {
-        Task LoadDevices(ILog log, bool includeLocked = false, bool forceRefresh = false, bool listExtraData = false);
+        Task LoadDevices(ILog log, bool includeLocked = false, bool forceRefresh = false, bool listExtraData = false, bool includeWirelessDevices = true);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -22,12 +22,12 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
 {
     public class SimulatorLoader : ISimulatorLoader
     {
-        private readonly BlockingEnumerableCollection<SimRuntime> _supportedRuntimes = new BlockingEnumerableCollection<SimRuntime>();
-        private readonly BlockingEnumerableCollection<SimDeviceType> _supportedDeviceTypes = new BlockingEnumerableCollection<SimDeviceType>();
-        private readonly BlockingEnumerableCollection<SimulatorDevice> _availableDevices = new BlockingEnumerableCollection<SimulatorDevice>();
-        private readonly BlockingEnumerableCollection<SimDevicePair> _availableDevicePairs = new BlockingEnumerableCollection<SimDevicePair>();
+        private readonly BlockingEnumerableCollection<SimRuntime> _supportedRuntimes = new();
+        private readonly BlockingEnumerableCollection<SimDeviceType> _supportedDeviceTypes = new();
+        private readonly BlockingEnumerableCollection<SimulatorDevice> _availableDevices = new();
+        private readonly BlockingEnumerableCollection<SimDevicePair> _availableDevicePairs = new();
 
-        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
+        private readonly SemaphoreSlim _semaphore = new(1);
         private readonly IMlaunchProcessManager _processManager;
         private bool _loaded;
 
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
         }
 
-        public async Task LoadDevices(ILog log, bool includeLocked = false, bool forceRefresh = false, bool listExtraData = false)
+        public async Task LoadDevices(ILog log, bool includeLocked = false, bool forceRefresh = false, bool listExtraData = false, bool _ = true)
         {
             await _semaphore.WaitAsync();
 


### PR DESCRIPTION
Not searching for wireless devices saves 18 seconds per run. Default is now to not search for them.

Resolves #623

This is a breaking change in case you connect devices wirelessly (cc @mattleibow @PureWeen @akoeplinger @steveisok)

@mandel-macaque this is **not** a breaking change for Xamarin (shared code behaves the same)