### PR TITLE
Add `--signal-app-end` to detect test run end for iOS/tvOS 14+ devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ To run the E2E tests, you can find a script in `tools/` that will build everythi
 ./tools/run-e2e-test.sh Apple/Simulator.Tests.proj
 ```
 
+## Troubleshooting
+
+Some XHarness commands only work in some scenarios and it's good to know what to expect from the tool.
+Some Android/Apple versions also require some workarounds and those are also good to know about.
+
+### My unit tests are not running
+
+For the `test` command, XHarness expects the application to contain a `TestRunner` which is a library you can find in this repository.
+This library executes unit tests similarly how you would execute them on other platforms.
+However, the `TestRunner` from this repository contains more mechanisms that help to work around some issues (mostly in Apple platforms).
+
+The way it works is that XHarness usually sets some [environmental variables](https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs) for the application and the [`TestRunner` recognizes them](https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs) and acts upon them.
+
+The workarounds we talk about are for example some TCP connections between the app and XHarness so that we can stream back the test results.
+
+For these reasons, the `test` command won't just work with any app. For those scenarios, use the `run` commands.
+
+### iOS/tvOS device runs are timing out
+
+For iOS/tvOS 14+, we have problems detecting when the application exits on the real device (simulators work fine).
+The workaround we went with lies in sharing a random string with the application using an [environmental variable `APP_END_TAG`](https://github.com/dotnet/xharness/blob/main/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs) and expecting the app to output this string at the end of its run.
+
+To turn this workaround on, run XHarness with `--signal-app-end` and make sure your application logs the string it reads from the env variable.
+Using the `TestRunner` from this repository will automatically give you this functionality.
+
 ## Contribution
 
 We welcome contributions! Please follow the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ To run the E2E tests, you can find a script in `tools/` that will build everythi
 Some XHarness commands only work in some scenarios and it's good to know what to expect from the tool.
 Some Android/Apple versions also require some workarounds and those are also good to know about.
 
-### My unit tests are not running
+### My Apple unit tests are not running
 
-For the `test` command, XHarness expects the application to contain a `TestRunner` which is a library you can find in this repository.
+For the `apple test` command, XHarness expects the application to contain a `TestRunner` which is a library you can find in this repository.
 This library executes unit tests similarly how you would execute them on other platforms.
 However, the `TestRunner` from this repository contains more mechanisms that help to work around some issues (mostly in Apple platforms).
 
@@ -195,7 +195,7 @@ The way it works is that XHarness usually sets some [environmental variables](ht
 
 The workarounds we talk about are for example some TCP connections between the app and XHarness so that we can stream back the test results.
 
-For these reasons, the `test` command won't just work with any app. For those scenarios, use the `run` commands.
+For these reasons, the `test` command won't just work with any app. For those scenarios, use the `apple run` commands.
 
 ### iOS/tvOS device runs are timing out
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             ILogs logs,
             IHelpers helpers,
             Action<string>? logCallback = null)
-            : base(processManager, captureLogFactory, logs, mainLog, logCallback)
+            : base(processManager, captureLogFactory, logs, mainLog, helpers, logCallback)
         {
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
             _snapshotReporterFactory = snapshotReporterFactory ?? throw new ArgumentNullException(nameof(snapshotReporterFactory));
@@ -56,16 +56,33 @@ namespace Microsoft.DotNet.XHarness.Apple
         public async Task<ProcessExecutionResult> RunMacCatalystApp(
             AppBundleInformation appInformation,
             TimeSpan timeout,
+            bool signalAppEnd,
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables,
             CancellationToken cancellationToken = default)
         {
             _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on MacCatalyst ***");
+            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             var envVariables = new Dictionary<string, string>();
             AddExtraEnvVars(envVariables, extraEnvVariables);
 
-            return await RunMacCatalystApp(appInformation, timeout, extraAppArguments ?? Enumerable.Empty<string>(), envVariables, cancellationToken);
+            if (signalAppEnd)
+            {
+                WatchForAppEndTag(out var appEndTag, ref appOutputLog, ref cancellationToken);
+                envVariables.Add(EnviromentVariables.AppEndTag, appEndTag);
+            }
+
+            using (appOutputLog)
+            {
+                return await RunMacCatalystApp(
+                    appInformation,
+                    appOutputLog,
+                    timeout,
+                    extraAppArguments ?? Enumerable.Empty<string>(),
+                    envVariables,
+                    cancellationToken);
+            }
         }
 
         public async Task<ProcessExecutionResult> RunApp(
@@ -74,6 +91,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IDevice device,
             IDevice? companionDevice,
             TimeSpan timeout,
+            bool signalAppEnd,
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables,
             CancellationToken cancellationToken = default)
@@ -84,6 +102,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             var isSimulator = target.Platform.IsSimulator();
             using var crashLogs = new Logs(_logs.Directory);
+            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(
                 _mainLog,
@@ -93,50 +112,61 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{device.Name}' ***");
 
-            if (isSimulator)
+            string? appEndTag = null;
+            if (signalAppEnd)
             {
-                simulator = device as ISimulatorDevice;
-                companionSimulator = companionDevice as ISimulatorDevice;
+                WatchForAppEndTag(out appEndTag, ref appOutputLog, ref cancellationToken);
+            }
 
-                if (simulator == null)
+            using (appOutputLog)
+            {
+                if (isSimulator)
                 {
-                    _mainLog.WriteLine("Didn't find any suitable simulator");
-                    throw new NoDeviceFoundException();
+                    simulator = device as ISimulatorDevice;
+                    companionSimulator = companionDevice as ISimulatorDevice;
+
+                    if (simulator == null)
+                    {
+                        _mainLog.WriteLine("Didn't find any suitable simulator");
+                        throw new NoDeviceFoundException();
+                    }
+
+                    var mlaunchArguments = GetSimulatorArguments(
+                        appInformation,
+                        simulator,
+                        extraAppArguments,
+                        extraEnvVariables,
+                        appEndTag);
+
+                    result = await RunSimulatorApp(
+                        mlaunchArguments,
+                        crashReporter,
+                        simulator,
+                        companionSimulator,
+                        timeout,
+                        cancellationToken);
+                }
+                else
+                {
+                    var mlaunchArguments = GetDeviceArguments(
+                        appInformation,
+                        device,
+                        target.Platform.IsWatchOSTarget(),
+                        extraAppArguments,
+                        extraEnvVariables,
+                        appEndTag);
+
+                    result = await RunDeviceApp(
+                        mlaunchArguments,
+                        crashReporter,
+                        device,
+                        extraEnvVariables,
+                        timeout,
+                        cancellationToken);
                 }
 
-                var mlaunchArguments = GetSimulatorArguments(
-                    appInformation,
-                    simulator,
-                    extraAppArguments,
-                    extraEnvVariables);
-
-                result = await RunSimulatorApp(
-                    mlaunchArguments,
-                    crashReporter,
-                    simulator,
-                    companionSimulator,
-                    timeout,
-                    cancellationToken);
+                return result;
             }
-            else
-            {
-                var mlaunchArguments = GetDeviceArguments(
-                    appInformation,
-                    device,
-                    target.Platform.IsWatchOSTarget(),
-                    extraAppArguments,
-                    extraEnvVariables);
-
-                result = await RunDeviceApp(
-                    mlaunchArguments,
-                    crashReporter,
-                    device,
-                    extraEnvVariables,
-                    timeout,
-                    cancellationToken);
-            }
-
-            return result;
         }
 
         private async Task<ProcessExecutionResult> RunSimulatorApp(
@@ -220,34 +250,33 @@ namespace Microsoft.DotNet.XHarness.Apple
             }
         }
 
-        private MlaunchArguments GetCommonArguments(
-            AppBundleInformation appInformation,
+        private static MlaunchArguments GetCommonArguments(
             IEnumerable<string> extraAppArguments,
-            IEnumerable<(string, string)> extraEnvVariables)
+            IEnumerable<(string, string)> extraEnvVariables,
+            string? appEndTag)
         {
-            string appOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.log", LogType.ApplicationLog);
-            string appErrorOutputLog = _logs.CreateFile($"{appInformation.BundleIdentifier}.err.log", LogType.ApplicationLog);
-
-            var args = new MlaunchArguments
-            {
-                new SetStdoutArgument(appOutputLog),
-                new SetStderrArgument(appErrorOutputLog),
-            };
+            var args = new MlaunchArguments();
 
             // Arguments passed to the iOS app bundle
             args.AddRange(extraAppArguments.Select(arg => new SetAppArgumentArgument(arg)));
             args.AddRange(extraEnvVariables.Select(v => new SetEnvVariableArgument(v.Item1, v.Item2)));
 
+            if (appEndTag != null)
+            {
+                args.Add(new SetEnvVariableArgument(EnviromentVariables.AppEndTag, appEndTag));
+            }
+
             return args;
         }
 
-        private MlaunchArguments GetSimulatorArguments(
+        private static MlaunchArguments GetSimulatorArguments(
             AppBundleInformation appInformation,
             ISimulatorDevice simulator,
             IEnumerable<string> extraAppArguments,
-            IEnumerable<(string, string)> extraEnvVariables)
+            IEnumerable<(string, string)> extraEnvVariables,
+            string? appEndTag)
         {
-            var args = GetCommonArguments(appInformation, extraAppArguments, extraEnvVariables);
+            var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag);
 
             args.Add(new SimulatorUDIDArgument(simulator.UDID));
 
@@ -271,14 +300,15 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private MlaunchArguments GetDeviceArguments(
+        private static MlaunchArguments GetDeviceArguments(
             AppBundleInformation appInformation,
             IDevice device,
             bool isWatchTarget,
             IEnumerable<string> extraAppArguments,
-            IEnumerable<(string, string)> extraEnvVariables)
+            IEnumerable<(string, string)> extraEnvVariables,
+            string? appEndTag)
         {
-            var args = GetCommonArguments(appInformation, extraAppArguments, extraEnvVariables);
+            var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag);
 
             args.Add(new DisableMemoryLimitsArgument());
             args.Add(new DeviceNameArgument(device));

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -160,6 +160,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                         mlaunchArguments,
                         crashReporter,
                         device,
+                        appOutputLog,
                         extraEnvVariables,
                         timeout,
                         cancellationToken);
@@ -219,6 +220,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             MlaunchArguments mlaunchArguments,
             ICrashSnapshotReporter crashReporter,
             IDevice device,
+            ILog appOutputLog,
             IEnumerable<(string, string)> extraEnvVariables,
             TimeSpan timeout,
             CancellationToken cancellationToken)
@@ -239,6 +241,8 @@ namespace Microsoft.DotNet.XHarness.Apple
                 return await _processManager.ExecuteCommandAsync(
                     mlaunchArguments,
                     _mainLog,
+                    appOutputLog,
+                    appOutputLog,
                     timeout,
                     envVars,
                     cancellationToken: cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             CancellationToken cancellationToken = default)
         {
             _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on MacCatalyst ***");
-            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+            var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             var envVariables = new Dictionary<string, string>();
             AddExtraEnvVars(envVariables, extraEnvVariables);
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             var isSimulator = target.Platform.IsSimulator();
             using var crashLogs = new Logs(_logs.Directory);
-            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+            var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(
                 _mainLog,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 
 namespace Microsoft.DotNet.XHarness.Apple
 {
@@ -21,18 +22,23 @@ namespace Microsoft.DotNet.XHarness.Apple
         private readonly IProcessManager _processManager;
         private readonly ICaptureLogFactory _captureLogFactory;
         private readonly ILogs _logs;
+        private readonly IHelpers _helpers;
         private readonly IFileBackedLog _mainLog;
+
+        protected bool _appEndSignalDetected = false;
 
         protected AppRunnerBase(
             IProcessManager processManager,
             ICaptureLogFactory captureLogFactory,
             ILogs logs,
             IFileBackedLog mainLog,
+            IHelpers helpers,
             Action<string>? logCallback = null)
         {
             _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
             _captureLogFactory = captureLogFactory ?? throw new ArgumentNullException(nameof(captureLogFactory));
             _logs = logs ?? throw new ArgumentNullException(nameof(logs));
+            _helpers = helpers ?? throw new ArgumentNullException(nameof(helpers));
 
             if (logCallback == null)
             {
@@ -47,6 +53,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
         protected async Task<ProcessExecutionResult> RunMacCatalystApp(
             AppBundleInformation appInfo,
+            ILog appOutputLog,
             TimeSpan timeout,
             IEnumerable<string> extraArguments,
             Dictionary<string, string> environmentVariables,
@@ -87,6 +94,8 @@ namespace Microsoft.DotNet.XHarness.Apple
                     "open",
                     arguments,
                     _mainLog,
+                    appOutputLog,
+                    appOutputLog,
                     timeout,
                     environmentVariables,
                     cancellationToken);
@@ -116,6 +125,27 @@ namespace Microsoft.DotNet.XHarness.Apple
 
                 envVariables[name] = value;
             }
+        }
+
+        protected string WatchForAppEndTag(
+            out string tag,
+            ref IFileBackedLog appLog,
+            ref CancellationToken cancellationToken)
+        {
+            tag = _helpers.GenerateGuid().ToString();
+            var appEndDetected = new CancellationTokenSource();
+            var appEndScanner = new ScanLog(tag, () =>
+            {
+                _mainLog.WriteLine("Detected test end tag in application's output");
+                _appEndSignalDetected = true;
+                appEndDetected.Cancel();
+            });
+
+            // We need to check for test end tag since iOS 14+ doesn't send the pidDiedCallback event to mlaunch
+            appLog = Log.CreateReadableAggregatedLog(appLog, appEndScanner);
+            cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, appEndDetected.Token).Token;
+
+            return tag;
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 xmlOutput: true);
 
             string? testEndTag = null;
-            if (testEndTag != null)
+            if (signalTestEnd)
             {
                 testEndTag = _helpers.GenerateGuid().ToString();
                 WatchForTestEndTag(testEndTag, ref appOutputLog, ref cancellationToken);
@@ -148,7 +148,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 xmlOutput: true); // cli always uses xml
 
             string? testEndTag = null;
-            if (testEndTag != null)
+            if (signalTestEnd)
             {
                 testEndTag = _helpers.GenerateGuid().ToString();
                 WatchForTestEndTag(testEndTag, ref appOutputLog, ref cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -87,11 +87,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 autoExit: true,
                 xmlOutput: true);
 
-            string? testEndTag = null;
-            if (signalTestEnd)
-            {
-                testEndTag = WatchForTestEndTag(ref testLog, ref cancellationToken);
-            }
+            string? testEndTag = signalTestEnd ? _helpers.GenerateGuid().ToString() : null;
 
             using (testLog)
             using (deviceListener)
@@ -662,8 +658,8 @@ namespace Microsoft.DotNet.XHarness.Apple
             var testEndScanner = new ScanLog(tag, () =>
             {
                 _mainLog.WriteLine("Detected test end tag in application's output");
-                testEndDetected.Cancel();
                 _testEndSignalDetected = true;
+                testEndDetected.Cancel();
             });
 
             // We need to check for test end tag since iOS 14+ doesn't send the pidDiedCallback event to mlaunch

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -286,20 +286,13 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             _mainLog.WriteLine("Starting test run");
 
-            var result = await _processManager.ExecuteCommandAsync(
+            var result = await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
                 mlaunchArguments,
                 _mainLog,
                 appOutputLog,
                 appOutputLog,
                 timeout,
-                cancellationToken: cancellationToken);
-
-            // When signal is detected, we cancel the call above via the cancellation token so we need to fix the result
-            if (_appEndSignalDetected)
-            {
-                result.TimedOut = false;
-                result.ExitCode = 0;
-            }
+                cancellationToken: cancellationToken));
 
             await testReporter.CollectSimulatorResult(result);
         }
@@ -343,21 +336,14 @@ namespace Microsoft.DotNet.XHarness.Apple
                 // We need to check for MT1111 (which means that mlaunch won't wait for the app to exit)
                 IFileBackedLog aggregatedLog = Log.CreateReadableAggregatedLog(_mainLog, testReporter.CallbackLog);
 
-                var result = await _processManager.ExecuteCommandAsync(
+                var result = await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
                     mlaunchArguments,
                     aggregatedLog,
                     appOutputLog,
                     appOutputLog,
                     timeout,
                     envVars,
-                    cancellationToken: cancellationToken);
-
-                // When signal is detected, we cancel the call above via the cancellation token so we need to fix the result
-                if (_appEndSignalDetected)
-                {
-                    result.TimedOut = false;
-                    result.ExitCode = 0;
-                }
+                    cancellationToken: cancellationToken));
 
                 await testReporter.CollectDeviceResult(result);
             }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -509,7 +509,6 @@ namespace Microsoft.DotNet.XHarness.Apple
         }
 
         private MlaunchArguments GetCommonArguments(
-            AppBundleInformation appInformation,
             XmlResultJargon xmlResultJargon,
             string[]? skippedMethods,
             string[]? skippedTestClasses,
@@ -556,7 +555,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? testEngTag)
         {
             var args = GetCommonArguments(
-                appInformation,
                 xmlResultJargon,
                 skippedMethods,
                 skippedTestClasses,
@@ -605,7 +603,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             string? testEngTag)
         {
             var args = GetCommonArguments(
-                appInformation,
                 xmlResultJargon,
                 skippedMethods,
                 skippedTestClasses,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             if (signalAppEnd)
             {
                 appEndTag = _helpers.GenerateGuid().ToString();
-                WatchForTestEndTag(appEndTag, ref appOutputLog, ref cancellationToken);
+                WatchForAppEndTag(appEndTag, ref appOutputLog, ref cancellationToken);
             }
 
             using (testLog)
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             if (signalAppEnd)
             {
                 appEndTag = _helpers.GenerateGuid().ToString();
-                WatchForTestEndTag(appEndTag, ref appOutputLog, ref cancellationToken);
+                WatchForAppEndTag(appEndTag, ref appOutputLog, ref cancellationToken);
             }
 
             using (testLog)
@@ -508,7 +508,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             if (appEndTag != null)
             {
-                variables.Add(EnviromentVariables.TestEndTag, appEndTag);
+                variables.Add(EnviromentVariables.AppEndTag, appEndTag);
             }
 
             AddExtraEnvVars(variables, extraEnvVariables);
@@ -661,7 +661,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private string WatchForTestEndTag(
+        private string WatchForAppEndTag(
             string tag,
             ref IFileBackedLog appLog,
             ref CancellationToken cancellationToken)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             CancellationToken cancellationToken = default)
         {
             var testLog = _logs.Create($"test-{TestTarget.MacCatalyst.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
-            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+            var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
                 RunMode.MacOS,
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             var isSimulator = target.Platform.IsSimulator();
 
             var testLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
-            var appOutputLog = _logs.Create(appInformation + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+            var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
                 runMode,

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken);
@@ -87,6 +88,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken)
@@ -96,6 +98,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     appBundleInfo,
                     timeout,
                     expectedExitCode,
+                    signalAppEnd,
                     environmentalVariables,
                     passthroughArguments,
                     cancellationToken);
@@ -108,6 +111,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     companionDevice,
                     timeout,
                     expectedExitCode,
+                    signalAppEnd,
                     environmentalVariables,
                     passthroughArguments,
                     cancellationToken);
@@ -131,6 +135,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IDevice? companionDevice,
             TimeSpan timeout,
             int expectedExitCode,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken)
@@ -143,6 +148,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 device,
                 companionDevice,
                 timeout,
+                signalAppEnd,
                 passthroughArguments,
                 environmentalVariables,
                 cancellationToken);
@@ -160,6 +166,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             AppBundleInformation appBundleInfo,
             TimeSpan timeout,
             int expectedExitCode,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken)
@@ -169,6 +176,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             ProcessExecutionResult result = await _appRunner.RunMacCatalystApp(
                 appBundleInfo,
                 timeout,
+                signalAppEnd,
                 passthroughArguments,
                 environmentalVariables,
                 cancellationToken: cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -212,9 +212,12 @@ namespace Microsoft.DotNet.XHarness.Apple
             {
                 _logger.LogError($"Application has finished with exit code {exitCode} but {expectedExitCode} was expected");
 
-                if (_errorKnowledgeBase.IsKnownTestIssue(_mainLog, out var failureMessage))
+                foreach (var log in _logs)
                 {
-                    _logger.LogError(failureMessage.Value.HumanMessage);
+                    if (_errorKnowledgeBase.IsKnownTestIssue(log, out var failureMessage))
+                    {
+                        _logger.LogError(failureMessage.Value.HumanMessage);
+                    }
                 }
 
                 return ExitCode.GENERAL_FAILURE;

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -184,12 +184,12 @@ namespace Microsoft.DotNet.XHarness.Apple
                 companionDevice,
                 timeout,
                 launchTimeout,
+                signalAppEnd,
                 passthroughArguments,
                 environmentalVariables,
                 xmlResultJargon,
                 skippedMethods: singleMethodFilters?.ToArray(),
                 skippedTestClasses: classMethodFilters?.ToArray(),
-                signalAppEnd,
                 cancellationToken: cancellationToken);
 
             return ParseResult(testResult, resultMessage);
@@ -214,12 +214,12 @@ namespace Microsoft.DotNet.XHarness.Apple
                 appBundleInfo,
                 timeout,
                 launchTimeout,
+                signalAppEnd,
                 passthroughArguments,
                 environmentalVariables,
                 xmlResultJargon,
                 skippedMethods: singleMethodFilters?.ToArray(),
                 skippedTestClasses: classMethodFilters?.ToArray(),
-                signalAppEnd,
                 cancellationToken: cancellationToken);
 
             return ParseResult(testResult, resultMessage);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -161,6 +161,8 @@ namespace Microsoft.DotNet.XHarness.Apple
                 }
             }
 
+            _logger.LogInformation("Starting test run for " + appBundleInfo.BundleIdentifier + "..");
+
             AppTester appTester = GetAppTester(communicationChannel, target.Platform.IsSimulator());
 
             (TestExecutingResult testResult, string resultMessage) = await appTester.TestApp(

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -255,20 +255,22 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             void LogProblem(string message)
             {
-                if (_errorKnowledgeBase.IsKnownTestIssue(_mainLog, out var issue))
+                foreach (var log in _logs)
                 {
-                    _logger.LogError(message + newLine + issue.Value.HumanMessage);
+                    if (_errorKnowledgeBase.IsKnownTestIssue(log, out var issue))
+                    {
+                        _logger.LogError(message + newLine + issue.Value.HumanMessage);
+                        return;
+                    }
+                }
+
+                if (resultMessage != null)
+                {
+                    _logger.LogError(message + newLine + resultMessage + newLine + newLine + checkLogsMessage);
                 }
                 else
                 {
-                    if (resultMessage != null)
-                    {
-                        _logger.LogError(message + newLine + resultMessage + newLine + newLine + checkLogsMessage);
-                    }
-                    else
-                    {
-                        _logger.LogError(message + newLine + checkLogsMessage);
-                    }
+                    _logger.LogError(message + newLine + checkLogsMessage);
                 }
             }
 
@@ -289,7 +291,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     return ExitCode.APP_LAUNCH_FAILURE;
 
                 case TestExecutingResult.Crashed:
-                    LogProblem("Application run crashed");
+                    LogProblem("Application test run crashed");
                     return ExitCode.APP_CRASH;
 
                 case TestExecutingResult.TimedOut:

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
-            bool signalTestEnd,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken);
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             bool includeWirelessDevices,
             bool resetSimulator,
             bool enableLldb,
-            bool signalTestEnd,
+            bool signalAppEnd,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken)
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     classMethodFilters,
                     environmentalVariables,
                     passthroughArguments,
-                    signalTestEnd,
+                    signalAppEnd,
                     cancellationToken);
 
             Func<AppBundleInformation, IDevice, IDevice?, Task<ExitCode>> executeApp = (appBundleInfo, device, companionDevice) =>
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                     classMethodFilters,
                     environmentalVariables,
                     passthroughArguments,
-                    signalTestEnd,
+                    signalAppEnd,
                     cancellationToken);
 
             return OrchestrateRun(
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> classMethodFilters,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
-            bool signalTestEnd,
+            bool signalAppEnd,
             CancellationToken cancellationToken)
         {
             var runMode = target.Platform.ToRunMode();
@@ -161,16 +161,16 @@ namespace Microsoft.DotNet.XHarness.Apple
                             "Test run might fail if permission is not granted. Permission is valid until app is uninstalled.");
                     }
 
-                    if (!signalTestEnd)
+                    if (!signalAppEnd)
                     {
-                        _logger.LogWarning("XHarness cannot reliably detect when app quits on iOS 14 and newer. Consider using --signal-test-end");
+                        _logger.LogWarning("XHarness cannot reliably detect when app quits on iOS 14 and newer. Consider using --signal-app-end");
                     }
                 }
             }
 
-            if (signalTestEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
+            if (signalAppEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
             {
-                _logger.LogWarning("The --signal-test-end option is recommended for device tests and is not required for simulators");
+                _logger.LogWarning("The --signal-app-end option is recommended for device tests and is not required for simulators");
             }
 
             _logger.LogInformation("Starting test run for " + appBundleInfo.BundleIdentifier + "..");
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 xmlResultJargon,
                 skippedMethods: singleMethodFilters?.ToArray(),
                 skippedTestClasses: classMethodFilters?.ToArray(),
-                signalTestEnd,
+                signalAppEnd,
                 cancellationToken: cancellationToken);
 
             return ParseResult(testResult, resultMessage);
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> classMethodFilters,
             IReadOnlyCollection<(string, string)> environmentalVariables,
             IEnumerable<string> passthroughArguments,
-            bool signalTestEnd,
+            bool signalAppEnd,
             CancellationToken cancellationToken)
         {
             AppTester appTester = GetAppTester(communicationChannel, TestTarget.MacCatalyst.IsSimulator());
@@ -219,7 +219,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 xmlResultJargon,
                 skippedMethods: singleMethodFilters?.ToArray(),
                 skippedTestClasses: classMethodFilters?.ToArray(),
-                signalTestEnd,
+                signalAppEnd,
                 cancellationToken: cancellationToken);
 
             return ParseResult(testResult, resultMessage);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -146,9 +146,9 @@ namespace Microsoft.DotNet.XHarness.Apple
             bool signalTestEnd,
             CancellationToken cancellationToken)
         {
+            var runMode = target.Platform.ToRunMode();
             if (Version.TryParse(device.OSVersion, out var version) && version.Major >= 14)
             {
-                var runMode = target.Platform.ToRunMode();
                 if (runMode == RunMode.iOS)
                 {
                     // iOS 14+ devices do not allow local network access and won't work unless the user confirms a dialog on the screen
@@ -166,11 +166,11 @@ namespace Microsoft.DotNet.XHarness.Apple
                         _logger.LogWarning("XHarness cannot reliably detect when app quits on iOS 14 and newer. Consider using --signal-test-end");
                     }
                 }
+            }
 
-                if (signalTestEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
-                {
-                    _logger.LogWarning("The --signal-test-end option is recommended for device tests and is not required for simulators.");
-                }
+            if (signalTestEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
+            {
+                _logger.LogWarning("The --signal-test-end option is recommended for device tests and is not required for simulators");
             }
 
             _logger.LogInformation("Starting test run for " + appBundleInfo.BundleIdentifier + "..");

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
         public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)ExitCode.SUCCESS);
+        public SignalAppEndArgument SignalAppEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -36,6 +37,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             XcodeRoot,
             MlaunchPath,
             EnableLldb,
+            SignalAppEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
+        public SignalTestEndArgument SignalTestEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -41,6 +42,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             SingleMethodFilters,
             ClassMethodFilters,
             EnableLldb,
+            SignalTestEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
-        public SignalTestEndArgument SignalTestEnd { get; } = new();
+        public SignalAppEndArgument SignalAppEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             SingleMethodFilters,
             ClassMethodFilters,
             EnableLldb,
-            SignalTestEnd,
+            SignalAppEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
         public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)ExitCode.SUCCESS);
+        public SignalAppEndArgument SignalAppEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -36,6 +37,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             XcodeRoot,
             MlaunchPath,
             EnableLldb,
+            SignalAppEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
+        public SignalTestEndArgument SignalTestEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -41,6 +42,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             SingleMethodFilters,
             ClassMethodFilters,
             EnableLldb,
+            SignalTestEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
         public ResetSimulatorArgument ResetSimulator { get; } = new();
-        public SignalTestEndArgument SignalTestEnd { get; } = new();
+        public SignalAppEndArgument SignalAppEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             SingleMethodFilters,
             ClassMethodFilters,
             EnableLldb,
-            SignalTestEnd,
+            SignalAppEnd,
             EnvironmentalVariables,
             ResetSimulator,
         };

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/SignalAppEndArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/SignalAppEndArgument.cs
@@ -9,9 +9,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
     /// <summary>
     /// Enables extra signaling between the TestRunner application and XHarness to work around problems in newer iOS.
     /// </summary>
-    internal class SignalTestEndArgument : SwitchArgument
+    internal class SignalAppEndArgument : SwitchArgument
     {
-        public SignalTestEndArgument() : base("signal-test-end", "Tells the TestRunner inside of the test application to signal back when tests have finished (iOS 14+ cannot detect this reliably otherwise)", false)
+        public SignalAppEndArgument() : base("signal-app-end", "Tells the test application to signal back when tests have finished (iOS 14+ cannot detect this reliably otherwise)", false)
         {
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/SignalTestEndArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/SignalTestEndArgument.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
+{
+    /// <summary>
+    /// Enables extra signaling between the TestRunner application and XHarness to work around problems in newer iOS.
+    /// </summary>
+    internal class SignalTestEndArgument : SwitchArgument
+    {
+        public SignalTestEndArgument() : base("signal-test-end", "Tells the TestRunner inside of the test application to signal back when tests have finished (iOS 14+ cannot detect this reliably otherwise)", false)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -43,15 +43,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
             IFileBackedLog runLog = logs.Create(logFileName, LogType.ExecutionLog.ToString(), timestamp: true);
 
             // Pipe the execution log to the debug output of XHarness effectively making "-v" turn this on
-            CallbackLog debugLog = new(message =>
-            {
-                // Currently, the test runner outputs every test result which is not desireable and the app's output is redirected here because of --signal-test-end
-                // This can be omitted once we have a proper protocol in place and we don't pipe app's output here anymore by using the StdoutArgument mlaunch arg
-                if (!message.Contains("[PASS]", System.StringComparison.InvariantCulture))
-                {
-                    logger.LogDebug(message.Trim());
-                }
-            });
+            CallbackLog debugLog = new(message => logger.LogDebug(message.Trim()));
 
             using var mainLog = Log.CreateReadableAggregatedLog(runLog, debugLog);
             mainLog.Timestamp = true;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -43,7 +43,16 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
             IFileBackedLog runLog = logs.Create(logFileName, LogType.ExecutionLog.ToString(), timestamp: true);
 
             // Pipe the execution log to the debug output of XHarness effectively making "-v" turn this on
-            CallbackLog debugLog = new(message => logger.LogDebug(message.Trim()));
+            CallbackLog debugLog = new(message =>
+            {
+                // Currently, the test runner outputs every test result which is not desireable and the app's output is redirected here because of --signal-test-end
+                // This can be omitted once we have a proper protocol in place and we don't pipe app's output here anymore by using the StdoutArgument mlaunch arg
+                if (!message.Contains("[PASS]", System.StringComparison.InvariantCulture))
+                {
+                    logger.LogDebug(message.Trim());
+                }
+            });
+
             using var mainLog = Log.CreateReadableAggregatedLog(runLog, debugLog);
             mainLog.Timestamp = true;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -44,7 +44,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
             // Pipe the execution log to the debug output of XHarness effectively making "-v" turn this on
             CallbackLog debugLog = new(message => logger.LogDebug(message.Trim()));
-
             using var mainLog = Log.CreateReadableAggregatedLog(runLog, debugLog);
             mainLog.Timestamp = true;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.IncludeWireless,
                     Arguments.ResetSimulator,
                     Arguments.EnableLldb,
+                    Arguments.SignalAppEnd,
                     Arguments.EnvironmentalVariables.Value,
                     PassThroughArguments,
                     cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     includeWirelessDevices: Arguments.IncludeWireless,
                     resetSimulator: Arguments.ResetSimulator,
                     enableLldb: Arguments.EnableLldb,
-                    signalTestEnd: Arguments.SignalTestEnd,
+                    signalAppEnd: Arguments.SignalAppEnd,
                     Arguments.EnvironmentalVariables.Value,
                     PassThroughArguments,
                     cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -38,8 +38,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.XmlResultJargon,
                     Arguments.SingleMethodFilters.Value,
                     Arguments.ClassMethodFilters.Value,
-                    Arguments.ResetSimulator,
-                    Arguments.EnableLldb,
+                    includeWirelessDevices: Arguments.IncludeWireless,
+                    resetSimulator: Arguments.ResetSimulator,
+                    enableLldb: Arguments.EnableLldb,
+                    signalTestEnd: Arguments.SignalTestEnd,
                     Arguments.EnvironmentalVariables.Value,
                     PassThroughArguments,
                     cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 Arguments.IncludeWireless,
                 Arguments.ResetSimulator,
                 Arguments.EnableLldb,
+                Arguments.SignalAppEnd,
                 Arguments.EnvironmentalVariables.Value,
                 PassThroughArguments,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 includeWirelessDevices: Arguments.IncludeWireless,
                 resetSimulator: Arguments.ResetSimulator,
                 enableLldb: Arguments.EnableLldb,
-                signalTestEnd: Arguments.SignalTestEnd,
+                signalAppEnd: Arguments.SignalAppEnd,
                 Arguments.EnvironmentalVariables.Value,
                 PassThroughArguments,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -53,8 +53,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                 Arguments.XmlResultJargon,
                 Arguments.SingleMethodFilters.Value,
                 Arguments.ClassMethodFilters.Value,
-                Arguments.ResetSimulator,
-                Arguments.EnableLldb,
+                includeWirelessDevices: Arguments.IncludeWireless,
+                resetSimulator: Arguments.ResetSimulator,
+                enableLldb: Arguments.EnableLldb,
+                signalTestEnd: Arguments.SignalTestEnd,
                 Arguments.EnvironmentalVariables.Value,
                 PassThroughArguments,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/Log.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/Log.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
     {
         public virtual Encoding Encoding => Encoding.UTF8;
         public string? Description { get; set; }
-        public bool Timestamp { get; set; } = true;
+        public virtual bool Timestamp { get; set; } = true;
 
         protected Log(string? description = null)
         {

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ScanLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ScanLog.cs
@@ -22,6 +22,11 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
 
         public ScanLog(string tag, Action tagFoundNotify)
         {
+            if (string.IsNullOrEmpty(tag))
+            {
+                throw new ArgumentException($"'{nameof(tag)}' cannot be null or empty.", nameof(tag));
+            }
+
             _tag = tag;
             _tagFoundNotify = tagFoundNotify;
             _buffer = new char[_tag.Length];

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ScanLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ScanLog.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.Common.Logging
+{
+    /// <summary>
+    /// Log that scans for a given tag and notifies when tag is found in the stream.
+    /// </summary>
+    public class ScanLog : Log
+    {
+        private readonly string _tag;
+        private readonly Action _tagFoundNotify;
+        private readonly char[] _buffer;
+        private int _startIndex;
+        private bool _hasBeenFilled = false;
+
+        public override bool Timestamp { get => false; set { } }
+
+        public ScanLog(string tag, Action tagFoundNotify)
+        {
+            _tag = tag;
+            _tagFoundNotify = tagFoundNotify;
+            _buffer = new char[_tag.Length];
+            _startIndex = -1;
+        }
+
+        protected override void WriteImpl(string value)
+        {
+            foreach (var c in value)
+            {
+                Add(c);
+
+                if (IsMatch())
+                {
+                    _tagFoundNotify();
+                }
+            }
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        private void Add(char c)
+        {
+            _startIndex++;
+
+            if (_startIndex == _buffer.Length - 1)
+            {
+                _hasBeenFilled = true;
+            }
+
+            _startIndex %= _buffer.Length;
+            _buffer[_startIndex] = c;
+        }
+
+        private bool IsMatch()
+        {
+            if (!_hasBeenFilled)
+            {
+                return false;
+            }
+
+            for (int i = 1; i <= _buffer.Length; i++)
+            {
+                int index = (i + _startIndex) % _buffer.Length;
+                if (_buffer[index] != _tag[i - 1])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -76,6 +76,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                 _classMethodFilters.AddRange(classes.Split(','));
             }
 
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.TestEndTag)))
+            {
+                TestEndTag = Environment.GetEnvironmentVariable(EnviromentVariables.TestEndTag);
+            }
+
             var os = new OptionSet() {
                 { "autoexit", "Exit application once the test run has completed", v => TerminateAfterExecution = true },
                 { "autostart", "If the app should automatically start running the tests", v => AutoStart = true },
@@ -106,7 +111,8 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                     "tests that have been provided by the '--method' and '--class' arguments will be ran. " +
                     "All other test will be ignored. Can be used more than once.",
                     v => _classMethodFilters.Add(v)
-                }
+                },
+                { "test-end-tag=", "String that will be outputted when test run has finished", v => TestEndTag = v },
             };
 
             try
@@ -168,5 +174,10 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
         /// Specify the test classes to be ran in the app.
         /// </summary>
         public ICollection<string> ClassMethodFilters => _classMethodFilters;
+
+        /// <summary>
+        /// String that will be outputted when test run has finished.
+        /// </summary>
+        public string TestEndTag { get; private set; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -76,9 +76,9 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                 _classMethodFilters.AddRange(classes.Split(','));
             }
 
-            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.TestEndTag)))
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnviromentVariables.AppEndTag)))
             {
-                TestEndTag = Environment.GetEnvironmentVariable(EnviromentVariables.TestEndTag);
+                AppEndTag = Environment.GetEnvironmentVariable(EnviromentVariables.AppEndTag);
             }
 
             var os = new OptionSet() {
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
                     "All other test will be ignored. Can be used more than once.",
                     v => _classMethodFilters.Add(v)
                 },
-                { "test-end-tag=", "String that will be outputted when test run has finished", v => TestEndTag = v },
+                { "test-end-tag=", "String that will be outputted when test run has finished", v => AppEndTag = v },
             };
 
             try
@@ -178,6 +178,6 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
         /// <summary>
         /// String that will be outputted when test run has finished.
         /// </summary>
-        public string TestEndTag { get; private set; }
+        public string AppEndTag { get; private set; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
@@ -65,9 +65,9 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
             logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
 
-            if (options.TestEndTag != null)
+            if (options.AppEndTag != null)
             {
-                logger.Info(options.TestEndTag);
+                logger.Info(options.AppEndTag);
             }
 
             if (options.TerminateAfterExecution)

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
@@ -64,6 +64,12 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             }
 
             logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+
+            if (options.TestEndTag != null)
+            {
+                logger.Info(options.TestEndTag);
+            }
+
             if (options.TerminateAfterExecution)
             {
                 TerminateWithSuccess();

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
@@ -52,6 +52,11 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
                 logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
 
+                if (options.TestEndTag != null)
+                {
+                    logger.Info(options.TestEndTag);
+                }
+
                 if (options.TerminateAfterExecution)
                 {
                     TerminateWithSuccess();

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
@@ -52,9 +52,9 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
 
                 logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
 
-                if (options.TestEndTag != null)
+                if (options.AppEndTag != null)
                 {
-                    logger.Info(options.TestEndTag);
+                    logger.Info(options.AppEndTag);
                 }
 
                 if (options.TerminateAfterExecution)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         /// <summary>
         /// Env var containing a tag that the test application will output once tests are finished to signalize it.
         /// </summary>
-        public const string TestEndTag = "TEST_END_TAG";
+        public const string AppEndTag = "TEST_END_TAG";
 
         /// <summary>
         /// Env var used to notify the test application that the output is expected to be xml.

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         public const string AutoStart = "NUNIT_AUTOSTART";
 
         /// <summary>
-        /// Env car that will tell the test application to exit once all the test have been ran.
+        /// Env var that will tell the test application to exit once all the test have been ran.
         /// </summary>
         public const string AutoExit = "NUNIT_AUTOEXIT";
 
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         /// over the usb cable.
         /// </summary>
         public const string UseTcpTunnel = "USE_TCP_TUNNEL";
+
+        /// <summary>
+        /// Env var containing a tag that the test application will output once tests are finished to signalize it.
+        /// </summary>
+        public const string TestEndTag = "TEST_END_TAG";
 
         /// <summary>
         /// Env var used to notify the test application that the output is expected to be xml.

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/EnviromentVariables.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
         /// <summary>
         /// Env var containing a tag that the test application will output once tests are finished to signalize it.
         /// </summary>
-        public const string AppEndTag = "TEST_END_TAG";
+        public const string AppEndTag = "RUN_END_TAG";
 
         /// <summary>
         /// Env var used to notify the test application that the output is expected to be xml.

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 {
     public interface ISimpleListener : IDisposable

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
@@ -9,7 +9,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 
 namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
-    public interface IDeviceLogCapturer
+    public interface IDeviceLogCapturer : IDisposable
     {
         void StartCapture();
         void StopCapture();
@@ -97,6 +97,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             _processManager.KillTreeAsync(_process, _mainLog, diagnostics: false).Wait();
             _process.Dispose();
         }
+
+        public void Dispose() => StopCapture();
     }
 }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
 
         Guid GenerateStableGuid(string seed = null);
 
+        Guid GenerateGuid();
+
         string Timestamp { get; }
 
         IEnumerable<IPAddress> GetLocalIpAddresses();
@@ -48,6 +50,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
             }
             return new Guid(bytes);
         }
+
+        public Guid GenerateGuid() => Guid.NewGuid();
 
         public string Timestamp => $"{DateTime.Now:yyyyMMdd_HHmmss}";
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
@@ -74,11 +74,11 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
                 .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
             _logs
-                .Setup(x => x.CreateFile(AppBundleIdentifier + ".log", LogType.ApplicationLog))
-                .Returns(_stdoutLog.FullPath);
+                .Setup(x => x.Create(AppBundleIdentifier + ".log", LogType.ApplicationLog.ToString(), It.IsAny<bool?>()))
+                .Returns(_stdoutLog);
             _logs
-                .Setup(x => x.CreateFile(AppBundleIdentifier + ".err.log", LogType.ApplicationLog))
-                .Returns(_stderrLog.FullPath);
+                .Setup(x => x.Create(AppBundleIdentifier + ".err.log", LogType.ApplicationLog.ToString(), It.IsAny<bool?>()))
+                .Returns(_stderrLog);
 
             var factory2 = new Mock<ICrashSnapshotReporterFactory>();
             factory2.SetReturnsDefault(_snapshotReporter.Object);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 _mockSimulator,
                 null,
                 timeout: TimeSpan.FromSeconds(30),
+                false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -117,6 +118,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 s_mockDevice,
                 null,
                 timeout: TimeSpan.FromSeconds(30),
+                false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -175,6 +177,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             var result = await appRunner.RunMacCatalystApp(
                 appInformation,
                 timeout: TimeSpan.FromSeconds(30),
+                false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -189,6 +192,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        "open",
                        It.Is<IList<string>>(args => args[0] == "-W" && args[1] == s_appPath),
                        _mainLog.Object,
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<CancellationToken>()),
@@ -207,8 +212,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 extension: null);
 
         private string GetExpectedDeviceMlaunchArgs() =>
-            $"--stdout={_stdoutLog.FullPath} " +
-            $"--stderr={_stderrLog.FullPath} " +
             "-argument=--foo=bar " +
             "-argument=--xyz " +
             "-setenv=appArg1=value1 " +
@@ -218,8 +221,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             "--wait-for-exit";
 
         private string GetExpectedSimulatorMlaunchArgs() =>
-            $"--stdout={_stdoutLog.FullPath} " +
-            $"--stderr={_stderrLog.FullPath} " +
             "-argument=--foo=bar " +
             "-argument=--xyz " +
             "-setenv=appArg1=value1 " +

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
@@ -15,6 +16,7 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Moq;
 using Xunit;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.Apple.Tests
 {
     public class AppRunnerTests : AppRunTestBase
@@ -55,7 +57,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 _mockSimulator,
                 null,
                 timeout: TimeSpan.FromSeconds(30),
-                false,
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -68,7 +70,9 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Verify(
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
-                       _mainLog.Object,
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<int>(),
@@ -118,7 +122,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 s_mockDevice,
                 null,
                 timeout: TimeSpan.FromSeconds(30),
-                false,
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -132,11 +136,126 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                        It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<int>(),
                        It.IsAny<CancellationToken>()),
                     Times.Once);
+
+            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
+            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
+
+            deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task RunOnDeviceWithAppEndSignalTest()
+        {
+            var deviceSystemLog = new Mock<IFileBackedLog>();
+            deviceSystemLog.SetupGet(x => x.FullPath).Returns(AppBundleIdentifier + "system.log");
+            deviceSystemLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
+
+            SetupLogList(new[] { deviceSystemLog.Object, _stdoutLog, _stderrLog });
+
+            _logs
+                .Setup(x => x.Create("device-" + DeviceName + "-mocked_timestamp.log", LogType.SystemLog.ToString(), It.IsAny<bool?>()))
+                .Returns(deviceSystemLog.Object);
+
+            var deviceLogCapturer = new Mock<IDeviceLogCapturer>();
+
+            var deviceLogCapturerFactory = new Mock<IDeviceLogCapturerFactory>();
+            deviceLogCapturerFactory
+                .Setup(x => x.Create(_mainLog.Object, deviceSystemLog.Object, DeviceName))
+                .Returns(deviceLogCapturer.Object);
+
+            var testEndSignal = Guid.NewGuid();
+            _helpers
+                .Setup(x => x.GenerateGuid())
+                .Returns(testEndSignal);
+
+            var appInformation = GetMockedAppBundleInfo();
+
+            List<MlaunchArguments> mlaunchArguments = new();
+            List<IFileBackedLog> appOutputLogs = new();
+            List<CancellationToken> cancellationTokens = new();
+
+            // Endlessly running mlaunch until it gets cancelled by the signal
+            var mlaunchCompleted = new TaskCompletionSource<ProcessExecutionResult>();
+            var appStarted = new TaskCompletionSource();
+
+            _processManager
+                .Setup(x => x.ExecuteCommandAsync(
+                       Capture.In(mlaunchArguments),
+                       It.IsAny<ILog>(),
+                       Capture.In(appOutputLogs),
+                       Capture.In(appOutputLogs),
+                       It.IsAny<TimeSpan>(),
+                       It.IsAny<Dictionary<string, string>?>(),
+                       It.IsAny<int>(),
+                       Capture.In(cancellationTokens)))
+                .Callback(() =>
+                {
+                    // Signal we have started mlaunch
+                    appStarted.SetResult();
+
+                    // When mlaunch gets signalled to shut down, shut down even our fake mlaunch
+                    cancellationTokens.Last().Register(() => mlaunchCompleted.SetResult(new ProcessExecutionResult
+                    {
+                        TimedOut = true,
+                    }));
+                })
+                .Returns(mlaunchCompleted.Task);
+
+            // Act
+            var appRunner = new AppRunner(
+                _processManager.Object,
+                _snapshotReporterFactory,
+                Mock.Of<ICaptureLogFactory>(),
+                deviceLogCapturerFactory.Object,
+                _mainLog.Object,
+                _logs.Object,
+                _helpers.Object);
+
+            var runTask = appRunner.RunApp(
+                appInformation,
+                new TestTargetOs(TestTarget.Device_iOS, null),
+                s_mockDevice,
+                null,
+                timeout: TimeSpan.FromSeconds(30),
+                signalAppEnd: true,
+                Array.Empty<string>(),
+                Array.Empty<(string, string)>());
+
+            // Everything should hang now since we mimicked mlaunch not being able to tell the app quits
+            // We will wait for XHarness to kick off the mlaunch (the app)
+            Assert.False(runTask.IsCompleted);
+            await Task.WhenAny(appStarted.Task, Task.Delay(1000));
+
+            // XHarness should still be running
+            Assert.False(runTask.IsCompleted);
+
+            // mlaunch should be started
+            Assert.True(appStarted.Task.IsCompleted);
+
+            // We will mimick the app writing the end signal
+            var appLog = appOutputLogs.First();
+            appLog.WriteLine(testEndSignal.ToString());
+
+            // AppTester should now complete fine
+            var result = await runTask;
+
+            // Verify
+            Assert.True(result.Succeeded);
+
+            var expectedArgs = $"-setenv=RUN_END_TAG={testEndSignal} " +
+                "--disable-memory-limits " +
+                $"--devname {s_mockDevice.DeviceIdentifier} " +
+                $"--launchdevbundleid {AppBundleIdentifier} " +
+                "--wait-for-exit";
+
+            Assert.Equal(mlaunchArguments.Last().AsCommandLine(), expectedArgs);
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
@@ -177,7 +296,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             var result = await appRunner.RunMacCatalystApp(
                 appInformation,
                 timeout: TimeSpan.FromSeconds(30),
-                false,
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -145,7 +145,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     Times.Once);
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
         }
@@ -257,7 +256,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
 
             Assert.Equal(mlaunchArguments.Last().AsCommandLine(), expectedArgs);
 
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -554,19 +554,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Setup(x => x.GenerateGuid())
                 .Returns(testEndSignal);
 
-            // Act
-            var appTester = new AppTester(
-                _processManager.Object,
-                _listenerFactory.Object,
-                _snapshotReporterFactory,
-                Mock.Of<ICaptureLogFactory>(),
-                deviceLogCapturerFactory.Object,
-                _testReporterFactory,
-                new XmlResultParser(),
-                _mainLog.Object,
-                _logs.Object,
-                _helpers.Object);
-
             List<MlaunchArguments> mlaunchArguments = new();
             List<IFileBackedLog> appOutputLogs = new();
             List<CancellationToken> cancellationTokens = new();
@@ -605,6 +592,19 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 launchAppPath: s_appPath,
                 supports32b: false,
                 extension: null);
+
+            // Act
+            var appTester = new AppTester(
+                _processManager.Object,
+                _listenerFactory.Object,
+                _snapshotReporterFactory,
+                Mock.Of<ICaptureLogFactory>(),
+                deviceLogCapturerFactory.Object,
+                _testReporterFactory,
+                new XmlResultParser(),
+                _mainLog.Object,
+                _logs.Object,
+                _helpers.Object);
 
             var testTask = appTester.TestApp(
                 appInformation,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -255,7 +255,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             }
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
         }
@@ -346,7 +345,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
         }
@@ -434,7 +432,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             _listener.Verify(x => x.StartAsync(), Times.AtLeastOnce);
             _listener.Verify(x => x.Dispose(), Times.AtLeastOnce);
 
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
@@ -653,7 +650,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             // we dont want to leak a process
             _tunnelBore.Verify(t => t.Close(s_mockDevice.DeviceIdentifier));
 
-            _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
             _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
             deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -137,6 +137,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                        _mainLog.Object,
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<int>(),
@@ -230,6 +232,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Verify(
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.Is<Dictionary<string, string>>(d => d["appArg1"] == "value1"),
@@ -326,6 +330,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                        It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<int>(),
@@ -411,6 +417,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Verify(
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
@@ -505,8 +513,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         }
 
         private string GetExpectedDeviceMlaunchArgs(string skippedTests = null, bool useTunnel = false, string extraArgs = null) =>
-            $"--stdout={_stdoutLog.FullPath} " +
-            $"--stderr={_stderrLog.FullPath} " +
             "-setenv=NUNIT_AUTOEXIT=true " +
             $"-setenv=NUNIT_HOSTPORT={Port} " +
             "-setenv=NUNIT_ENABLE_XML_OUTPUT=true " +
@@ -521,8 +527,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             "--wait-for-exit";
 
         private string GetExpectedSimulatorMlaunchArgs() =>
-            $"--stdout={_stdoutLog.FullPath} " +
-            $"--stderr={_stderrLog.FullPath} " +
             "-setenv=NUNIT_AUTOEXIT=true " +
             $"-setenv=NUNIT_HOSTPORT={Port} " +
             "-setenv=NUNIT_ENABLE_XML_OUTPUT=true " +

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppTesterTests.cs
@@ -123,8 +123,9 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 null,
                 TimeSpan.FromSeconds(30),
                 TimeSpan.FromSeconds(30),
-                new string[] { "--foo=bar", "--xyz" },
-                new[] { ("appArg1", "value1") });
+                signalAppEnd: false,
+                extraAppArguments: new string[] { "--foo=bar", "--xyz" },
+                extraEnvVariables: new[] { ("appArg1", "value1") });
 
             // Verify
             Assert.Equal(TestExecutingResult.Succeeded, result);
@@ -217,6 +218,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 null,
                 timeout: TimeSpan.FromSeconds(30),
                 testLaunchTimeout: TimeSpan.FromSeconds(30),
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -312,9 +314,10 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 s_mockDevice,
                 null,
                 timeout: TimeSpan.FromSeconds(30),
+                testLaunchTimeout: TimeSpan.FromSeconds(30),
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") },
-                testLaunchTimeout: TimeSpan.FromSeconds(30),
                 skippedMethods: skippedTests);
 
             // Verify
@@ -404,6 +407,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 extraEnvVariables: new[] { ("appArg1", "value1") },
                 timeout: TimeSpan.FromSeconds(30),
                 testLaunchTimeout: TimeSpan.FromSeconds(30),
+                signalAppEnd: false,
                 skippedTestClasses: skippedClasses);
 
             // Verify
@@ -484,6 +488,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 appInformation,
                 timeout: TimeSpan.FromSeconds(30),
                 testLaunchTimeout: TimeSpan.FromSeconds(30),
+                signalAppEnd: false,
                 extraAppArguments: new[] { "--foo=bar", "--xyz" },
                 extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -497,6 +502,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                        "open",
                        It.Is<IList<string>>(args => args.Contains(s_appPath) && args.Contains("--foo=bar") && args.Contains("--foo=bar")),
                        _mainLog.Object,
+                       It.IsAny<ILog>(),
+                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.Is<Dictionary<string, string>>(envVars =>
                             envVars["NUNIT_HOSTNAME"] == "127.0.0.1" &&

--- a/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ScanLogTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ScanLogTest.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Common.Logging;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Common.Tests.Logging
+{
+    public class ScanLogTest
+    {
+        [Theory]
+        [InlineData("lo", "lo", true)]
+        [InlineData("This is a log message", "log", true)]
+        [InlineData("emessag", "message", false)]
+        [InlineData("This is a log message", "This is a log message", true)]
+        [InlineData("This is a log message.", ".", true)]
+        public void TagIsFoundInLog(string message, string tag, bool shouldFind)
+        {
+            bool found = false;
+            var log = new ScanLog(tag, () => found = true);
+            log.Write(message);
+            Assert.Equal(shouldFind, found);
+        }
+
+        [Fact]
+        public void TagIsFoundInSeveralMessages()
+        {
+            bool found = false;
+            var log = new ScanLog("123", () => found = true);
+            log.Write("abc1");
+            log.Write("2");
+            log.Write("3cdef");
+            Assert.True(found);
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ScanLogTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.Common.Tests/Logging/ScanLogTest.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.XHarness.Common.Tests.Logging
     public class ScanLogTest
     {
         [Theory]
-        [InlineData("lo", "lo", true)]
         [InlineData("This is a log message", "log", true)]
         [InlineData("emessag", "message", false)]
         [InlineData("This is a log message", "This is a log message", true)]

--- a/tests/integration-tests/Apple/Device.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Device.Commands.Tests.proj
@@ -27,15 +27,11 @@
         <TestTimeout>00:05:00</TestTimeout>
         <LaunchTimeout>00:04:30</LaunchTimeout>
         <CustomCommands>
-          set -ex;
-          deviceId=`xharness apple device $target`;
+          set -ex; deviceId=`xharness apple device $target`;
           xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" -v;
-          set +e;
-          result=0;
-          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout --signal-test-end -v;
-          ((result|=$?));
-          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v;
-          ((result|=$?));
+          set +e; result=0;
+          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout --signal-app-end -v; ((result|=$?));
+          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v; ((result|=$?));
           exit $result;
         </CustomCommands>
       </XHarnessAppBundleToTest>

--- a/tests/integration-tests/Apple/Device.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Device.Commands.Tests.proj
@@ -32,7 +32,7 @@
           xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" -v;
           set +e;
           result=0;
-          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v;
+          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout --signal-test-end -v;
           ((result|=$?));
           xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v;
           ((result|=$?));


### PR DESCRIPTION
Signals the test runner to log a given tag at the end of the test run and ends the test run. Useful for iOS/tvOS 14+ where mlaunch cannot detect the app quit.

This functionality should be eventually superseded by a full protocol between the app and XHarness but this way keeps it backwards compatible and also won't break Xamarin who is sharing some of the code.

Fixes #574

```
prvysoky[~/Documents/work]>  xharness apple just-test -t ios-device -a net.dot.System.Buffers.Tests -o o --timeout 00:01:00 | gnomon
   0.0156s   XHarness command issued: apple just-test -t ios-device -a net.dot.System.Buffers.Tests -o o --timeout 00:01:00
   0.0107s   info: Preparing run for ios-device
   3.7489s   info: Looking for available ios-device devices..
   0.0033s   info: Found physical device 'iPremek'
   0.0001s   warn: XHarness cannot reliably detect when app quits on iOS 14 and newer. Consider using --signal-test-end
  82.0663s   info: Starting test run for net.dot.System.Buffers.Tests..
   0.0001s   info: Application finished the test run successfully
   0.0028s   info: Tests run: 82 Passed: 75 Inconclusive: 0 Failed: 0 Ignored: 7
   0.0073s   XHarness exit code: 0
   0.0004s

     Total   85.8567s
   
prvysoky[~/Documents/work]>  xharness apple just-test -t ios-device -a net.dot.System.Buffers.Tests -o o --timeout 00:01:00 --signal-test-end | gnomon
   0.0170s   XHarness command issued: apple just-test -t ios-device -a net.dot.System.Buffers.Tests -o o --timeout 00:01:00 --signal-test-end
   0.0109s   info: Preparing run for ios-device
   3.9628s   info: Looking for available ios-device devices..
   0.0031s   info: Found physical device 'iPremek'
  18.0050s   info: Starting test run for net.dot.System.Buffers.Tests..
   0.0001s   info: Application finished the test run successfully
   0.0027s   info: Tests run: 82 Passed: 75 Inconclusive: 0 Failed: 0 Ignored: 7
   0.0067s   XHarness exit code: 0
   0.0002s

     Total   22.0098s
```