### PR TITLE
Move XHarnessCommand and XHarnessCommandArguments to the CLI project

### DIFF
--- a/XHarness.sln
+++ b/XHarness.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XHarness.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit", "src\Microsoft.DotNet.XHarness.InstrumentationBase.Xunit\Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit.csproj", "{FBDF39C0-1096-4088-B057-2FF8CCDFB32D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.XHarness.CLI.Tests", "tests\Microsoft.DotNet.XHarness.CLI.Tests\Microsoft.DotNet.XHarness.CLI.Tests.csproj", "{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +104,10 @@ Global
 		{FBDF39C0-1096-4088-B057-2FF8CCDFB32D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBDF39C0-1096-4088-B057-2FF8CCDFB32D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBDF39C0-1096-4088-B057-2FF8CCDFB32D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -121,6 +127,7 @@ Global
 		{C1CB4AA8-A96C-4C06-BD39-4D8D09A15D86} = {1018BF4C-BD8F-49D7-9797-758E68B9FC9D}
 		{D51E7536-E698-42F4-939A-F259D543D1E1} = {713ACDCF-301D-4C96-8B75-5BF2A35A326D}
 		{FBDF39C0-1096-4088-B057-2FF8CCDFB32D} = {713ACDCF-301D-4C96-8B75-5BF2A35A326D}
+		{B81EF83E-F2C5-4DFA-82ED-2761C2BC25CA} = {1018BF4C-BD8F-49D7-9797-758E68B9FC9D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {56D5F4DA-F710-4026-8F49-4A903BCAA9B5}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidUninstallCommandArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceArchitectureArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceArchitectureArgument.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceIdArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceIdArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceOutputFolderArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceOutputFolderArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/InstrumentationArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/InstrumentationArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/InstrumentationNameArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/InstrumentationNameArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/LaunchTimeoutArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/LaunchTimeoutArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/PackageNameArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/PackageNameArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     internal class PackageNameArgument : RequiredStringArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/WifiArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/WifiArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetDeviceCommandsArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetDeviceCommandsArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleGetStateCommandArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleInstallCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleUninstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleUninstallCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/BundleIdentifierArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/BundleIdentifierArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class BundleIdentifierArgument : RequiredStringArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/CommunicationChannelArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/CommunicationChannelArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.XHarness.Apple;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/DeviceNameArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/DeviceNameArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/EnableLldbArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/EnableLldbArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/EnvironmentalVariablesArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/EnvironmentalVariablesArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ForceInstallationArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ForceInstallationArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class ForceInstallationArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/IncludeWirelessArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/IncludeWirelessArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/LaunchTimeoutArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/LaunchTimeoutArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ListInstalledArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ListInstalledArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class ListInstalledArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/MlaunchArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/MlaunchArgument.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.Common.Execution;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ResetSimulatorArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ResetSimulatorArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ShowDevicesUUIDArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ShowDevicesUUIDArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class ShowDevicesUUIDArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ShowSimulatorsUUIDArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/ShowSimulatorsUUIDArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class ShowSimulatorsUUIDArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/TargetArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/TargetArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/UseJsonArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/UseJsonArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal class UseJsonArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/XcodeArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/XcodeArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/XmlResultJargonArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/XmlResultJargonArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.XHarness.Common;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/IAppleAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/IAppleAppRunArguments.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
 {
     internal interface IAppleAppRunArguments : IXHarnessCommandArguments

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/FindCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/InstallCommandArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/ListCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/ListCommandArguments.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/SimulatorsCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Simulators/SimulatorsCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.CommandArguments
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     public abstract class Argument
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/AppPathArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/AppPathArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/ClassMethodFilters.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/ClassMethodFilters.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/ExpectedExitCodeArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/ExpectedExitCodeArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/OutputDirectoryArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/OutputDirectoryArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/SingleMethodFilters.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/SingleMethodFilters.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/TimeoutArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/TimeoutArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerHttpEnvironmentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerHttpEnvironmentVariables.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerHttpsEnvironmentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerHttpsEnvironmentVariables.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerMiddlewareArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerMiddlewareArgument.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseCorsArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseCorsArguments.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     internal class WebServerUseCorsArguments : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseHttpsArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseHttpsArguments.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     internal class WebServerUseHttpsArguments : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/HelpArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/HelpArgument.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.CommandArguments
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     public class HelpArgument : SwitchArgument
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/VerbosityArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/VerbosityArgument.cs
@@ -4,7 +4,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.CommandArguments
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     public class VerbosityArgument : Argument
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserArguments.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class BrowserArguments : RepeatableArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserLocationArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BrowserLocationArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class BrowserLocationArgument : StringArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/DebuggerPortArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/DebuggerPortArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class DebuggerPortArgument : IntArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/ErrorPatternsFileArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/ErrorPatternsFileArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/HTMLFileArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/HTMLFileArgument.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArgument.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArguments.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class JavaScriptEngineArguments : RepeatableArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptFileArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptFileArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class JavaScriptFileArgument : RequiredStringArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoHeadlessArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoHeadlessArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class NoHeadlessArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoIncognitoArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoIncognitoArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class NoIncognitoArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/QuitAppAtEndArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/QuitAppAtEndArgument.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {
     internal class QuitAppAtEndArgument : SwitchArgument

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/XHarnessCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/XHarnessCommandArguments.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.CommandArguments
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
 {
     public interface IXHarnessCommandArguments
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -11,7 +11,6 @@ using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -8,9 +8,9 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -6,7 +6,6 @@ using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.Android.Execution;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Android

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Apple;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleGetDeviceCommand.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Apple;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -39,7 +39,11 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
 
             var mainLog = serviceProvider.GetRequiredService<IFileBackedLog>();
             var appBundleInformationParser = serviceProvider.GetRequiredService<IAppBundleInformationParser>();
-            var appBundleInfo = await appBundleInformationParser.ParseFromAppBundle(Arguments.AppBundlePath.Value ?? throw new ArgumentNullException(), Arguments.Target.Value.Platform, mainLog, cancellationToken);
+            var appBundleInfo = await appBundleInformationParser.ParseFromAppBundle(
+                Arguments.AppBundlePath.Value ?? throw new ArgumentException("App bundle path not provided"),
+                Arguments.Target.Value.Platform,
+                mainLog,
+                cancellationToken);
 
             var orchestrator = serviceProvider.GetRequiredService<IRunOrchestrator>();
             return await orchestrator.OrchestrateRun(

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -12,7 +12,6 @@ using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple.Simulators;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/GetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/GetStateCommand.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessCommand.cs
@@ -6,14 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Mono.Options;
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
+namespace Microsoft.DotNet.XHarness.CLI.Commands
 {
     public abstract class XHarnessCommand : Command
     {
@@ -152,7 +153,8 @@ namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
         private static ILoggerFactory CreateLoggerFactory(LogLevel verbosity) => LoggerFactory.Create(builder =>
         {
             builder
-                .AddConsoleFormatter<XHarnessConsoleLoggerFormatter, SimpleConsoleFormatterOptions>(options => {
+                .AddConsoleFormatter<XHarnessConsoleLoggerFormatter, SimpleConsoleFormatterOptions>(options =>
+                {
                     options.ColorBehavior = EnvironmentVariables.IsTrue(EnvironmentVariables.Names.DISABLE_COLOR_OUTPUT) ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Default;
                     options.TimestampFormat = EnvironmentVariables.IsTrue(EnvironmentVariables.Names.LOG_TIMESTAMPS) ? "[HH:mm:ss] " : null!;
                 })

--- a/src/Microsoft.DotNet.XHarness.CLI/Program.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Program.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.XHarness.CLI.Commands;
 using Microsoft.DotNet.XHarness.CLI.Commands.Apple;
 using Microsoft.DotNet.XHarness.CLI.Commands.Wasm;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Mono.Options;
 
 namespace Microsoft.DotNet.XHarness.CLI

--- a/src/Microsoft.DotNet.XHarness.CLI/XHarnessConsoleLoggerFormatter.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/XHarnessConsoleLoggerFormatter.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 
-namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
+namespace Microsoft.DotNet.XHarness.CLI
 {
     /// <summary>
     /// Copied over from SimpleConsoleFormatter. Leaves out the logger name and new line, turning
@@ -48,7 +48,12 @@ namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
 
         public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, TextWriter textWriter)
         {
-            string message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+            if (logEntry.Formatter == null)
+            {
+                return;
+            }
+
+            var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
             if (logEntry.Exception == null && message == null)
             {
                 return;
@@ -56,11 +61,11 @@ namespace Microsoft.DotNet.XHarness.Common.CLI.Commands
 
             LogLevel logLevel = logEntry.LogLevel;
             var logLevelColors = GetLogLevelConsoleColors(logLevel);
-            string logLevelString = GetLogLevelString(logLevel);
+            var logLevelString = GetLogLevelString(logLevel);
 
             if (_options.TimestampFormat != null)
             {
-                string timestamp = DateTimeOffset.Now.ToString(_options.TimestampFormat);
+                var timestamp = DateTimeOffset.Now.ToString(_options.TimestampFormat);
                 textWriter.Write(timestamp);
             }
 

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
     {
         #region Private variables
 
-        private static readonly Lazy<string> s_autoDetectedXcodeRoot = new Lazy<string>(DetectXcodePath, LazyThreadSafetyMode.PublicationOnly);
+        private static readonly Lazy<string> s_autoDetectedXcodeRoot = new(DetectXcodePath, LazyThreadSafetyMode.PublicationOnly);
         private readonly string? _xcodeRoot;
         private Version? _xcode_version;
 

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/WindowsProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/WindowsProcessManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
     {
         // We cannot enumerate processes well on Windows but we will use the CLI as .NET Core 3.1 and will kill the whole process tree
         // (this library is only used under netstandard 2.1 in Xamarin where it runs on OSX only)
-        protected override List<int> GetChildProcessIds(ILog log, int pid) => new List<int> { pid };
+        protected override List<int> GetChildProcessIds(ILog log, int pid) => new() { pid };
 
         protected override int Kill(int pid, int sig)
         {

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/AggregatedLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/AggregatedLog.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
         // Log that will duplicate log output to multiple other logs.
         private class AggregatedLog : Log
         {
-            protected readonly List<ILog> _logs = new List<ILog>();
+            protected readonly List<ILog> _logs = new();
 
             public AggregatedLog(params ILog[] logs)
             {

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/CallbackLog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
     public class CallbackLog : Log
     {
         private readonly Action<string> _onWrite;
-        private readonly StringBuilder _captured = new StringBuilder();
+        private readonly StringBuilder _captured = new();
 
         public CallbackLog(Action<string> onWrite)
             : base("Callback log")

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/ConsoleLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/ConsoleLog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
     /// </summary>
     public class ConsoleLog : ReadableLog
     {
-        readonly StringBuilder _captured = new StringBuilder();
+        readonly StringBuilder _captured = new();
 
         protected override void WriteImpl(string value)
         {

--- a/src/Microsoft.DotNet.XHarness.Common/Logging/MemoryLog.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Logging/MemoryLog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.XHarness.Common.Logging
     /// </summary>
     public class MemoryLog : ReadableLog
     {
-        private readonly StringBuilder _captured = new StringBuilder();
+        private readonly StringBuilder _captured = new();
 
         protected override void WriteImpl(string value) => _captured.Append(value);
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TcpTextWriter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Common
     {
         private static readonly TimeSpan s_connectionAwaitPeriod = TimeSpan.FromMinutes(1);
 
-        private StreamWriter _writer;
+        private readonly StreamWriter _writer;
 
         private TcpTextWriter(StreamWriter writer)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Collections/BlockingEnumerableCollection.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Collections/BlockingEnumerableCollection.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Collections
     public class BlockingEnumerableCollection<T> : IEnumerable<T> where T : class
     {
         private readonly List<T> _list = new();
-        private TaskCompletionSource<bool> _completed = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> _completed = new();
 
         public int Count
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/MLaunchArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Execution/MLaunchArguments.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Execution
 
     public class MlaunchArguments : IEnumerable<MlaunchArgument>
     {
-        private readonly List<MlaunchArgument> _arguments = new List<MlaunchArgument>();
+        private readonly List<MlaunchArgument> _arguments = new();
 
         public MlaunchArguments(params MlaunchArgument[] args)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             }
             catch (Exception e)
             {
-                if (!(e is SocketException se) || se.SocketErrorCode != SocketError.Interrupted)
+                if (e is not SocketException se || se.SocketErrorCode != SocketError.Interrupted)
                 {
                     Console.WriteLine("[{0}] : {1}", DateTime.Now, e);
                 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
     public abstract class SimpleListener : ISimpleListener
     {
-        private readonly TaskCompletionSource<bool> _stopped = new TaskCompletionSource<bool>();
-        private readonly TaskCompletionSource<bool> _connected = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource<bool> _stopped = new();
+        private readonly TaskCompletionSource<bool> _connected = new();
 
         public IFileBackedLog TestLog { get; private set; }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             }
             catch (Exception e)
             {
-                if (!(e is SocketException se) || se.SocketErrorCode != SocketError.Interrupted)
+                if (e is not SocketException se || se.SocketErrorCode != SocketError.Interrupted)
                 {
                     Log.WriteLine("[{0}] : {1}", DateTime.Now, e);
                 }
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
             }
             catch (Exception e)
             {
-                if (!(e is SocketException se) || se.SocketErrorCode != SocketError.Interrupted)
+                if (e is not SocketException se || se.SocketErrorCode != SocketError.Interrupted)
                 {
                     Log.WriteLine($"Failed to read TCP data: {e}");
                 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TcpTunnel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
     // the host and the device via the usb cable.
     public class TcpTunnel : ITcpTunnel
     {
-        private readonly object _processExecutionLock = new object();
+        private readonly object _processExecutionLock = new();
         private readonly IMlaunchProcessManager _processManager;
         private Task<ProcessExecutionResult> _tcpTunnelExecutionTask = null;
         private CancellationTokenSource _cancellationToken;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/TunnelBore.cs
@@ -28,9 +28,9 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
 
     public class TunnelBore : ITunnelBore
     {
-        private readonly object _tunnelsLock = new object();
+        private readonly object _tunnelsLock = new();
         private readonly IMlaunchProcessManager _processManager;
-        private readonly ConcurrentDictionary<string, TcpTunnel> _tunnels = new ConcurrentDictionary<string, TcpTunnel>();
+        private readonly ConcurrentDictionary<string, TcpTunnel> _tunnels = new();
 
         public TunnelBore(IMlaunchProcessManager processManager)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/AppInstallMonitorLog.cs
@@ -25,8 +25,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
         public bool CopyingWatchApp;
         public TimeSpan AppCopyDuration;
         public TimeSpan WatchAppCopyDuration;
-        public Stopwatch AppCopyStart = new Stopwatch();
-        public Stopwatch WatchAppCopyStart = new Stopwatch();
+        public Stopwatch AppCopyStart = new();
+        public Stopwatch WatchAppCopyStart = new();
         public int AppPercentComplete;
         public int WatchAppPercentComplete;
         public long AppBytes;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/LogFile.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
 {
     public class LogFile : FileBackedLog
     {
-        private readonly object _lockObj = new object();
+        private readonly object _lockObj = new();
 
         public override string FullPath { get; }
 
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Logging
             Write(bytes, 0, bytes.Length);
         }
 
-        public override StreamReader GetReader() => new StreamReader(new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+        public override StreamReader GetReader() => new(new FileStream(FullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 
         public override void Dispose()
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared
         /// </summary>
         private readonly string? _additionalLogsDirectory;
 
-        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         /// <summary>
         /// Callback needed for the Xamarin.Xharness project that does extra logging in case of a crash.

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/Helpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
         // annoying when XS reloads the projects, and also causes unnecessary rebuilds).
         // Nothing really breaks when the sequence isn't identical from run to run, so
         // this is just a best minimal effort.
-        private static readonly Random s_guidGenerator = new Random(unchecked((int)0xdeadf00d));
+        private static readonly Random s_guidGenerator = new(unchecked((int)0xdeadf00d));
         public Guid GenerateStableGuid(string seed = null)
         {
             var bytes = new byte[16];

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Utilities/PlistExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Utilities
 {
     public static class PListExtensions
     {
-        private static readonly ConditionalWeakTable<XmlDocument, string> s_filenames = new ConditionalWeakTable<XmlDocument, string>();
+        private static readonly ConditionalWeakTable<XmlDocument, string> s_filenames = new();
 
         public const string BundleExecutablePropertyName = "CFBundleExecutable";
         public const string BundleIdentifierPropertyName = "CFBundleIdentifier";

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/XmlResultParser.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.XmlResults
     public class XmlResultParser : IResultParser
     {
         private static readonly IHelpers s_helpers = new Helpers();
-        private readonly Dictionary<XmlResultJargon, (IXmlResultParser Parser, ITestReportGenerator Generator)> _xmlFormatters = new Dictionary<XmlResultJargon, (IXmlResultParser Parser, ITestReportGenerator Generator)>
+        private readonly Dictionary<XmlResultJargon, (IXmlResultParser Parser, ITestReportGenerator Generator)> _xmlFormatters = new()
         {
             { XmlResultJargon.TouchUnit, (new TouchUnitResultParser(), new TouchUnitTestReportGenerator()) },
             { XmlResultJargon.NUnitV2, (new NUnitV2ResultParser(), new NUnitV2TestReportGenerator()) },

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
         }
 
         private static AppBundleInformation GetMockedAppBundleInfo() =>
-            new AppBundleInformation(
+            new(
                 appName: AppName,
                 bundleIdentifier: AppBundleIdentifier,
                 appPath: s_appPath,

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/CommandArguments/ArgumentTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/CommandArguments/ArgumentTests.cs
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
 using Xunit;
 
 #nullable enable
-namespace Microsoft.DotNet.XHarness.Common.Tests.Utilities
+namespace Microsoft.DotNet.XHarness.CLI.Tests.Arguments
 {
     public class ArgumentTests
     {

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/Commands/XHarnessCommandTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/Commands/XHarnessCommandTests.cs
@@ -5,15 +5,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 using Mono.Options;
 using Xunit;
 
 #nullable enable
-namespace Microsoft.DotNet.XHarness.Common.Tests.Utilities
+namespace Microsoft.DotNet.XHarness.CLI.Tests.CommandArguments
 {
     public class XHarnessCommandTests
     {

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/Microsoft.DotNet.XHarness.CLI.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/Microsoft.DotNet.XHarness.CLI.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- Mono.Options is apparently not strong-name signed -->
+    <NoWarn>CS8002;</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.XHarness.CLI\Microsoft.DotNet.XHarness.CLI.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.XHarness.Common\Microsoft.DotNet.XHarness.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/UnitTestArguments.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/UnitTestArguments.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 
 #nullable enable
-namespace Microsoft.DotNet.XHarness.Common.Tests.Utilities
+namespace Microsoft.DotNet.XHarness.CLI.Tests
 {
     internal class UnitTestArguments<TArgument> : XHarnessCommandArguments where TArgument : Argument
     {

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/UnitTestCommand.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/UnitTestCommand.cs
@@ -4,13 +4,13 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common.CLI;
-using Microsoft.DotNet.XHarness.Common.CLI.CommandArguments;
-using Microsoft.DotNet.XHarness.Common.CLI.Commands;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
-namespace Microsoft.DotNet.XHarness.Common.Tests.Utilities
+namespace Microsoft.DotNet.XHarness.CLI.Tests
 {
     internal class UnitTestCommand
     {


### PR DESCRIPTION
We don't need this anymore since we moved the SimulatorInstaller inside of the CLI project so let's prevent confusion