### PR TITLE
[wasm] Add another error snippet

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -207,7 +207,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             string[] err_snippets = new[]
             {
                 "exited abnormally",
-                "Cannot start the driver service"
+                "Cannot start the driver service",
+                "failed to start"
             };
 
             foreach (var file in Directory.EnumerateFiles(Arguments.OutputDirectory, $"{driverName}-*.log"))


### PR DESCRIPTION
On windows/helix I am getting this error:

    [13:34:28] crit: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
                      ---> OpenQA.Selenium.WebDriverException: unknown error: Chrome failed to start: crashed.

Add another snippet so that Activation is repeated when we get this
error.