### PR TITLE
Remove `--reset-simulator` from `just-*` commands

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -20,7 +20,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public IncludeWirelessArgument IncludeWireless { get; } = new();
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
-        public ResetSimulatorArgument ResetSimulator { get; } = new();
         public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)ExitCode.SUCCESS);
         public SignalAppEndArgument SignalAppEnd { get; } = new();
 
@@ -38,7 +37,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             EnableLldb,
             SignalAppEnd,
             EnvironmentalVariables,
-            ResetSimulator,
         };
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -24,7 +24,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
         public ClassMethodFilters ClassMethodFilters { get; } = new();
         public EnableLldbArgument EnableLldb { get; } = new();
         public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
-        public ResetSimulatorArgument ResetSimulator { get; } = new();
         public SignalAppEndArgument SignalAppEnd { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
@@ -45,7 +44,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple
             EnableLldb,
             SignalAppEnd,
             EnvironmentalVariables,
-            ResetSimulator,
         };
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.Timeout,
                     Arguments.ExpectedExitCode,
                     Arguments.IncludeWireless,
-                    Arguments.ResetSimulator,
+                    resetSimulator: false,
                     Arguments.EnableLldb,
                     Arguments.SignalAppEnd,
                     Arguments.EnvironmentalVariables.Value,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple
                     Arguments.SingleMethodFilters.Value,
                     Arguments.ClassMethodFilters.Value,
                     includeWirelessDevices: Arguments.IncludeWireless,
-                    resetSimulator: Arguments.ResetSimulator,
+                    resetSimulator: false,
                     enableLldb: Arguments.EnableLldb,
                     signalAppEnd: Arguments.SignalAppEnd,
                     Arguments.EnvironmentalVariables.Value,


### PR DESCRIPTION
Resetting the simulator doesn't make sense since we expect the application to be already installed