### PR TITLE
Redirect simulator logs into a separate file

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -271,14 +271,13 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
-            var appErrorLog = _logs.CreateFile(appInformation.BundleIdentifier + ".err.log", LogType.ApplicationLog);
-
             var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag: null);
 
             args.Add(new SimulatorUDIDArgument(simulator.UDID));
+
+            var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
             args.Add(new SetStdoutArgument(appLog));
-            args.Add(new SetStderrArgument(appErrorLog));
+            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data
 
             if (appInformation.Extension.HasValue)
             {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
             args.Add(new SetStdoutArgument(appLog));
-            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data
+            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data, however stderr captures stdout of the app too
 
             if (appInformation.Extension.HasValue)
             {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -102,7 +102,6 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             var isSimulator = target.Platform.IsSimulator();
             using var crashLogs = new Logs(_logs.Directory);
-            var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
             ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(
                 _mainLog,
@@ -112,50 +111,50 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{device.Name}' ***");
 
-            string? appEndTag = null;
-            if (signalAppEnd)
-            {
-                WatchForAppEndTag(out appEndTag, ref appOutputLog, ref cancellationToken);
-            }
 
-            using (appOutputLog)
+            if (isSimulator)
             {
-                if (isSimulator)
+                simulator = device as ISimulatorDevice;
+                companionSimulator = companionDevice as ISimulatorDevice;
+
+                if (simulator == null)
                 {
-                    simulator = device as ISimulatorDevice;
-                    companionSimulator = companionDevice as ISimulatorDevice;
-
-                    if (simulator == null)
-                    {
-                        _mainLog.WriteLine("Didn't find any suitable simulator");
-                        throw new NoDeviceFoundException();
-                    }
-
-                    var mlaunchArguments = GetSimulatorArguments(
-                        appInformation,
-                        simulator,
-                        extraAppArguments,
-                        extraEnvVariables,
-                        appEndTag);
-
-                    result = await RunSimulatorApp(
-                        mlaunchArguments,
-                        crashReporter,
-                        simulator,
-                        companionSimulator,
-                        appOutputLog,
-                        timeout,
-                        cancellationToken);
+                    _mainLog.WriteLine("Didn't find any suitable simulator");
+                    throw new NoDeviceFoundException();
                 }
-                else
+
+                var mlaunchArguments = GetSimulatorArguments(
+                    appInformation,
+                    simulator,
+                    extraAppArguments,
+                    extraEnvVariables);
+
+                result = await RunSimulatorApp(
+                    mlaunchArguments,
+                    crashReporter,
+                    simulator,
+                    companionSimulator,
+                    timeout,
+                    cancellationToken);
+            }
+            else
+            {
+                var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+                string? appEndTag = null;
+                if (signalAppEnd)
+                {
+                    WatchForAppEndTag(out appEndTag, ref appOutputLog, ref cancellationToken);
+                }
+
+                using (appOutputLog)
                 {
                     var mlaunchArguments = GetDeviceArguments(
-                        appInformation,
-                        device,
-                        target.Platform.IsWatchOSTarget(),
-                        extraAppArguments,
-                        extraEnvVariables,
-                        appEndTag);
+                    appInformation,
+                    device,
+                    target.Platform.IsWatchOSTarget(),
+                    extraAppArguments,
+                    extraEnvVariables,
+                    appEndTag);
 
                     result = await RunDeviceApp(
                         mlaunchArguments,
@@ -166,9 +165,9 @@ namespace Microsoft.DotNet.XHarness.Apple
                         timeout,
                         cancellationToken);
                 }
-
-                return result;
             }
+
+            return result;
         }
 
         private async Task<ProcessExecutionResult> RunSimulatorApp(
@@ -176,7 +175,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             ICrashSnapshotReporter crashReporter,
             ISimulatorDevice simulator,
             ISimulatorDevice? companionSimulator,
-            ILog appOutputLog,
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
@@ -215,13 +213,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             _mainLog.WriteLine("Starting test run");
 
-            return await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
-                mlaunchArguments,
-                _mainLog,
-                appOutputLog,
-                appOutputLog,
-                timeout,
-                cancellationToken: cancellationToken));
+            return await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
         }
 
         private async Task<ProcessExecutionResult> RunDeviceApp(
@@ -254,7 +246,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 cancellationToken: cancellationToken));
         }
 
-        private static MlaunchArguments GetCommonArguments(
+        private MlaunchArguments GetCommonArguments(
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables,
             string? appEndTag)
@@ -273,16 +265,19 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private static MlaunchArguments GetSimulatorArguments(
+        private MlaunchArguments GetSimulatorArguments(
             AppBundleInformation appInformation,
             ISimulatorDevice simulator,
             IEnumerable<string> extraAppArguments,
-            IEnumerable<(string, string)> extraEnvVariables,
-            string? appEndTag)
+            IEnumerable<(string, string)> extraEnvVariables)
         {
-            var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag);
+            var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
+            var appErrorLog = _logs.CreateFile(appInformation.BundleIdentifier + ".err.log", LogType.ApplicationLog);
+            var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag: null);
 
             args.Add(new SimulatorUDIDArgument(simulator.UDID));
+            args.Add(new SetStdoutArgument(appLog));
+            args.Add(new SetStderrArgument(appErrorLog));
 
             if (appInformation.Extension.HasValue)
             {
@@ -304,7 +299,7 @@ namespace Microsoft.DotNet.XHarness.Apple
             return args;
         }
 
-        private static MlaunchArguments GetDeviceArguments(
+        private MlaunchArguments GetDeviceArguments(
             AppBundleInformation appInformation,
             IDevice device,
             bool isWatchTarget,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -273,6 +273,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         {
             var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
             var appErrorLog = _logs.CreateFile(appInformation.BundleIdentifier + ".err.log", LogType.ApplicationLog);
+
             var args = GetCommonArguments(extraAppArguments, extraEnvVariables, appEndTag: null);
 
             args.Add(new SimulatorUDIDArgument(simulator.UDID));

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -536,9 +536,6 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> extraAppArguments,
             IEnumerable<(string, string)> extraEnvVariables)
         {
-            var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
-            var appErrorLog = _logs.CreateFile(appInformation.BundleIdentifier + ".err.log", LogType.ApplicationLog);
-
             var args = GetCommonArguments(
                 xmlResultJargon,
                 skippedMethods,
@@ -552,8 +549,10 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "127.0.0.1"));
             args.Add(new SimulatorUDIDArgument(simulator));
+
+            var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
             args.Add(new SetStdoutArgument(appLog));
-            args.Add(new SetStderrArgument(appErrorLog));
+            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data
 
             if (appInformation.Extension.HasValue)
             {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -555,7 +555,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
             args.Add(new SetStdoutArgument(appLog));
-            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data
+            args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data, however stderr captures stdout of the app too
 
             if (appInformation.Extension.HasValue)
             {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -173,7 +173,10 @@ namespace Microsoft.DotNet.XHarness.Apple
 
                 _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{device.Name}' ***");
 
-                using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(testReporter.CancellationToken, cancellationToken);
+                using var combinedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
+                    testReporter.CancellationToken,
+                    cancellationToken);
+                cancellationToken = combinedCancellationToken.Token;
 
                 if (isSimulator)
                 {
@@ -196,7 +199,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                         (ISimulatorDevice)device,
                         companionDevice as ISimulatorDevice,
                         timeout,
-                        combinedCancellationToken.Token);
+                        cancellationToken);
                 }
                 else
                 {
@@ -232,7 +235,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                             appOutputLog,
                             timeout,
                             extraEnvVariables,
-                            combinedCancellationToken.Token);
+                            cancellationToken);
                     }
                 }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -140,6 +140,12 @@ namespace Microsoft.DotNet.XHarness.Apple
             IEnumerable<string> passthroughArguments,
             CancellationToken cancellationToken)
         {
+            var runMode = target.Platform.ToRunMode();
+            if (signalAppEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
+            {
+                _logger.LogWarning("The --signal-app-end option is used for device tests and has no effect on simulators");
+            }
+
             _logger.LogInformation($"Starting application '{appBundleInfo.AppName}' on '{device.Name}'");
 
             ProcessExecutionResult result = await _appRunner.RunApp(

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.XHarness.Apple
 
             if (signalAppEnd && (runMode == RunMode.Sim64 || runMode == RunMode.Sim32))
             {
-                _logger.LogWarning("The --signal-app-end option is recommended for device tests and is not required for simulators");
+                _logger.LogWarning("The --signal-app-end option is used for device tests and has no effect on simulators");
             }
 
             _logger.LogInformation("Starting test run for " + appBundleInfo.BundleIdentifier + "..");

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunTestBase.cs
@@ -74,6 +74,9 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                 .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
                 .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
             _logs
+                .Setup(x => x.CreateFile(AppBundleIdentifier + ".log", LogType.ApplicationLog))
+                .Returns(_stdoutLog.FullPath);
+            _logs
                 .Setup(x => x.Create(AppBundleIdentifier + ".log", LogType.ApplicationLog.ToString(), It.IsAny<bool?>()))
                 .Returns(_stdoutLog);
             _logs

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppRunnerTests.cs
@@ -71,8 +71,6 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
                     x => x.ExecuteCommandAsync(
                        It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                        It.IsAny<ILog>(),
-                       It.IsAny<ILog>(),
-                       It.IsAny<ILog>(),
                        It.IsAny<TimeSpan>(),
                        It.IsAny<Dictionary<string, string>>(),
                        It.IsAny<int>(),
@@ -342,6 +340,8 @@ namespace Microsoft.DotNet.XHarness.Apple.Tests
             "-argument=--xyz " +
             "-setenv=appArg1=value1 " +
             $"--device=:v2:udid={_mockSimulator.UDID} " +
+            $"--stdout=./{AppBundleIdentifier}.log " +
+            $"--stderr=./{AppBundleIdentifier}.log " +
             $"--launchsimbundleid={AppBundleIdentifier}";
 
         private void SetupLogList(IEnumerable<IFileBackedLog> logs)


### PR DESCRIPTION
Use mlaunch capability that can redirect the output. Do this for Simulators only so that `--signal-app-end` keeps working for devices

Fixes #653 