### PR TITLE
Added NodeJS Engine

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineArgument.cs
@@ -42,5 +42,9 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         /// SpiderMonkey
         /// </summary>
         SpiderMonkey,
+        /// <summary>
+        /// NodeJS
+        /// </summary>
+        NodeJS,
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -56,17 +56,19 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var engineBinary = Arguments.Engine.Value switch
             {
                 JavaScriptEngine.V8 => "v8",
-                JavaScriptEngine.NodeJS => "node",
                 JavaScriptEngine.JavaScriptCore => "jsc",
                 JavaScriptEngine.SpiderMonkey => "sm",
+                JavaScriptEngine.NodeJS => "node",
                 _ => throw new ArgumentException("Engine not set")
             };
 
-            if (engineBinary.Equals("node"))
-                engineBinary = FindEngineInPath(engineBinary + ".exe"); // NodeJS ships as .exe rather than .cmd
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                if (engineBinary.Equals("node"))
+                    engineBinary = FindEngineInPath(engineBinary + ".exe"); // NodeJS ships as .exe rather than .cmd
 
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                engineBinary = FindEngineInPath(engineBinary + ".cmd");
+                else
+                    engineBinary = FindEngineInPath(engineBinary + ".cmd");
+            }
 
             var webServerCts = new CancellationTokenSource();
             try

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -56,12 +56,16 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             var engineBinary = Arguments.Engine.Value switch
             {
                 JavaScriptEngine.V8 => "v8",
+                JavaScriptEngine.NodeJS => "node",
                 JavaScriptEngine.JavaScriptCore => "jsc",
                 JavaScriptEngine.SpiderMonkey => "sm",
                 _ => throw new ArgumentException("Engine not set")
             };
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (engineBinary.Equals("node"))
+                engineBinary = FindEngineInPath(engineBinary + ".exe"); // NodeJS ships as .exe rather than .cmd
+
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 engineBinary = FindEngineInPath(engineBinary + ".cmd");
 
             var webServerCts = new CancellationTokenSource();


### PR DESCRIPTION
Added a `NodeJS` engine when running xharness.

## Why is this needed
I am adding NodeJS support to MONO WASM (dotnet/runtime) and so this change would facilitate the testing as well as future maintenance of this feature.

## How is it used
Exactly the same as V8 or any other JavaScript engine.
Example: `XHarness wasm test --app=. --output-directory=".\xharness-output" --engine=NodeJS  --js-file=runtime.js   --   --run WasmTestRunner.dll System.AppContext.Tests.dll  -notrait category=OuterLoop -notrait category=failing` (this command runs some of the tests in dotnet/runtime on NodeJS)