### PR TITLE
Disable PreEnumerateTheories in default TestAssemblyConfiguration for iOS/Android

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -1081,7 +1081,7 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
             {
                 using (var discoverySink = new TestDiscoverySink())
                 {
-                    var configuration = GetConfiguration(assembly) ?? new TestAssemblyConfiguration();
+                    var configuration = GetConfiguration(assembly) ?? new TestAssemblyConfiguration() { PreEnumerateTheories = false };
                     ITestFrameworkDiscoveryOptions discoveryOptions = GetFrameworkOptionsForDiscovery(configuration);
                     discoveryOptions.SetSynchronousMessageReporting(true);
                     Logger.OnDebug($"Starting test discovery in the '{assembly}' assembly");


### PR DESCRIPTION
It's already disabled for Browser and according to https://github.com/xunit/xunit/issues/1746#issuecomment-412313820 the theory pre-enumeration only makes sense for UI scenarios like VS test explorer, which doesn't apply for xharness.

This should also speed up test discovery: https://github.com/dotnet/runtime/pull/55643#issuecomment-880013700