### PR TITLE
[wasm] new argument --background-throttling

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BackgroundThrottlingArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/BackgroundThrottlingArgument.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
+{
+    internal class BackgroundThrottlingArgument : SwitchArgument
+    {
+        public BackgroundThrottlingArgument()
+            : base("background-throttling", "Hide browser tab and don't prevent timer throttling", false)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public NoIncognitoArgument NoIncognito { get; } = new();
         public NoHeadlessArgument NoHeadless { get; } = new();
         public NoQuitArgument NoQuit { get; } = new();
+        public BackgroundThrottlingArgument BackgroundThrottling { get; } = new();
 
         public WebServerMiddlewareArgument WebServerMiddlewarePathsAndTypes { get; } = new();
         public WebServerHttpEnvironmentVariables WebServerHttpEnvironmentVariables { get; } = new();
@@ -46,6 +47,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             NoIncognito,
             NoHeadless,
             NoQuit,
+            BackgroundThrottling,
             WebServerMiddlewarePathsAndTypes,
             WebServerHttpEnvironmentVariables,
             WebServerHttpsEnvironmentVariables,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -81,6 +81,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                     Task.Delay(_arguments.Timeout)
                 };
 
+                if (_arguments.BackgroundThrottling)
+                {
+                    // throttling only happens when the page is not visible
+                    driver.Manage().Window.Minimize();
+                }
+
                 var task = await Task.WhenAny(tasks).ConfigureAwait(false);
                 if (task == tasks[^1] || cts.IsCancellationRequested)
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
 
             options.AddArguments(Arguments.BrowserArgs.Value);
 
-            if (!Arguments.NoHeadless)
+            if (!Arguments.NoHeadless && !Arguments.BackgroundThrottling)
                 options.AddArguments("--headless");
 
             if (Arguments.DebuggerPort.Value != null)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -171,20 +171,31 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             if (!Arguments.NoIncognito)
                 options.AddArguments("--incognito");
 
+            if (!Arguments.BackgroundThrottling)
+            {
+                options.AddArguments(new[]
+                {
+                    "--disable-background-timer-throttling",
+                    "--disable-backgrounding-occluded-windows",
+                    "--disable-renderer-backgrounding",
+                    "--enable-features=NetworkService,NetworkServiceInProcess",
+                });
+            }
+            else
+            {
+                options.AddArguments(@"--enable-features=IntensiveWakeUpThrottling:grace_period_seconds/1");
+            }
+
             options.AddArguments(new[]
             {
                 // added based on https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts#L159-L181
-                "--enable-features=NetworkService,NetworkServiceInProcess",
                 "--allow-insecure-localhost",
-                "--disable-background-timer-throttling",
-                "--disable-backgrounding-occluded-windows",
                 "--disable-breakpad",
                 "--disable-component-extensions-with-background-pages",
                 "--disable-dev-shm-usage",
                 "--disable-extensions",
                 "--disable-features=TranslateUI",
                 "--disable-ipc-flooding-protection",
-                "--disable-renderer-backgrounding",
                 "--force-color-profile=srgb",
                 "--metrics-recording-only"
             });


### PR DESCRIPTION
new argument `--background-throttling` 
- to minimize browser and don't make it headless
- not prevent timer throttling via browser arguments

Only works for Chrome and Edge
