### PR TITLE
Fix regression with wasm test commands

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/DebuggerPortArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/DebuggerPortArgument.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
     internal class DebuggerPortArgument : Argument<int?>
     {
         public DebuggerPortArgument()
-            : base("debugger=|d=", "Run browser in debug mode, with a port to listen on. Default port number is 9222", null)
+            : base("debugger=", "Run browser in debug mode, with a port to listen on. Default port number is 9222", null)
         {
         }
         public override void Action(string argumentValue)


### PR DESCRIPTION
```
+ ./RunTests.sh
XHarness command issued: wasm test-browser --app=. --output-directory=/datadisks/disk1/work/A75F0978/w/A089091A/uploads/xharness-output --engine=V8 --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js -- --run WasmTestRunner.dll Microsoft.Extensions.Configuration.CommandLine.Tests.dll -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: d
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at Mono.Options.OptionSet.AddImpl(Option option)
   at Mono.Options.OptionSet.InsertItem(Int32 index, Option item)
   at System.Collections.ObjectModel.Collection`1.Add(T item)
   at Mono.Options.OptionSet.Add(String prototype, String description, Action`1 action, Boolean hidden)
   at Microsoft.DotNet.XHarness.CLI.Commands.XHarnessCommand`1.Invoke(IEnumerable`1 arguments) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessCommand.cs:line 76
   at Mono.Options.CommandSet.Run(IEnumerable`1 arguments)
   at Microsoft.DotNet.XHarness.CLI.Program.Main(String[] args) in /_/src/Microsoft.DotNet.XHarness.CLI/Program.cs:line 49
./RunTests.sh: line 29:  8715 Aborted                 (core dumped) $HARNESS_RUNNER wasm $XHARNESS_COMMAND --app=. --output-directory=$XHARNESS_OUT --engine=V8 --engine-arg=--stack-trace-limit=1000 --js-file=runtime.js $WasmXHarnessArgs -- $WasmXHarnessMonoArgs --run WasmTestRunner.dll Microsoft.Extensions.Configuration.CommandLine.Tests.dll $WasmTestAppArgs -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing $RSP_FILE
```

fixes https://github.com/dotnet/xharness/issues/705