### PR TITLE
Allow printing ADB path using `xharness android state --adb`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.XHarness.Android
 
         public int APIVersion => _api ?? GetAPIVersion();
 
+        public string AdbExePath => _absoluteAdbExePath;
+
         public AdbRunner(ILogger log, string adbExePath = "") : this(log, new AdbProcessManager(log), adbExePath) { }
 
         public AdbRunner(ILogger log, IAdbProcessManager processManager, string adbExePath = "")
@@ -51,17 +53,20 @@ namespace Microsoft.DotNet.XHarness.Android
                 _log.LogDebug($"Using {AdbEnvironmentVariableName} environment variable ({environmentPath}) for ADB path.");
                 adbExePath = environmentPath;
             }
+
             if (string.IsNullOrEmpty(adbExePath))
             {
                 adbExePath = GetCliAdbExePath();
             }
 
             _absoluteAdbExePath = Path.GetFullPath(Environment.ExpandEnvironmentVariables(adbExePath));
+
             if (!File.Exists(_absoluteAdbExePath))
             {
                 _log.LogError($"Unable to find adb.exe");
                 throw new FileNotFoundException($"Could not find adb.exe. Either set it in the environment via {AdbEnvironmentVariableName} or call with valid path (provided:  '{adbExePath}')", adbExePath);
             }
+
             if (!_absoluteAdbExePath.Equals(adbExePath))
             {
                 _log.LogDebug($"ADBRunner using ADB.exe supplied from {adbExePath}");

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
@@ -1,14 +1,18 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
 {
     internal class AndroidGetStateCommandArguments : XHarnessCommandArguments
     {
-        protected override IEnumerable<Argument> GetArguments() => Enumerable.Empty<Argument>();
+        public ShowAdbPathArgument ShowAdbPath { get; set; } = new();
+
+        protected override IEnumerable<Argument> GetArguments() => new Argument[]
+        {
+            ShowAdbPath
+        };
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ShowAdbPathArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ShowAdbPathArgument.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android
+{
+    internal class ShowAdbPathArgument : SwitchArgument
+    {
+        public ShowAdbPathArgument() : base("adb|show-adb-path", "Prints ONLY path to the adb executable XHarness is using", false)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -25,10 +25,17 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android
 
         protected override Task<ExitCode> InvokeInternal(ILogger logger)
         {
+            var runner = new AdbRunner(logger);
+
+            if (Arguments.ShowAdbPath)
+            {
+                Console.WriteLine(runner.AdbExePath);
+                return Task.FromResult(ExitCode.SUCCESS);
+            }
+
             logger.LogInformation("Getting state of ADB and attached Android device(s)");
             try
             {
-                var runner = new AdbRunner(logger);
                 string state = runner.GetAdbState();
                 if (string.IsNullOrEmpty(state))
                 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Program.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Program.cs
@@ -98,10 +98,21 @@ namespace Microsoft.DotNet.XHarness.CLI
 
             switch (args[0])
             {
-                case "ios":
                 case "apple":
-                case "android":
                     return args[1] == "device";
+
+                case "android":
+                    if (args[1] == "device")
+                    {
+                        return true;
+                    }
+
+                    if (args[1] == "state" && args.Contains("--adb"))
+                    {
+                        return true;
+                    }
+
+                    return false;
             }
 
             return false;


### PR DESCRIPTION
Needed for https://github.com/dotnet/arcade/pull/7970 and for dotnet performance tests

Also drops "Get" from "*GetDevice" and "*GetState" commands to follow the rest of the commandset