### PR TITLE
Fix race condition in SimpleFileListener

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleFileListener.cs
@@ -57,18 +57,17 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Listeners
                         else if (!_xmlOutput && line.StartsWith("Tests run: ", StringComparison.Ordinal))
                         {
                             Log.WriteLine("Tests have finished executing");
-                            Finished();
-                            return;
+                            break;
                         }
                         else if (_xmlOutput && line == "<!-- the end -->")
                         {
                             Log.WriteLine("Tests have finished executing");
-                            Finished();
-                            return;
+                            break;
                         }
                     }
                 }
             }
+            Finished();
         }
 
         private class BlockingFileStream : FileStream


### PR DESCRIPTION
The race condition goes like this:

* SimpleFileListener reads from one file, and writes to another.
* The reading will block until the SimpleFileListener is cancelled and
  everything has been read from the file (and written to the other file).
* When the SimpleFileListener is cancelled, the blocking read will detect
  this, and once everything has been read and written, call
  SimpleFileListener.Finished to mark that the blocking read/write was
  finished.
* The call to SimpleFileListener.Finished would notify anybody waiting for the
  listener to finish that the listener was done.
* Those waiters would now read from the listener's file output.
* The blocking read/write method would flush the output stream (because the
  call to SimpleFileListener.Finished happened inside the 'using' clause).

The fix is to move the call to SimpleFileListener.Finished to outside the
'using' clause of the output stream.