### PR TITLE
Revert "Disable tvOS 15.0 device tests in the PR pipeline"

### DIFF
--- a/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.tvOS.Tests.proj
@@ -3,10 +3,7 @@
 
     <ItemGroup>
         <HelixTargetQueue Include="osx.1015.amd64.appletv.open"/>
-        <!--
-        Disabled because of https://github.com/dotnet/xharness/issues/735
         <HelixTargetQueue Include="osx.1100.amd64.appletv.open"/>
-        -->
 
         <!-- apple test / tvos-device -->
         <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">


### PR DESCRIPTION
tvOS 15 device setup is complete now (https://github.com/dotnet/core-eng/issues/14662)

This reverts commit 63fdb286a2207cb1fd85a70118e1bd1d875fe5f6