### PR TITLE
Make ProcessManager logs more clear to read

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
             };
 
             var sb = new StringBuilder();
-            sb.AppendLine($"Running {StringUtils.Quote(process.StartInfo.FileName)} {process.StartInfo.Arguments}");
+            sb.Append($"Running {StringUtils.Quote(process.StartInfo.FileName)} {process.StartInfo.Arguments}");
 
             if (process.StartInfo.EnvironmentVariables != null)
             {
@@ -272,15 +272,17 @@ namespace Microsoft.DotNet.XHarness.Common.Execution
                     {
                         if (!headerShown)
                         {
-                            sb.Append("With env vars: ");
+                            sb.AppendLine().Append("With env vars: ");
                             headerShown = true;
                         }
 
-                        sb.Append($"{variable}={StringUtils.Quote(b)} ");
+                        sb.AppendLine().Append($"    {variable} = '{StringUtils.Quote(b)}'");
                     }
                 }
             }
 
+            // Separate process calls in logs
+            log.WriteLine(string.Empty);
             log.WriteLine(sb.ToString());
 
             process.Start();


### PR DESCRIPTION
Makes blocks belonging to the same app
```
...
[02:37:10.4312410] Running /Applications/Xcode115.app/Contents/Developer/usr/bin/simctl uninstall 0FECC678-839F-4AB9-9B14-68610B557F61 net.dot.Microsoft.Extensions.Logging.Testing.Tests

[02:37:10.9823530] An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=165):
[02:37:10.9835900] Unable to lookup in current state: Shutdown
[02:37:10.9842920] Process simctl exited with 165
[02:37:10.9939120] Installing '/tmp/helix/working/AF0B0974/w/AC370925/e/Microsoft.Extensions.Logging.Testing.Tests.app' to 'iPhone X (iOS 13.5) - created by XHarness' (36.05 MB)
```

connect visually for easier reading:
```
...

[02:37:10.4312410] Running /Applications/Xcode115.app/Contents/Developer/usr/bin/simctl uninstall 0FECC678-839F-4AB9-9B14-68610B557F61 net.dot.Microsoft.Extensions.Logging.Testing.Tests
[02:37:10.9823530] An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=165):
[02:37:10.9835900] Unable to lookup in current state: Shutdown
[02:37:10.9842920] Process simctl exited with 165
[02:37:10.9939120] Installing '/tmp/helix/working/AF0B0974/w/AC370925/e/Microsoft.Extensions.Logging.Testing.Tests.app' to 'iPhone X (iOS 13.5) - created by XHarness' (36.05 MB)
```