### PR TITLE
Detect broken Simulator state when uninstalling the application

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         protected override Task CleanUpSimulators(IDevice device, IDevice? companionDevice)
             => Task.CompletedTask; // no-op so that we don't remove the app after (reset will only clean it up before)
 
-        protected override Task UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
+        protected override Task<ExitCode> UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
         {
             // For the installation, we want to uninstall during preparation only
             if (isPreparation)
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.XHarness.Apple
                 return base.UninstallApp(target, bundleIdentifier, device, isPreparation, cancellationToken);
             }
 
-            return Task.CompletedTask;
+            return Task.FromResult(ExitCode.SUCCESS);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         protected override Task<ExitCode> InstallApp(AppBundleInformation appBundleInfo, IDevice device, TestTargetOs target, CancellationToken cancellationToken)
             => Task.FromResult(ExitCode.SUCCESS); // no-op - we only want to run the app
 
-        protected override Task UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
-            => Task.CompletedTask; // no-op - we only want to run the app
+        protected override Task<ExitCode> UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
+            => Task.FromResult(ExitCode.SUCCESS); // no-op - we only want to run the app
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.XHarness.Apple
         protected override Task<ExitCode> InstallApp(AppBundleInformation appBundleInfo, IDevice device, TestTargetOs target, CancellationToken cancellationToken)
             => Task.FromResult(ExitCode.SUCCESS); // no-op - we only want to run the app
 
-        protected override Task UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
-            => Task.CompletedTask; // no-op - we only want to run the app
+        protected override Task<ExitCode> UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
+            => Task.FromResult(ExitCode.SUCCESS); // no-op - we only want to run the app
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
@@ -78,12 +78,12 @@ namespace Microsoft.DotNet.XHarness.Apple
         protected override Task<ExitCode> InstallApp(AppBundleInformation appBundleInfo, IDevice device, TestTargetOs target, CancellationToken cancellationToken)
             => Task.FromResult(ExitCode.SUCCESS); // no-op - we only want to uninstall the app
 
-        protected override Task UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
+        protected override Task<ExitCode> UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
         {
             // For the uninstallation, we don't want to uninstall twice so we skip the preparation one
             if (isPreparation)
             {
-                return Task.CompletedTask;
+                return Task.FromResult(ExitCode.SUCCESS);
             }
 
             return base.UninstallApp(target, bundleIdentifier, device, isPreparation, cancellationToken);


### PR DESCRIPTION
Recognizes a bad state from a specific exit code and then exits with `SIMULATOR_FAILURE` exit code instead.
Prevents hangs when running the application.

Resolves https://github.com/dotnet/core-eng/issues/14799

> Note: This will make the machines reboot in Helix when the simulator is stuck in this state as we already reboot on `SIMULATOR_FAILURE`