### PR TITLE
[wasm] Add mime-type for alternate javascript file extensions

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -123,6 +123,8 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands
             {
                 var provider = new FileExtensionContentTypeProvider();
                 provider.Mappings[".wasm"] = "application/wasm";
+                provider.Mappings[".cjs"] = "text/javascript";
+                provider.Mappings[".mjs"] = "text/javascript";
 
                 foreach (var extn in new string[] { ".dll", ".pdb", ".dat", ".blat" })
                 {


### PR DESCRIPTION
- `.mjs` - ES6 module
- `.cjs` - commonJS module

So that the files could be hosted by xharness for tests.