### PR TITLE
Fix console output flushing in WASM XUnit runner

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             {
                 if (line.Contains("STARTRESULTXML"))
                 {
+                    _logger.LogDebug("Reached start of testResults.xml");
                     _xmlResultsFileWriter = File.CreateText(_xmlResultsFilePath);
                     return;
                 }
@@ -113,6 +114,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             {
                 if (line.Contains("ENDRESULTXML"))
                 {
+                    _logger.LogDebug("Reached end of testResults.xml");
                     _xmlResultsFileWriter.Flush();
                     _xmlResultsFileWriter.Dispose();
                     _xmlResultsFileWriter = null;
@@ -128,6 +130,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             // has been written to the console
             if (line.StartsWith("WASM EXIT"))
             {
+                _logger.LogDebug("Reached wasm exit");
                 WasmExitReceivedTcs.SetResult(true);
             }
         }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -69,12 +69,13 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
                 Console.WriteLine($"STARTRESULTXML");
                 var resultsXml = new XElement("assemblies");
                 resultsXml.Add(resultsXmlAssembly);
-                resultsXml.Save(Console.OpenStandardOutput());
+                resultsXml.Save(Console.Out);
                 Console.WriteLine();
                 Console.WriteLine($"ENDRESULTXML");
             }
 
             var failed = resultsSink.ExecutionSummary.Failed > 0 || resultsSink.ExecutionSummary.Errors > 0;
+            Console.Out.Flush();
             return failed ? 1 : 0;
         }
     }


### PR DESCRIPTION
- TestResults.xml was not complete under some circumstances.
- Sometimes it happend that WASM exit code was written before last messages from Console.WriteLine.
- Add debug log lines when testResults.xml is found during WASM messages processing.