### PR TITLE
Enforce the MacOS 10.15 pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,7 @@ stages:
         - job: OSX
           pool:
             name: Hosted macOS
+            vmImage: macOS-10.15
           strategy:
             matrix:
               Release:


### PR DESCRIPTION
- XHarness is used on 10.15 the most
- We are being warned about 10.14 being deprecated even though we didn't specify 10.14 anywhere