### PR TITLE
New switch "web-server-use-cop" for webserver to set Cross-Origin-Policy headers

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseCrossOriginPolicyArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUseCrossOriginPolicyArguments.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments
+{
+    internal class WebServerUseCrossOriginPolicyArguments : SwitchArgument
+    {
+        public WebServerUseCrossOriginPolicyArguments()
+            : base("web-server-use-cop", "Sets Cross-Origin-Opener-Policy=same-origin and Cross-Origin-Embedder-Policy=require-corp", false)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/IWebServerArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/IWebServerArguments.cs
@@ -11,5 +11,6 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         WebServerHttpsEnvironmentVariables WebServerHttpsEnvironmentVariables { get; }
         WebServerUseHttpsArguments WebServerUseHttps { get; }
         WebServerUseCorsArguments WebServerUseCors { get; }
+        WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public WebServerHttpsEnvironmentVariables WebServerHttpsEnvironmentVariables { get; } = new();
         public WebServerUseHttpsArguments WebServerUseHttps { get; } = new();
         public WebServerUseCorsArguments WebServerUseCors { get; } = new();
+        public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -53,6 +54,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             WebServerHttpsEnvironmentVariables,
             WebServerUseHttps,
             WebServerUseCors,
+            WebServerUseCrossOriginPolicy,
         };
 
         public override void Validate()

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
         public WebServerHttpsEnvironmentVariables WebServerHttpsEnvironmentVariables { get; } = new();
         public WebServerUseHttpsArguments WebServerUseHttps { get; } = new();
         public WebServerUseCorsArguments WebServerUseCors { get; } = new();
+        public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
 
         protected override IEnumerable<Argument> GetArguments() => new Argument[]
         {
@@ -37,6 +38,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm
             WebServerHttpsEnvironmentVariables,
             WebServerUseHttps,
             WebServerUseCors,
+            WebServerUseCrossOriginPolicy,
         };
     }
 }


### PR DESCRIPTION
Enabling the switch the webserver will serve all requests with these response headers

```
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin
```