### PR TITLE
Add script for running E2E tests on Windows

### DIFF
--- a/tools/install-xharness.sh
+++ b/tools/install-xharness.sh
@@ -36,7 +36,7 @@ chmod u+x "$dotnet_install"
 dotnet_dir="$here/.dotnet"
 
 printf "Installing .NET SDK locally to \033[0;33m%s\033[0m..\n" "$dotnet_dir"
-$dotnet_install --install-dir "$dotnet_dir" --version "6.0.100-rc.1.21430.12"
+$dotnet_install --install-dir "$dotnet_dir" --version "6.0.100"
 echo 'dotnet installed'
 
 export DOTNET_ROOT="$here/.dotnet"

--- a/tools/run-e2e-test.ps1
+++ b/tools/run-e2e-test.ps1
@@ -1,15 +1,21 @@
-### This script is a quick way to run the XHarness E2E tests.
-### These test are located in tests/integration-tests and require the Arcade and Helix SDK.
-### To run them, you need to invoke these through MSBuild which makes the process a bit cumbersome.
-### This script should make things easier.
-###
-### Usage: .\run-e2e-test.ps1 -TestProject Apple/SimulatorInstaller.Tests.proj [-SkipBuild]
+<#
+.SYNOPSIS
+  This script is a quick way to run the XHarness E2E tests.
+  These test are located in tests/integration-tests and require the Arcade and Helix SDK.
+  To run them, you need to invoke these through MSBuild which makes the process a bit cumbersome.
+  This script should make things easier.
+
+.EXAMPLE
+  .\run-e2e-test.ps1 -TestProject Apple/SimulatorInstaller.Tests.proj [-SkipBuild]
+#>
 
 param (
+    <# Path to the test project. Can be also relative to tests/integration-tests, e.g. Apple/Device.iOS.Tests.proj #>
     [Parameter(Mandatory = $true)]
     [string]
     $TestProject,
-    
+
+    <# Skip re-building the local package #>
     [switch]
     $SkipBuild = $false
 )
@@ -57,7 +63,7 @@ if ($SkipBuild) {
 
 $Env:BUILD_REASON = "pr"
 $Env:BUILD_REPOSITORY_NAME = "arcade"
-$Env:BUILD_SOURCEBRANCH = "prvysoky"
+$Env:BUILD_SOURCEBRANCH = "test"
 $Env:SYSTEM_TEAMPROJECT = "dnceng"
 $Env:SYSTEM_ACCESSTOKEN = ""
 

--- a/tools/run-e2e-test.ps1
+++ b/tools/run-e2e-test.ps1
@@ -1,0 +1,66 @@
+### This script is a quick way to run the XHarness E2E tests.
+### These test are located in tests/integration-tests and require the Arcade and Helix SDK.
+### To run them, you need to invoke these through MSBuild which makes the process a bit cumbersome.
+### This script should make things easier.
+###
+### Usage: .\run-e2e-test.ps1 -TestProject Apple/SimulatorInstaller.Tests.proj [-SkipBuild]
+
+param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $TestProject,
+    
+    [switch]
+    $SkipBuild = $false
+)
+
+$repoRoot = "$PSScriptRoot\.."
+
+function Write-Projects {
+    Write-Output "Possible options:"
+    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\Android"
+    foreach ($item in $files) {
+        '  - Android\{0}' -f $item.Name
+    }
+
+    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\Apple"
+    foreach ($item in $files) {
+        '  - Apple\{0}' -f $item.Name
+    }
+
+    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\WASM"
+    foreach ($item in $files) {
+        '  - WASM\{0}' -f $item.Name
+    }
+}
+
+if (-not(Test-Path -Path $TestProject -PathType Leaf)) {
+    $TestProject = "$repoRoot\tests\integration-tests\$TestProject"
+
+    if (-not(Test-Path -Path $TestProject -PathType Leaf)) {
+        Write-Error "The file $TestProject not found"
+        Write-Projects
+        Exit 1
+    }
+}
+
+if ($SkipBuild) {
+    Write-Host -ForegroundColor Cyan "> Skipping build"
+} else {
+    Write-Host -ForegroundColor Cyan "> Building Microsoft.DotNet.XHarness.CLI.1.0.0-dev.nupkg"
+
+    Remove-Item -Recurse -ErrorAction SilentlyContinue "$repoRoot\artifacts\tmp\Debug\Microsoft.DotNet.XHarness.CLI"
+    Remove-Item -Recurse -ErrorAction SilentlyContinue "$repoRoot\artifacts\artifacts\packages"
+
+    & "$repoRoot\Build.cmd" -pack -projects "$repoRoot\src\Microsoft.DotNet.XHarness.CLI\Microsoft.DotNet.XHarness.CLI.csproj"
+}
+
+$Env:BUILD_REASON = "pr"
+$Env:BUILD_REPOSITORY_NAME = "arcade"
+$Env:BUILD_SOURCEBRANCH = "prvysoky"
+$Env:SYSTEM_TEAMPROJECT = "dnceng"
+$Env:SYSTEM_ACCESSTOKEN = ""
+
+Write-Host -ForegroundColor Cyan "> Starting tests (logging to XHarness.binlog)"
+
+& "$repoRoot\Build.cmd" -configuration Debug -test -projects "$TestProject" /p:RestoreUsingNugetTargets=false /bl:.\XHarness.binlog

--- a/tools/run-e2e-test.ps1
+++ b/tools/run-e2e-test.ps1
@@ -20,23 +20,15 @@ param (
     $SkipBuild = $false
 )
 
-$repoRoot = "$PSScriptRoot\.."
+$repoRoot = Resolve-Path "$PSScriptRoot\.."
 
 function Write-Projects {
+    $testRoot = "$repoRoot\tests\integration-tests\"
+    $files = Get-ChildItem -Recurse -Include *Tests.proj -Path $testRoot | ForEach-Object { $_.FullName.Substring($testRoot.Length) }
+
     Write-Output "Possible options:"
-    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\Android"
     foreach ($item in $files) {
-        '  - Android\{0}' -f $item.Name
-    }
-
-    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\Apple"
-    foreach ($item in $files) {
-        '  - Apple\{0}' -f $item.Name
-    }
-
-    $files = Get-ChildItem -Include *Tests.proj -Recurse -Path "$repoRoot\tests\integration-tests\WASM"
-    foreach ($item in $files) {
-        '  - WASM\{0}' -f $item.Name
+        " - $item"
     }
 }
 

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -44,7 +44,7 @@ done
 here="$( cd -P "$( dirname "$source" )" && pwd )"
 repo_root="$( cd -P "$( dirname "$here" )" && pwd )"
 
-if [ -z $test_project ] || [ "-h" == "$test_project" ] || [ "--help" == "$test_project" ]; then
+if [ -z "$test_project" ] || [ "-h" == "$test_project" ] || [ "--help" == "$test_project" ]; then
   fail "Usage: ./run-e2e-test.sh Apple/SimulatorInstaller.Tests.proj [--skip-build]"
   print_projects
   exit 2
@@ -82,6 +82,8 @@ if [ "true" != "$skip_build" ]; then
   highlight "> Building Microsoft.DotNet.XHarness.CLI.1.0.0-dev.nupkg"
   rm -rf "$repo_root/artifacts/tmp/Debug/Microsoft.DotNet.XHarness.CLI" "$repo_root/artifacts/packages"
   "$repo_root/build.sh" -build -pack --projects "$repo_root/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj"
+else
+  highlight "> Skipping build"
 fi
 
 export BUILD_REASON="dev"
@@ -90,5 +92,5 @@ export BUILD_SOURCEBRANCH="master"
 export SYSTEM_TEAMPROJECT="dnceng"
 export SYSTEM_ACCESSTOKEN=""
 
-highlight "> Starting tests (logging to ./XHarness.binlog)"
+highlight "> Starting tests (logging to XHarness.binlog)"
 "$repo_root/build.sh" -configuration Debug -restore -test -projects "$test_project" /p:RestoreUsingNugetTargets=false /bl:./XHarness.binlog


### PR DESCRIPTION
We already have a shell script for Linux/MacOS but we could use this when working with the repo on Windows 