### PR TITLE
Detect app launch timeout on Apple

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -434,7 +434,7 @@ public class AppTester : AppRunnerBase, IAppTester
 
         deviceListener.ConnectedTask
             .TimeoutAfter(testLaunchTimeout)
-            .ContinueWith(testReporter.LaunchCallback)
+            .ContinueWith(testReporter.LaunchCallback, cancellationToken)
             .DoNotAwait();
 
         _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on MacCatalyst ***");

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -125,7 +125,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 environmentalVariables,
                 passthroughArguments,
                 signalAppEnd,
-                cancellationToken);
+                cancellationToken); // This cancellation token doesn't include the launch-timeout one
         }
 
         Task<ExitCode> ExecuteApp(AppBundleInformation appBundleInfo, IDevice device, IDevice? companionDevice)
@@ -145,7 +145,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 environmentalVariables,
                 passthroughArguments,
                 signalAppEnd,
-                cancellationToken);
+                cancellationToken); // This cancellation token doesn't include the launch-timeout one
         }
 
         return await OrchestrateOperation(

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -299,6 +299,10 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             case TestExecutingResult.Crashed:
                 return LogProblem("Application test run crashed", ExitCode.APP_LAUNCH_FAILURE);
 
+            case TestExecutingResult.LaunchTimedOut:
+                _logger.LogError("Application launch timed out before the test execution has started");
+                return ExitCode.APP_LAUNCH_TIMEOUT;
+
             case TestExecutingResult.TimedOut:
                 _logger.LogWarning($"Application test run timed out");
                 return ExitCode.TIMED_OUT;

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
@@ -105,4 +105,10 @@ public enum ExitCode
     /// Hardware device is in some corrupted state, or just locked screen
     /// </summary>
     DEVICE_FAILURE = 89,
+
+    /// <summary>
+    /// This timeout occurs when the Apple app has been launched but hasn't
+    /// connected yetover TCP and --launch-timeout expires
+    /// </summary>
+    APP_LAUNCH_TIMEOUT = 90,
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
@@ -13,29 +13,30 @@ public enum TestExecutingResult
     InProgress = 0x1,
     Finished = 0x2,
     Waiting = 0x4,
-    StateMask = NotStarted + InProgress + Waiting + Finished,
+    StateMask = NotStarted | InProgress | Waiting | Finished,
 
     // In progress state
-    Building = 0x10 + InProgress,
-    BuildQueued = 0x10 + InProgress + Waiting,
-    Built = 0x20 + InProgress,
-    Running = 0x40 + InProgress,
-    RunQueued = 0x40 + InProgress + Waiting,
-    InProgressMask = 0x10 + 0x20 + 0x40,
+    Building = 0x10 | InProgress,
+    BuildQueued = 0x10 | InProgress | Waiting,
+    Built = 0x20 | InProgress,
+    Running = 0x40 | InProgress,
+    RunQueued = 0x40 | InProgress | Waiting,
+    InProgressMask = 0x10 | 0x20 | 0x40,
 
     // Finished results
-    Succeeded = 0x100 + Finished,
-    Failed = 0x200 + Finished,
-    Ignored = 0x400 + Finished,
-    DeviceNotFound = 0x800 + Finished,
+    Succeeded = 0x100 | Finished,
+    Failed = 0x200 | Finished,
+    Ignored = 0x400 | Finished,
+    DeviceNotFound = 0x800 | Finished,
 
     // Finished & Failed results
-    Crashed = 0x1000 + Failed,
-    TimedOut = 0x2000 + Failed,
-    HarnessException = 0x4000 + Failed,
-    LaunchFailure = 0x6000 + Failed,
-    BuildFailure = 0x8000 + Failed,
+    Crashed = 0x1000 | Failed,
+    TimedOut = 0x2000 | Failed,
+    HarnessException = 0x4000 | Failed,
+    LaunchFailure = 0x6000 | Failed,
+    BuildFailure = 0x8000 | Failed,
 
     // Other results
-    BuildSucceeded = 0x10000 + Succeeded,
+    BuildSucceeded = 0x10000 | Succeeded,
+    LaunchTimedOut = 0x20000 | LaunchFailure | TimedOut,
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -296,8 +296,16 @@ public class TestReporter : ITestReporter
         else
         {
             _cancellationTokenSource.Cancel();
-            _mainLog.WriteLine("Test execution timed out after {0} minute(s).", _timeoutWatch.Elapsed.TotalMinutes);
             _timedout = true;
+
+            if (_listener.ConnectedTask.IsCompleted && _listener.ConnectedTask.Result)
+            {
+                _mainLog.WriteLine($"Test execution timed out after {_timeoutWatch.Elapsed.TotalMinutes:0.##} minutes");
+            }
+            else
+            {
+                _mainLog.WriteLine($"Test failed to start in {_timeoutWatch.Elapsed.TotalMinutes:0.##} minutes");
+            }
         }
     }
 
@@ -617,7 +625,15 @@ public class TestReporter : ITestReporter
 
         if (_timedout)
         {
-            result.ExecutingResult = TestExecutingResult.TimedOut;
+            // Did the test execution start?
+            if (_listener.ConnectedTask.IsCompleted && _listener.ConnectedTask.Result)
+            {
+                result.ExecutingResult = TestExecutingResult.TimedOut;
+            }
+            else
+            {
+                result.ExecutingResult = TestExecutingResult.LaunchTimedOut;
+            }
         }
         else if (_launchFailure)
         {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -522,7 +522,7 @@ public class TestReporter : ITestReporter
             return;
         }
 
-        if (string.IsNullOrEmpty(crashReason))
+        if (!string.IsNullOrEmpty(crashReason))
         {
             _resultParser.GenerateFailure(
                 _logs,

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
@@ -14,37 +14,38 @@ public class TestExecutingResultTests
     [InlineData(
         new[]
         {
-                TestExecutingResult.Crashed,
-                TestExecutingResult.TimedOut,
-                TestExecutingResult.HarnessException,
-                TestExecutingResult.LaunchFailure,
-                TestExecutingResult.BuildFailure,
-                TestExecutingResult.Failed,
+            TestExecutingResult.Crashed,
+            TestExecutingResult.TimedOut,
+            TestExecutingResult.HarnessException,
+            TestExecutingResult.LaunchFailure,
+            TestExecutingResult.BuildFailure,
+            TestExecutingResult.LaunchTimedOut,
+            TestExecutingResult.Failed,
         },
         TestExecutingResult.Failed
     )]
     [InlineData(
         new[]
         {
-                TestExecutingResult.Building,
-                TestExecutingResult.BuildQueued,
-                TestExecutingResult.Built,
-                TestExecutingResult.Running,
-                TestExecutingResult.RunQueued,
-                TestExecutingResult.InProgress,
-                TestExecutingResult.StateMask,
+            TestExecutingResult.Building,
+            TestExecutingResult.BuildQueued,
+            TestExecutingResult.Built,
+            TestExecutingResult.Running,
+            TestExecutingResult.RunQueued,
+            TestExecutingResult.InProgress,
+            TestExecutingResult.StateMask,
         },
         TestExecutingResult.InProgress
     )]
     [InlineData(
         new[]
         {
-                TestExecutingResult.Succeeded,
-                TestExecutingResult.BuildSucceeded,
+            TestExecutingResult.Succeeded,
+            TestExecutingResult.BuildSucceeded,
         },
         TestExecutingResult.Succeeded
     )]
-    public void FlaggedIsPresentWhereItShouldBe(TestExecutingResult[] withFlag, TestExecutingResult flag)
+    public void FlagIsPresentWhereItShouldBe(TestExecutingResult[] withFlag, TestExecutingResult flag)
     {
         var withoutFlag = Enum.GetValues(typeof(TestExecutingResult))
             .Cast<TestExecutingResult>()
@@ -56,6 +57,24 @@ public class TestExecutingResultTests
         }
 
         foreach (var result in withFlag)
+        {
+            Assert.True(result.HasFlag(flag), $"{result} should have {flag}");
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        TestExecutingResult.LaunchTimedOut,
+        new[]
+        {
+            TestExecutingResult.TimedOut,
+            TestExecutingResult.LaunchFailure,
+            TestExecutingResult.Failed,
+        }
+    )]
+    public void ResultHasFlag(TestExecutingResult result, TestExecutingResult[] flags)
+    {
+        foreach (var flag in flags)
         {
             Assert.True(result.HasFlag(flag), $"{result} should have {flag}");
         }


### PR DESCRIPTION
The shared Xamarin code allowed for a short window in-between the app being installed and launched but not having connected over TCP to XHarness' listener.
We add a more granular code that will describe this case so that we don't need to return `TIMED_OUT` when `--launch-timeout` occurs since `TIMED_OUT` means that tests themselves are running too long. This new launch timeout is then categorized as infra failure rather than user's fault.

Resolves #785 