### PR TITLE
Refactor target-specific ApplicationEntryPoint subclasses to have non-xunit-specific base classes

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/AndroidApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/AndroidApplicationEntryPointBase.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.TestRunners.Common;
+
+public abstract class AndroidApplicationEntryPointBase : ApplicationEntryPoint
+{    /// <summary>
+     /// Implementors should provide a text writter than will be used to
+     /// write the logging of the tests that are executed.
+     /// </summary>
+    public abstract TextWriter? Logger { get; }
+
+    /// <summary>
+    /// Implementors should provide a full path in which the final
+    /// results of the test run will be written. This property must not
+    /// return null.
+    /// </summary>
+    public abstract string TestsResultsFinalPath { get; }
+
+    public override async Task RunAsync()
+    {
+        var options = ApplicationOptions.Current;
+        // we generate the logs in two different ways depending if the generate xml flag was
+        // provided. If it was, we will write the xml file to the tcp writer if present, else
+        // we will write the normal console output using the LogWriter
+        var logger = (Logger == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, Logger);
+        logger.MinimumLogLevel = MinimumLogLevel.Info;
+
+        var runner = await InternalRunAsync(logger);
+        if (options.EnableXml)
+        {
+            if (TestsResultsFinalPath == null)
+            {
+                throw new InvalidOperationException("Tests results final path cannot be null.");
+            }
+
+            using (var stream = File.Create(TestsResultsFinalPath))
+            using (var writer = new StreamWriter(stream))
+            {
+                WriteResults(runner, options, logger, writer);
+            }
+        }
+        else
+        {
+            WriteResults(runner, options, logger, Console.Out);
+        }
+
+        logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+
+        if (options.AppEndTag != null)
+        {
+            logger.Info(options.AppEndTag);
+        }
+
+        if (options.TerminateAfterExecution)
+        {
+            TerminateWithSuccess();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/AndroidApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/AndroidApplicationEntryPointBase.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -7,11 +11,12 @@ using System.Threading.Tasks;
 #nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Common;
 
+/// <summary>
+/// Implementors should provide a text writter than will be used to
+/// write the logging of the tests that are executed.
+/// </summary>
 public abstract class AndroidApplicationEntryPointBase : ApplicationEntryPoint
-{    /// <summary>
-     /// Implementors should provide a text writter than will be used to
-     /// write the logging of the tests that are executed.
-     /// </summary>
+{
     public abstract TextWriter? Logger { get; }
 
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationOptions.cs
@@ -16,7 +16,7 @@ internal enum XmlMode
     Wrapped = 1,
 }
 
-internal class ApplicationOptions
+public class ApplicationOptions
 {
     public static ApplicationOptions Current = new();
     private readonly List<string> _singleMethodFilters = new();

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/LogWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/LogWriter.cs
@@ -3,28 +3,30 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Common;
 
 public class LogWriter
 {
     private readonly TextWriter _writer;
-    private readonly IDevice _device;
+    private readonly IDevice? _device;
 
     public MinimumLogLevel MinimumLogLevel { get; set; } = MinimumLogLevel.Info;
 
     public LogWriter() : this(null, Console.Out) { }
 
-    public LogWriter(IDevice device) : this(device, Console.Out) { }
+    public LogWriter(IDevice? device) : this(device, Console.Out) { }
 
     public LogWriter(TextWriter w) : this(null, w) { }
 
-    public LogWriter(IDevice device, TextWriter writer)
+    public LogWriter(IDevice? device, TextWriter writer)
     {
         _writer = writer ?? Console.Out;
         _device = device;
-        if (_device != null) // we just write the header if we do have the device info
+        if (_device is not null) // we just write the header if we do have the device info
         {
             InitLogging();
         }
@@ -35,6 +37,7 @@ public class LogWriter
 
     public void InitLogging()
     {
+        Debug.Assert(_device is not null);
         // print some useful info
         _writer.WriteLine("[Runner executing:\t{0}]", "Run everything");
         _writer.WriteLine("[{0}:\t{1} v{2}]", _device.Model, _device.SystemName, _device.SystemVersion);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
@@ -10,44 +10,16 @@ using System.Threading.Tasks;
 #nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Common;
 
-public abstract class WasmApplicationEntryPointBase : ApplicationEntryPoint, IDevice
+public abstract class WasmApplicationEntryPointBase : ApplicationEntryPoint
 {
-    public string BundleIdentifier => string.Empty;
-
-    public string UniqueIdentifier => string.Empty;
-
-    public string Name => string.Empty;
-
-    public string Model => string.Empty;
-
-    public string SystemName => string.Empty;
-
-    public string SystemVersion => string.Empty;
-
-    public string Locale => string.Empty;
-
     protected override int? MaxParallelThreads => 1;
 
-    protected override IDevice Device => this;
+    protected override IDevice? Device => null;
 
     public override async Task RunAsync()
     {
         var options = ApplicationOptions.Current;
-        // we generate the logs in two different ways depending if the generate xml flag was
-        // provided. If it was, we will write the xml file to the tcp writer if present, else
-        // we will write the normal console output using the LogWriter
-        var logger = new LogWriter(Device);
-        logger.MinimumLogLevel = MinimumLogLevel.Info;
-
-        var runner = await InternalRunAsync(logger);
-        WriteResults(runner, options, logger, Console.Out);
-
-        logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
-
-        if (options.AppEndTag != null)
-        {
-            logger.Info(options.AppEndTag);
-        }
+        var runner = await InternalRunAsync(options, null, Console.Out);
 
         LastRunHadFailedTests = runner.FailedTests != 0;
     }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Common;
+
+public abstract class WasmApplicationEntryPointBase : ApplicationEntryPoint, IDevice
+{
+
+    public string BundleIdentifier => string.Empty;
+
+    public string UniqueIdentifier => string.Empty;
+
+    public string Name => string.Empty;
+
+    public string Model => string.Empty;
+
+    public string SystemName => string.Empty;
+
+    public string SystemVersion => string.Empty;
+
+    public string Locale => string.Empty;
+
+    protected override int? MaxParallelThreads => 1;
+
+    protected override IDevice Device => this;
+
+    public override async Task RunAsync()
+    {
+        var options = ApplicationOptions.Current;
+        // we generate the logs in two different ways depending if the generate xml flag was
+        // provided. If it was, we will write the xml file to the tcp writer if present, else
+        // we will write the normal console output using the LogWriter
+        var logger = new LogWriter(Device);
+        logger.MinimumLogLevel = MinimumLogLevel.Info;
+
+        var runner = await InternalRunAsync(logger);
+        WriteResults(runner, options, logger, Console.Out);
+
+        logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
+
+        if (options.AppEndTag != null)
+        {
+            logger.Info(options.AppEndTag);
+        }
+
+        LastRunHadFailedTests = runner.FailedTests != 0;
+    }
+
+    public bool LastRunHadFailedTests { get; set; }
+
+    protected override void TerminateWithSuccess() => Environment.Exit(0);
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/WasmApplicationEntryPointBase.cs
@@ -1,13 +1,17 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Common;
 
 public abstract class WasmApplicationEntryPointBase : ApplicationEntryPoint, IDevice
 {
-
     public string BundleIdentifier => string.Empty;
 
     public string UniqueIdentifier => string.Empty;

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.TestRunners.Common;
+
+public abstract class iOSApplicationEntryPointBase : ApplicationEntryPoint
+{
+    public override async Task RunAsync()
+    {
+        var options = ApplicationOptions.Current;
+        TcpTextWriter? writer;
+
+        try
+        {
+            writer = options.UseTunnel
+                ? TcpTextWriter.InitializeWithTunnelConnection(options.HostPort)
+                : TcpTextWriter.InitializeWithDirectConnection(options.HostName, options.HostPort);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("Failed to initialize TCP writer. Continuing on console." + Environment.NewLine + ex);
+            writer = null; // null means we will fall back to console output
+        }
+
+        // we generate the logs in two different ways depending if the generate xml flag was
+        // provided. If it was, we will write the xml file to the tcp writer if present, else
+        // we will write the normal console output using the LogWriter
+        using (writer)
+        {
+            var logger = (writer == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, writer);
+            logger.MinimumLogLevel = MinimumLogLevel.Info;
+
+            // if we have ignore files, ignore those tests
+            var runner = await InternalRunAsync(logger);
+
+            WriteResults(runner, options, logger, writer ?? Console.Out);
+
+            logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
+
+            if (options.AppEndTag != null)
+            {
+                logger.Info(options.AppEndTag);
+            }
+
+            if (options.TerminateAfterExecution)
+            {
+                TerminateWithSuccess();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/iOSApplicationEntryPointBase.cs
@@ -28,30 +28,12 @@ public abstract class iOSApplicationEntryPointBase : ApplicationEntryPoint
             writer = null; // null means we will fall back to console output
         }
 
-        // we generate the logs in two different ways depending if the generate xml flag was
-        // provided. If it was, we will write the xml file to the tcp writer if present, else
-        // we will write the normal console output using the LogWriter
         using (writer)
         {
             var logger = (writer == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, writer);
             logger.MinimumLogLevel = MinimumLogLevel.Info;
 
-            // if we have ignore files, ignore those tests
-            var runner = await InternalRunAsync(logger);
-
-            WriteResults(runner, options, logger, writer ?? Console.Out);
-
-            logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
-
-            if (options.AppEndTag != null)
-            {
-                logger.Info(options.AppEndTag);
-            }
-
-            if (options.TerminateAfterExecution)
-            {
-                TerminateWithSuccess();
-            }
+            await InternalRunAsync(options, writer, writer);
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/AndroidApplicationEntryPoint.cs
@@ -11,21 +11,8 @@ using Microsoft.DotNet.XHarness.TestRunners.Common;
 
 namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
-public abstract class AndroidApplicationEntryPoint : ApplicationEntryPoint
+public abstract class AndroidApplicationEntryPoint : AndroidApplicationEntryPointBase
 {
-    /// <summary>
-    /// Implementors should provide a text writter than will be used to
-    /// write the logging of the tests that are executed.
-    /// </summary>
-    public abstract TextWriter? Logger { get; }
-
-    /// <summary>
-    /// Implementors should provide a full path in which the final
-    /// results of the test run will be written. This property must not
-    /// return null.
-    /// </summary>
-    public abstract string TestsResultsFinalPath { get; }
-
     protected override bool IsXunit => true;
 
     protected override TestRunner GetTestRunner(LogWriter logWriter)
@@ -33,46 +20,5 @@ public abstract class AndroidApplicationEntryPoint : ApplicationEntryPoint
         var runner = new XUnitTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
         ConfigureRunnerFilters(runner, ApplicationOptions.Current);
         return runner;
-    }
-
-    public override async Task RunAsync()
-    {
-        var options = ApplicationOptions.Current;
-        // we generate the logs in two different ways depending if the generate xml flag was
-        // provided. If it was, we will write the xml file to the tcp writer if present, else
-        // we will write the normal console output using the LogWriter
-        var logger = (Logger == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, Logger);
-        logger.MinimumLogLevel = MinimumLogLevel.Info;
-
-        var runner = await InternalRunAsync(logger);
-        if (options.EnableXml)
-        {
-            if (TestsResultsFinalPath == null)
-            {
-                throw new InvalidOperationException("Tests results final path cannot be null.");
-            }
-
-            using (var stream = File.Create(TestsResultsFinalPath))
-            using (var writer = new StreamWriter(stream))
-            {
-                WriteResults(runner, options, logger, writer);
-            }
-        }
-        else
-        {
-            WriteResults(runner, options, logger, Console.Out);
-        }
-
-        logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests}");
-
-        if (options.AppEndTag != null)
-        {
-            logger.Info(options.AppEndTag);
-        }
-
-        if (options.TerminateAfterExecution)
-        {
-            TerminateWithSuccess();
-        }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -56,7 +56,7 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
             var discoverer = new ThreadlessXunitDiscoverer(assemblyInfo, new NullSourceInformationProvider(), discoverySink);
 
             discoverer.FindWithoutThreads(includeSourceInformation: false, discoverySink, discoveryOptions);
-            var testCasesToRun = discoverySink.TestCases.Where(t => _filters.IsExcluded(t)).ToList();
+            var testCasesToRun = discoverySink.TestCases.Where(t => !_filters.IsExcluded(t)).ToList();
             Console.WriteLine($"Discovered:  {assemblyFileName} (found {testCasesToRun.Count} of {discoverySink.TestCases.Count} test cases)");
 
             var summaryTaskSource = new TaskCompletionSource<ExecutionSummary>();

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -13,36 +14,49 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
-internal class ThreadlessXunitTestRunner
+internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
 {
-    public static async Task<int> Run(string assemblyFileName, bool printXml, XunitFilters filters, bool oneLineResults = false)
+    public ThreadlessXunitTestRunner(LogWriter logger, bool oneLineResults = false) : base(logger)
     {
-        try
+        _oneLineResults = oneLineResults;
+    }
+
+    protected override string ResultsFileName { get => string.Empty; set => throw new InvalidOperationException("This runner outputs its results to stdout."); }
+
+    private readonly XElement _assembliesElement = new XElement("assemblies");
+    private readonly bool _oneLineResults;
+
+    public override async Task Run(IEnumerable<TestAssemblyInfo> testAssemblies)
+    {
+        var configuration = new TestAssemblyConfiguration() { ShadowCopy = false, ParallelizeAssembly = false, ParallelizeTestCollections = false, MaxParallelThreads = 1, PreEnumerateTheories = false };
+        var discoveryOptions = TestFrameworkOptions.ForDiscovery(configuration);
+        var discoverySink = new TestDiscoverySink();
+        var diagnosticSink = new ConsoleDiagnosticMessageSink();
+        var testOptions = TestFrameworkOptions.ForExecution(configuration);
+        var testSink = new TestMessageSink();
+
+        var totalSummary = new ExecutionSummary();
+        foreach (var testAsmInfo in testAssemblies)
         {
-            var configuration = new TestAssemblyConfiguration() { ShadowCopy = false, ParallelizeAssembly = false, ParallelizeTestCollections = false, MaxParallelThreads = 1, PreEnumerateTheories = false };
-            var discoveryOptions = TestFrameworkOptions.ForDiscovery(configuration);
-            var discoverySink = new TestDiscoverySink();
-            var diagnosticSink = new ConsoleDiagnosticMessageSink();
-            var testOptions = TestFrameworkOptions.ForExecution(configuration);
-            var testSink = new TestMessageSink();
+            string assemblyFileName = testAsmInfo.FullPath;
             var controller = new Xunit2(AppDomainSupport.Denied, new NullSourceInformationProvider(), assemblyFileName, configFileName: null, shadowCopy: false, shadowCopyFolder: null, diagnosticMessageSink: diagnosticSink, verifyTestAssemblyExists: false);
 
             discoveryOptions.SetSynchronousMessageReporting(true);
             testOptions.SetSynchronousMessageReporting(true);
 
             Console.WriteLine($"Discovering: {assemblyFileName} (method display = {discoveryOptions.GetMethodDisplayOrDefault()}, method display options = {discoveryOptions.GetMethodDisplayOptionsOrDefault()})");
-            var assembly = Assembly.LoadFrom(assemblyFileName);
-            var assemblyInfo = new global::Xunit.Sdk.ReflectionAssemblyInfo(assembly);
+            var assemblyInfo = new global::Xunit.Sdk.ReflectionAssemblyInfo(testAsmInfo.Assembly);
             var discoverer = new ThreadlessXunitDiscoverer(assemblyInfo, new NullSourceInformationProvider(), discoverySink);
 
             discoverer.FindWithoutThreads(includeSourceInformation: false, discoverySink, discoveryOptions);
-            var testCasesToRun = discoverySink.TestCases.Where(filters.Filter).ToList();
+            var testCasesToRun = discoverySink.TestCases.Where(t => _filters.IsExcluded(t)).ToList();
             Console.WriteLine($"Discovered:  {assemblyFileName} (found {testCasesToRun.Count} of {discoverySink.TestCases.Count} test cases)");
 
             var summaryTaskSource = new TaskCompletionSource<ExecutionSummary>();
@@ -50,53 +64,77 @@ internal class ThreadlessXunitTestRunner
             var resultsXmlAssembly = new XElement("assembly");
             var resultsSink = new DelegatingXmlCreationSink(summarySink, resultsXmlAssembly);
 
+
             if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
             {
                 testSink.Execution.TestStartingEvent += args => { Console.WriteLine($"[STRT] {args.Message.Test.DisplayName}"); };
             }
-            testSink.Execution.TestPassedEvent += args => { Console.WriteLine($"[PASS] {args.Message.Test.DisplayName}"); };
-            testSink.Execution.TestSkippedEvent += args => { Console.WriteLine($"[SKIP] {args.Message.Test.DisplayName}"); };
-            testSink.Execution.TestFailedEvent += args => { Console.WriteLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}"); };
+            testSink.Execution.TestPassedEvent += args =>
+            {
+                Console.WriteLine($"[PASS] {args.Message.Test.DisplayName}");
+                PassedTests++;
+            };
+            testSink.Execution.TestSkippedEvent += args =>
+            {
+                Console.WriteLine($"[SKIP] {args.Message.Test.DisplayName}");
+                SkippedTests++;
+            };
+            testSink.Execution.TestFailedEvent += args =>
+            {
+                Console.WriteLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}");
+                FailedTests++;
+            };
+            testSink.Execution.TestFinishedEvent += args => ExecutedTests++;
 
             testSink.Execution.TestAssemblyStartingEvent += args => { Console.WriteLine($"Starting:    {assemblyFileName}"); };
             testSink.Execution.TestAssemblyFinishedEvent += args => { Console.WriteLine($"Finished:    {assemblyFileName}"); };
 
             controller.RunTests(testCasesToRun, resultsSink, testOptions);
 
-            var summary = await summaryTaskSource.Task;
-            Console.WriteLine($"{Environment.NewLine}=== TEST EXECUTION SUMMARY ==={Environment.NewLine}Total: {summary.Total}, Errors: 0, Failed: {summary.Failed}, Skipped: {summary.Skipped}, Time: {TimeSpan.FromSeconds((double)summary.Time).TotalSeconds}s{Environment.NewLine}");
-
-            if (printXml)
-            {
-                if (oneLineResults)
-                {
-                    var resultsXml = new XElement("assemblies");
-                    resultsXml.Add(resultsXmlAssembly);
-                    using var ms = new MemoryStream();
-                    resultsXml.Save(ms);
-                    var bytes = ms.ToArray();
-                    var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
-                    Console.WriteLine($"STARTRESULTXML {bytes.Length} {base64} ENDRESULTXML");
-                    Console.WriteLine($"Finished writing {bytes.Length} bytes of RESULTXML");
-                }
-                else
-                {
-                    Console.WriteLine($"STARTRESULTXML");
-                    var resultsXml = new XElement("assemblies");
-                    resultsXml.Add(resultsXmlAssembly);
-                    resultsXml.Save(Console.Out);
-                    Console.WriteLine();
-                    Console.WriteLine($"ENDRESULTXML");
-                }
-            }
-
-            var failed = resultsSink.ExecutionSummary.Failed > 0 || resultsSink.ExecutionSummary.Errors > 0;
-            return failed ? 1 : 0;
+            totalSummary = Combine(totalSummary, await summaryTaskSource.Task);
+            _assembliesElement.Add(resultsXmlAssembly);
         }
-        catch (Exception ex)
+        TotalTests = totalSummary.Total;
+        Console.WriteLine($"{Environment.NewLine}=== TEST EXECUTION SUMMARY ==={Environment.NewLine}Total: {totalSummary.Total}, Errors: 0, Failed: {totalSummary.Failed}, Skipped: {totalSummary.Skipped}, Time: {TimeSpan.FromSeconds((double)totalSummary.Time).TotalSeconds}s{Environment.NewLine}");
+    }
+
+    private ExecutionSummary Combine(ExecutionSummary aggregateSummary, ExecutionSummary assemblySummary)
+    {
+        return new ExecutionSummary
         {
-            Console.Error.WriteLine($"ThreadlessXunitTestRunner failed: {ex}");
-            return 2;
+            Total = aggregateSummary.Total + assemblySummary.Total,
+            Failed = aggregateSummary.Failed + assemblySummary.Failed,
+            Skipped = aggregateSummary.Skipped + assemblySummary.Skipped,
+            Errors = aggregateSummary.Errors + assemblySummary.Errors,
+            Time = aggregateSummary.Time + assemblySummary.Time
+        };
+    }
+
+    public override string WriteResultsToFile(XmlResultJargon xmlResultJargon)
+    {
+        Debug.Assert(xmlResultJargon == XmlResultJargon.xUnit);
+        WriteResultsToFile(Console.Out, xmlResultJargon);
+        return "";
+    }
+
+    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+    {
+        if (_oneLineResults)
+        {
+
+            using var ms = new MemoryStream();
+            _assembliesElement.Save(ms);
+            var bytes = ms.ToArray();
+            var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
+            Console.WriteLine($"STARTRESULTXML {bytes.Length} {base64} ENDRESULTXML");
+            Console.WriteLine($"Finished writing {bytes.Length} bytes of RESULTXML");
+        }
+        else
+        {
+            writer.WriteLine($"STARTRESULTXML");
+            _assembliesElement.Save(writer);
+            writer.WriteLine();
+            writer.WriteLine($"ENDRESULTXML");
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -27,14 +27,13 @@ internal class XsltIdGenerator
     public int GenerateHash() => _seed++;
 }
 
-internal class XUnitTestRunner : TestRunner
+internal class XUnitTestRunner : XunitTestRunnerBase
 {
     private readonly TestMessageSink _messageSink;
 
     public int? MaxParallelThreads { get; set; }
 
     private XElement _assembliesElement;
-    private XUnitFiltersCollection _filters = new();
 
     public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
     protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
@@ -1126,66 +1125,4 @@ internal class XUnitTestRunner : TestRunner
             }
         }
     }
-
-    public override void SkipTests(IEnumerable<string> tests)
-    {
-        if (tests.Any())
-        {
-            // create a single filter per test
-            foreach (var t in tests)
-            {
-                if (t.StartsWith("KLASS:", StringComparison.Ordinal))
-                {
-                    var klass = t.Replace("KLASS:", "");
-                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
-                }
-                else if (t.StartsWith("KLASS32:", StringComparison.Ordinal) && IntPtr.Size == 4)
-                {
-                    var klass = t.Replace("KLASS32:", "");
-                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
-                }
-                else if (t.StartsWith("KLASS64:", StringComparison.Ordinal) && IntPtr.Size == 8)
-                {
-                    var klass = t.Replace("KLASS32:", "");
-                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
-                }
-                else if (t.StartsWith("Platform32:", StringComparison.Ordinal) && IntPtr.Size == 4)
-                {
-                    var filter = t.Replace("Platform32:", "");
-                    _filters.Add(XUnitFilter.CreateSingleFilter(filter, true));
-                }
-                else
-                {
-                    _filters.Add(XUnitFilter.CreateSingleFilter(t, true));
-                }
-            }
-        }
-    }
-
-    public override void SkipCategories(IEnumerable<string> categories)
-    {
-        if (categories == null)
-        {
-            throw new ArgumentNullException(nameof(categories));
-        }
-
-        foreach (var c in categories)
-        {
-            var traitInfo = c.Split('=');
-            if (traitInfo.Length == 2)
-            {
-                _filters.Add(XUnitFilter.CreateTraitFilter(traitInfo[0], traitInfo[1], true));
-            }
-            else
-            {
-                _filters.Add(XUnitFilter.CreateTraitFilter(c, null, true));
-            }
-        }
-    }
-
-    public override void SkipMethod(string method, bool isExcluded)
-        => _filters.Add(XUnitFilter.CreateSingleFilter(singleTestName: method, exclude: isExcluded));
-
-    public override void SkipClass(string className, bool isExcluded)
-        => _filters.Add(XUnitFilter.CreateClassFilter(className: className, exclude: isExcluded));
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XunitTestRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XunitTestRunnerBase.cs
@@ -1,9 +1,14 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.DotNet.XHarness.TestRunners.Common;
 
+#nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
 public abstract class XunitTestRunnerBase : TestRunner
 {

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XunitTestRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XunitTestRunnerBase.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
+public abstract class XunitTestRunnerBase : TestRunner
+{
+    private protected XUnitFiltersCollection _filters = new();
+
+    protected XunitTestRunnerBase(LogWriter logger) : base(logger)
+    {
+    }
+
+    public override void SkipTests(IEnumerable<string> tests)
+    {
+        if (tests.Any())
+        {
+            // create a single filter per test
+            foreach (var t in tests)
+            {
+                if (t.StartsWith("KLASS:", StringComparison.Ordinal))
+                {
+                    var klass = t.Replace("KLASS:", "");
+                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                }
+                else if (t.StartsWith("KLASS32:", StringComparison.Ordinal) && IntPtr.Size == 4)
+                {
+                    var klass = t.Replace("KLASS32:", "");
+                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                }
+                else if (t.StartsWith("KLASS64:", StringComparison.Ordinal) && IntPtr.Size == 8)
+                {
+                    var klass = t.Replace("KLASS32:", "");
+                    _filters.Add(XUnitFilter.CreateClassFilter(klass, true));
+                }
+                else if (t.StartsWith("Platform32:", StringComparison.Ordinal) && IntPtr.Size == 4)
+                {
+                    var filter = t.Replace("Platform32:", "");
+                    _filters.Add(XUnitFilter.CreateSingleFilter(filter, true));
+                }
+                else
+                {
+                    _filters.Add(XUnitFilter.CreateSingleFilter(t, true));
+                }
+            }
+        }
+    }
+
+    public override void SkipCategories(IEnumerable<string> categories) => SkipCategories(categories, isExcluded: true);
+
+    public virtual void SkipCategories(IEnumerable<string> categories, bool isExcluded)
+    {
+        if (categories == null)
+        {
+            throw new ArgumentNullException(nameof(categories));
+        }
+
+        foreach (var c in categories)
+        {
+            var traitInfo = c.Split('=');
+            if (traitInfo.Length == 2)
+            {
+                _filters.Add(XUnitFilter.CreateTraitFilter(traitInfo[0], traitInfo[1], isExcluded));
+            }
+            else
+            {
+                _filters.Add(XUnitFilter.CreateTraitFilter(c, null, isExcluded));
+            }
+        }
+    }
+
+    public override void SkipMethod(string method, bool isExcluded)
+        => _filters.Add(XUnitFilter.CreateSingleFilter(singleTestName: method, exclude: isExcluded));
+
+    public override void SkipClass(string className, bool isExcluded)
+        => _filters.Add(XUnitFilter.CreateClassFilter(className: className, exclude: isExcluded));
+
+    public virtual void SkipNamespace(string namespaceName, bool isExcluded)
+        => _filters.Add(XUnitFilter.CreateNamespaceFilter(namespaceName, exclude: isExcluded));
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/iOSApplicationEntryPoint.cs
@@ -9,7 +9,7 @@ using Microsoft.DotNet.XHarness.TestRunners.Common;
 #nullable enable
 namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
-public abstract class iOSApplicationEntryPoint : ApplicationEntryPoint
+public abstract class iOSApplicationEntryPoint : iOSApplicationEntryPointBase
 {
     protected override TestRunner GetTestRunner(LogWriter logWriter)
     {
@@ -19,48 +19,4 @@ public abstract class iOSApplicationEntryPoint : ApplicationEntryPoint
     }
 
     protected override bool IsXunit => true;
-
-    public override async Task RunAsync()
-    {
-        var options = ApplicationOptions.Current;
-        TcpTextWriter? writer;
-
-        try
-        {
-            writer = options.UseTunnel
-                ? TcpTextWriter.InitializeWithTunnelConnection(options.HostPort)
-                : TcpTextWriter.InitializeWithDirectConnection(options.HostName, options.HostPort);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("Failed to initialize TCP writer. Continuing on console." + Environment.NewLine + ex);
-            writer = null; // null means we will fall back to console output
-        }
-
-        // we generate the logs in two different ways depending if the generate xml flag was
-        // provided. If it was, we will write the xml file to the tcp writer if present, else
-        // we will write the normal console output using the LogWriter
-        using (writer)
-        {
-            var logger = (writer == null || options.EnableXml) ? new LogWriter(Device) : new LogWriter(Device, writer);
-            logger.MinimumLogLevel = MinimumLogLevel.Info;
-
-            // if we have ignore files, ignore those tests
-            var runner = await InternalRunAsync(logger);
-
-            WriteResults(runner, options, logger, writer ?? Console.Out);
-
-            logger.Info($"Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests + runner.SkippedTests}");
-
-            if (options.AppEndTag != null)
-            {
-                logger.Info(options.AppEndTag);
-            }
-
-            if (options.TerminateAfterExecution)
-            {
-                TerminateWithSuccess();
-            }
-        }
-    }
 }


### PR DESCRIPTION
Today, xharness implements the `AndroidApplicationEntryPoint`, `iOSApplicationEntryPoint` and `WasmApplicationEntryPoint` classes as xunit-specific implementations. Additionally, the `WasmApplicationEntryPoint` type didn't derive at all from `ApplicationEntryPoint` and didn't have good customization points, so it wasn't possible to replace the runner with a different runner.

For the test refactoring work that @trylek and I are doing in dotnet/runtime to make the runtime tests run more like regular tests, we're using a custom source-generated test runner. As a result, we're going to have a test runner/executor that is not the Xunit-provided runner, but we'll need to provide custom runners for each platform to provide our filtering and test execution mechanisms.

To limit the number of assemblies loaded and to ensure that we aren't depending on XUnit but still get the features that xharness uses to run tests correctly, I figured that the easiest way was to refactor the entrypoint classes to have non-Xunit-specific base implementations per-target platform. I also refactored the Wasm entry-point and runner to conform to the `TestRunner` and `ApplicationEntryPoint` base classes so Wasm test runs with our new execution model will be able to easily use the new runner.

I've done my best to keep API and ABI compatibility so as to not break consumers when they pull down the newer versions of the libraries.

cc: @fanyang-mono @naricc 