### PR TITLE
Fix macOS-10.15 vmImage name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,8 +99,7 @@ stages:
         jobs:
         - job: OSX
           pool:
-            name: Hosted macOS
-            vmImage: macOS-10.15
+            vmImage: 'macOS-10.15'
           strategy:
             matrix:
               Release:


### PR DESCRIPTION
Somehow this stopped working over the weekend:
https://dev.azure.com/dnceng/public/_build/results?buildId=1509819&view=results