### PR TITLE
Get Android device architecture for diagnostic data

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -508,9 +508,16 @@ public class AdbRunner
         return result;
     }
 
-    public string? GetDeviceArchitecture(ILogger logger)
+    public string? GetDeviceArchitecture(ILogger logger, string? deviceName = null)
     {
-        var result = RunAdbCommand(new[] { "shell", "getprop", "ro.product.cpu.abi" }, TimeSpan.FromMinutes(1));
+        IEnumerable<string> args = new[] { "shell", "getprop", "ro.product.cpu.abi" };
+
+        if (!string.IsNullOrEmpty(deviceName))
+        {
+            args = new[] { "-s", deviceName }.Concat(args);
+        }
+
+        var result = RunAdbCommand(args, TimeSpan.FromMinutes(1));
 
         if (!result.Succeeded)
         {

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -446,8 +446,6 @@ public class AdbRunner
         return devicesAndProperties;
     }
 
-
-
     public string? GetDeviceToUse(ILogger logger, IEnumerable<string> apkRequiredProperties, string propertyName)
     {
         var allDevicesAndTheirProperties = GetAllDevicesToUse(logger, apkRequiredProperties, propertyName);
@@ -508,6 +506,21 @@ public class AdbRunner
         }
 
         return result;
+    }
+
+    public string? GetDeviceArchitecture(ILogger logger)
+    {
+        var result = RunAdbCommand(new[] { "shell", "getprop", "ro.product.cpu.abi" }, TimeSpan.FromMinutes(1));
+
+        if (!result.Succeeded)
+        {
+            _log.LogError("Failed to get device's architecture. Check if a device is attached / emulator is started" + Environment.NewLine + result.StandardError);
+            return null;
+        }
+
+        _log.LogDebug($"Detected architecture `{result.StandardOutput}` on the selected device");
+
+        return result.StandardOutput.Trim();
     }
 
     public ProcessExecutionResults RunApkInstrumentation(string apkName, string? instrumentationClassName, Dictionary<string, string> args, TimeSpan timeout)

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetStateCommandArguments.cs
@@ -8,5 +8,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
 internal class AndroidGetStateCommandArguments : XHarnessCommandArguments
 {
-    protected override IEnumerable<Argument> GetArguments() => System.Array.Empty<Argument>();
+    public UseJsonArgument UseJson { get; set; } = new();
+
+    protected override IEnumerable<Argument> GetArguments() => new Argument[]
+    {
+        UseJson,
+    };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/UseJsonArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/UseJsonArgument.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple;
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments;
 
 internal class UseJsonArgument : SwitchArgument
 {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidCommand.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.CLI.Commands;
 using Microsoft.DotNet.XHarness.Common;
@@ -26,9 +25,9 @@ internal abstract class AndroidCommand<TArguments> : XHarnessCommand<TArguments>
         IDiagnosticsData data,
         string deviceName,
         int apiVersion,
-        IEnumerable<string> apkRequiredArchitecture)
+        string? deviceArchitecture)
     {
-        data.Target = string.Join(",", apkRequiredArchitecture);
+        data.Target = deviceArchitecture;
         data.TargetOS = "API " + apiVersion;
         data.Device = deviceName;
         data.IsDevice = !deviceName.ToLowerInvariant().StartsWith("emulator");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -71,7 +71,7 @@ Arguments:
 
             runner.SetActiveDevice(deviceToUse);
 
-            var deviceArchitecture = runner.GetDeviceArchitecture(logger);
+            var deviceArchitecture = runner.GetDeviceArchitecture(logger) ?? string.Join(",", apkRequiredArchitecture);
 
             FillDiagnosticData(DiagnosticsData, deviceToUse, runner.APIVersion, deviceArchitecture);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -71,7 +71,9 @@ Arguments:
 
             runner.SetActiveDevice(deviceToUse);
 
-            FillDiagnosticData(DiagnosticsData, deviceToUse, runner.APIVersion, apkRequiredArchitecture);
+            var deviceArchitecture = runner.GetDeviceArchitecture(logger);
+
+            FillDiagnosticData(DiagnosticsData, deviceToUse, runner.APIVersion, deviceArchitecture);
 
             Console.WriteLine(deviceToUse);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -99,7 +99,7 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
         var state = runner.GetAdbState().Trim();
 
         Dictionary<string, string?> deviceAndArchList = runner.GetAttachedDevicesWithProperties("architecture");
-        var allDevices = deviceAndArchList
+        List<DeviceInfo> allDevices = deviceAndArchList
             .Select(d => new DeviceInfo(
                 Name: d.Key,
                 Architecture: runner.GetDeviceArchitecture(logger, d.Key) ?? "unknown",

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
@@ -25,24 +28,55 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
 
     protected override Task<ExitCode> InvokeInternal(ILogger logger)
     {
-        var runner = new AdbRunner(logger);
-
-        logger.LogInformation("Getting state of ADB and attached Android device(s)");
         try
         {
-            string state = runner.GetAdbState();
-            if (string.IsNullOrEmpty(state))
-            {
-                state = "No device attached";
-            }
-            logger.LogInformation($"ADB Version info:{Environment.NewLine}{runner.GetAdbVersion()}");
-            logger.LogInformation($"ADB State ('device' if physically attached):{Environment.NewLine}{state}");
+            var data = GetStateData(logger);
 
-            logger.LogInformation($"List of devices:");
-            var deviceAndArchList = runner.GetAttachedDevicesWithProperties("architecture");
-            foreach (string device in deviceAndArchList.Keys)
+            if (Arguments.UseJson)
             {
-                logger.LogInformation($"Device: '{device}' - Architecture: {deviceAndArchList[device]}");
+                var options = new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                };
+
+                JsonSerializer.Serialize(Console.OpenStandardOutput(), data, options);
+            }
+            else
+            {
+                var state = data.DeviceState switch
+                {
+                    "device" => "Device/emulator is ready",
+                    null or "" => "No device attached",
+                    _ => data.DeviceState,
+                };
+
+                void PrintDeviceInfo(DeviceInfo device)
+                {
+                    logger.LogInformation($"{device.Name}:{Environment.NewLine}" +
+                        $"  Architecture: {device.Architecture}{Environment.NewLine}" +
+                        $"  Supported architectures: {string.Join(", ", device.SupportedArchitectures)}");
+                }
+
+                logger.LogInformation($"ADB Version info:{Environment.NewLine}{string.Join(Environment.NewLine, data.AdbVersion)}");
+                logger.LogInformation($"ADB State:{Environment.NewLine}{state}");
+
+                if (data.Emulators.Any())
+                {
+                    logger.LogInformation($"List of emulators:");
+                    foreach (DeviceInfo emulator in data.Emulators)
+                    {
+                        PrintDeviceInfo(emulator);
+                    }
+                }
+
+                if (data.Devices.Any())
+                {
+                    logger.LogInformation($"List of devices:");
+                    foreach (DeviceInfo device in data.Devices)
+                    {
+                        PrintDeviceInfo(device);
+                    }
+                }
             }
 
             return Task.FromResult(ExitCode.SUCCESS);
@@ -53,4 +87,33 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
             return Task.FromResult(ExitCode.GENERAL_FAILURE);
         }
     }
+
+    private static StateData GetStateData(ILogger logger)
+    {
+        var runner = new AdbRunner(logger);
+
+        logger.LogDebug("Getting state of ADB and attached Android device(s)");
+
+        var adbVersion = runner.GetAdbVersion()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var state = runner.GetAdbState().Trim();
+
+        var deviceAndArchList = runner.GetAttachedDevicesWithProperties("architecture");
+        var allDevices = deviceAndArchList
+            .Select(d => new DeviceInfo(
+                Name: d.Key,
+                Architecture: runner.GetDeviceArchitecture(logger, d.Key) ?? "unknown",
+                SupportedArchitectures: d.Value?.Split(',') ?? Enumerable.Empty<string>()))
+            .ToList();
+
+        var emulators = allDevices.Where(d => d.Name.StartsWith("emulator"));
+        var devices = allDevices.Except(emulators);
+
+        return new StateData(state, adbVersion, emulators, devices);
+    }
+
+    private record StateData(string DeviceState, string[] AdbVersion, IEnumerable<DeviceInfo> Emulators, IEnumerable<DeviceInfo> Devices);
+
+    private record DeviceInfo(string Name, string Architecture, IEnumerable<string> SupportedArchitectures);
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -112,7 +112,9 @@ Arguments:
 
             runner.SetActiveDevice(deviceId);
 
-            FillDiagnosticData(diagnosticsData, deviceId, runner.APIVersion, apkRequiredArchitecture);
+            var deviceArchitecture = runner.GetDeviceArchitecture(logger);
+
+            FillDiagnosticData(diagnosticsData, deviceId, runner.APIVersion, deviceArchitecture);
 
             runner.TimeToWaitForBootCompletion = bootTimeoutSeconds;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -63,13 +63,13 @@ Arguments:
         try
         {
             return Task.FromResult(InvokeHelper(
-            logger: logger,
-            apkPackageName: Arguments.PackageName,
-            appPackagePath: Arguments.AppPackagePath,
-            apkRequiredArchitecture: apkRequiredArchitecture,
-            deviceId: Arguments.DeviceId,
-            bootTimeoutSeconds: Arguments.LaunchTimeout,
-            runner: runner,
+                logger: logger,
+                apkPackageName: Arguments.PackageName,
+                appPackagePath: Arguments.AppPackagePath,
+                apkRequiredArchitecture: apkRequiredArchitecture,
+                deviceId: Arguments.DeviceId,
+                bootTimeoutSeconds: Arguments.LaunchTimeout,
+                runner: runner,
             DiagnosticsData));
         }
         catch (NoDeviceFoundException noDevice)
@@ -112,7 +112,7 @@ Arguments:
 
             runner.SetActiveDevice(deviceId);
 
-            var deviceArchitecture = runner.GetDeviceArchitecture(logger);
+            var deviceArchitecture = runner.GetDeviceArchitecture(logger) ?? string.Join(",", apkRequiredArchitecture);
 
             FillDiagnosticData(diagnosticsData, deviceId, runner.APIVersion, deviceArchitecture);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.Android.Execution;
@@ -71,7 +70,8 @@ Arguments:
         // For test command, this was already filled during installation
         if (DiagnosticsData.Device == null)
         {
-            FillDiagnosticData(DiagnosticsData, deviceId, runner.APIVersion, Enumerable.Empty<string>());
+            var deviceArchitecture = runner.GetDeviceArchitecture(logger);
+            FillDiagnosticData(DiagnosticsData, deviceId, runner.APIVersion, deviceArchitecture);
         }
 
         runner.TimeToWaitForBootCompletion = Arguments.LaunchTimeout;

--- a/src/Microsoft.DotNet.XHarness.CLI/Program.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Program.cs
@@ -102,6 +102,7 @@ public static class Program
                 return args[1] switch
                 {
                     "device" => true,
+                    "state" => args.Contains("--json"),
                     _ => false,
                 };
 
@@ -109,6 +110,7 @@ public static class Program
                 return args[1] switch
                 {
                     "device" => true,
+                    "state" => args.Contains("--json"),
                     "adb" => true,
                     _ => false,
                 };


### PR DESCRIPTION
Currently, we do not include device's architecture in diagnostic data but rather the first of a list of all supported archs by the device. This PR adds a new ADB call that queries for the actual architecture of the device.

Secondly, this PR brings the Android and Apple `state` commands on-par and allows to export Android state information as JSON too (useful for querying devices over Helix for example).

Fixes #794 