### PR TITLE
Add `DOTNET_ROOT` instructions to `Install-XHarness.ps1`

### DIFF
--- a/tools/Install-XHarness.ps1
+++ b/tools/Install-XHarness.ps1
@@ -28,6 +28,6 @@ Write-Host "Installing XHarness in current folder" -ForegroundColor Cyan
 ./.dotnet/dotnet tool install --tool-path . --version $xharness_version --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json Microsoft.DotNet.XHarness.CLI
 
 Write-Host "Run following command: " -ForegroundColor Cyan -NoNewline
-Write-Host '$Env:DOTNET_ROOT=".\.dotnet"' -ForegroundColor Yellow
+Write-Host "`$Env:DOTNET_ROOT='$pwd.dotnet'" -ForegroundColor Yellow
 Write-Host "Then run XHarness using: " -ForegroundColor Cyan -NoNewline
 Write-Host ".\xharness help" -ForegroundColor Yellow

--- a/tools/Install-XHarness.ps1
+++ b/tools/Install-XHarness.ps1
@@ -27,5 +27,7 @@ Write-Host "Installing XHarness in current folder" -ForegroundColor Cyan
 
 ./.dotnet/dotnet tool install --tool-path . --version $xharness_version --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json Microsoft.DotNet.XHarness.CLI
 
-Write-Host "XHarness installed, run it using: " -ForegroundColor Cyan -NoNewline
+Write-Host "Run following command: " -ForegroundColor Cyan -NoNewline
+Write-Host '$Env:DOTNET_ROOT=".\.dotnet"' -ForegroundColor Yellow
+Write-Host "Then run XHarness using: " -ForegroundColor Cyan -NoNewline
 Write-Host ".\xharness help" -ForegroundColor Yellow


### PR DESCRIPTION
This prevents the user from not being able to run things. Similar instructions are already in the Linux script 