### PR TITLE
ThreadlessXunitTestRunner: Escape newlines in test result lines

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -71,17 +71,17 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
             }
             testSink.Execution.TestPassedEvent += args =>
             {
-                Console.WriteLine($"[PASS] {args.Message.Test.DisplayName}");
+                Console.WriteLine($"[PASS] {EscapeNewLines(args.Message.Test.DisplayName)}");
                 PassedTests++;
             };
             testSink.Execution.TestSkippedEvent += args =>
             {
-                Console.WriteLine($"[SKIP] {args.Message.Test.DisplayName}");
+                Console.WriteLine($"[SKIP] {EscapeNewLines(args.Message.Test.DisplayName)}");
                 SkippedTests++;
             };
             testSink.Execution.TestFailedEvent += args =>
             {
-                Console.WriteLine($"[FAIL] {args.Message.Test.DisplayName}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}");
+                Console.WriteLine($"[FAIL] {EscapeNewLines(args.Message.Test.DisplayName)}{Environment.NewLine}{ExceptionUtility.CombineMessages(args.Message)}{Environment.NewLine}{ExceptionUtility.CombineStackTraces(args.Message)}");
                 FailedTests++;
             };
             testSink.Execution.TestFinishedEvent += args => ExecutedTests++;
@@ -96,6 +96,8 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
         }
         TotalTests = totalSummary.Total;
         Console.WriteLine($"{Environment.NewLine}=== TEST EXECUTION SUMMARY ==={Environment.NewLine}Total: {totalSummary.Total}, Errors: 0, Failed: {totalSummary.Failed}, Skipped: {totalSummary.Skipped}, Time: {TimeSpan.FromSeconds((double)totalSummary.Time).TotalSeconds}s{Environment.NewLine}");
+
+        static string EscapeNewLines(string message) => message.Replace("\r", "\\r").Replace("\n", "\\n");
     }
 
     private ExecutionSummary Combine(ExecutionSummary aggregateSummary, ExecutionSummary assemblySummary)


### PR DESCRIPTION
`ThreadlessXunitTestRunner` writes lines like:

    `[PASS] foo.testname(testargs)`

to the console, which gets parsed by `WasmTestMessageProcessor`. But if
the list of arguments contains a new line(eg. in data for
`System.Text.RegularExpressions` tests), then the output line gets written
as multiple lines to the console. And that results in the output looking
like:

```
[02:41:04] info: abc, beginning: 0, length: 5, expectedSuccess: True, expectedValue: "a\nabc")
[02:41:04] info: abc, beginning: 0, length: 5, expectedSuccess: True, expectedValue: "a\nabc")
...
```

Each of those lines being the last part of the `[PASS] foo.testname(someargs, "\nabc, ..")`.

Instead, we escape the new line chars.

Partially fixes https://github.com/dotnet/xharness/issues/816