### PR TITLE
Report `RETURN_CODE_NOT_SET` when exit code detection blows up

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -235,7 +235,15 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             return ExitCode.RETURN_CODE_NOT_SET;
         }
 
-        exitCode = exitCodeDetector.DetectExitCode(appBundleInfo, systemLog);
+        try
+        {
+            exitCode = exitCodeDetector.DetectExitCode(appBundleInfo, systemLog);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError($"Failed to determine the exit code:{Environment.NewLine}{e}");
+            return ExitCode.RETURN_CODE_NOT_SET;
+        }
 
         if (exitCode is null)
         {


### PR DESCRIPTION
The exit code detector throws an exception when it fails to completely find the system log:
```
[02:27:32] fail: Application run failed:
                 System.Exception: Failed to detect application's exit code. The system log was empty / not found at /tmp/helix/working/A09F08E2/w/CB8C0AAA/uploads/iPhone X (iOS 15.0) - created by XHarness.log
                    at Microsoft.DotNet.XHarness.Apple.ExitCodeDetector.DetectExitCode(AppBundleInformation appBundleInfo, IReadableLog systemLog) in /_/src/Microsoft.DotNet.XHarness.Apple/ExitCodeDetector.cs:line 38
                    at Microsoft.DotNet.XHarness.Apple.RunOrchestrator.ParseResult(IExitCodeDetector exitCodeDetector, Int32 expectedExitCode, AppBundleInformation appBundleInfo, ProcessExecutionResult result) in /_/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs:line 238
                    at Microsoft.DotNet.XHarness.Apple.RunOrchestrator.ExecuteApp(AppBundleInformation appBundleInfo, TestTargetOs target, IDevice device, IDevice companionDevice, TimeSpan timeout, Int32 expectedExitCode, Boolean signalAppEnd, IReadOnlyCollection`1 environmentalVariables, IEnumerable`1 passthroughArguments, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs:line 186
                    at Microsoft.DotNet.XHarness.Apple.BaseOrchestrator.OrchestrateOperation(TestTargetOs target, String deviceName, Boolean includeWirelessDevices, Boolean resetSimulator, Boolean enableLldb, AppBundleInformation appBundleInfo, Func`2 executeMacCatalystApp, Func`4 executeApp, CancellationToken cancellationToken) in /_/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs:line 212
                 
[02:27:32] info: Uninstalling the application 'net.dot.HelloiOS' from 'iPhone X (iOS 15.0) - created by XHarness'
XHarness exit code: 71 (GENERAL_FAILURE)
```