### PR TITLE
Refactor querying Android devices, allow specifying API version

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -449,14 +449,14 @@ public class AdbRunner
     }
 
     public List<AndroidDevice> GetAttachedDevicesWithProperties()
-        => GetAttachedDevicesWithProperties(
+        => GetDevices(
                 AdbPropertyNames.Architecture,
                 AdbPropertyNames.ApiVersion,
                 AdbPropertyNames.SupportedArchitectures)
             .Select(DeviceFromPropertyBag)
             .ToList();
 
-    private Dictionary<string, Dictionary<string, string?>> GetAttachedDevicesWithProperties(params string[] properties)
+    private Dictionary<string, Dictionary<string, string?>> GetDevices(params string[] propertiesToLoad)
     {
         var devicesAndProperties = new Dictionary<string, Dictionary<string, string?>>();
 
@@ -503,7 +503,7 @@ public class AdbRunner
                     var deviceProperties = new Dictionary<string, string?>();
                     devicesAndProperties.Add(deviceSerial, deviceProperties);
 
-                    foreach (var property in properties)
+                    foreach (var property in propertiesToLoad)
                     {
                         var shellResult = RunAdbCommand(GetAdbArguments(deviceSerial, property), TimeSpan.FromSeconds(30));
 
@@ -664,7 +664,7 @@ public class AdbRunner
 
         try
         {
-            devices = GetAttachedDevicesWithProperties(properties.ToArray())
+            devices = GetDevices(properties.ToArray())
                 .Select(DeviceFromPropertyBag)
                 .ToList();
         }
@@ -814,7 +814,7 @@ public class AdbRunner
 
     #endregion
 
-        #region Process runner helpers
+    #region Process runner helpers
 
     public ProcessExecutionResults RunAdbCommand(params string[] arguments) => RunAdbCommand(arguments, TimeSpan.FromMinutes(5));
 

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -657,7 +657,7 @@ public class AdbRunner
 
         if (requiredInstalledApp != null)
         {
-            properties.Add("app");
+            properties.Add(AdbPropertyNames.InstalledApps);
         }
 
         List<AndroidDevice> devices;
@@ -715,7 +715,7 @@ public class AdbRunner
 
         if (requiredInstalledApp != null)
         {
-            devices = devices.Where(device => device.InstalledApplications?.Contains(requiredInstalledApp) ?? false).ToList();
+            devices = devices.Where(device => device.InstalledApplications?.Any(app => app.Contains(requiredInstalledApp)) ?? false).ToList();
 
             if (devices.Count == 0)
             {

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -746,9 +746,11 @@ public class AdbRunner
             return null;
         }
 
-        _log.LogDebug($"Detected architecture `{result.StandardOutput}` on the selected device");
+        var architecture = result.StandardOutput.Trim();
 
-        return result.StandardOutput.Trim();
+        _log.LogDebug($"Detected architecture `{architecture}` on the selected device");
+
+        return architecture;
     }
 
     public ProcessExecutionResults RunApkInstrumentation(string apkName, string? instrumentationClassName, Dictionary<string, string> args, TimeSpan timeout)

--- a/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.XHarness.Android;
+
+public record AndroidDevice(
+    string DeviceSerial,
+    int? ApiVersion = null,
+    string? Architecture = null,
+    ICollection<string>? SupportedArchitectures = null,
+    ICollection<string>? InstalledApplications = null);

--- a/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
@@ -6,9 +6,17 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.Android;
 
-public record AndroidDevice(
-    string DeviceSerial,
-    int? ApiVersion = null,
-    string? Architecture = null,
-    IReadOnlyCollection<string>? SupportedArchitectures = null,
-    IReadOnlyCollection<string>? InstalledApplications = null);
+public record AndroidDevice
+{
+    public string DeviceSerial { get; init; }
+
+    public int? ApiVersion { get; set; } = null;
+
+    public string? Architecture { get; set; } = null;
+
+    public IReadOnlyCollection<string>? SupportedArchitectures { get; set; } = null;
+
+    public IReadOnlyCollection<string>? InstalledApplications { get; set; } = null;
+
+    public AndroidDevice(string deviceSerial) => DeviceSerial = deviceSerial;
+}

--- a/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
@@ -10,5 +10,5 @@ public record AndroidDevice(
     string DeviceSerial,
     int? ApiVersion = null,
     string? Architecture = null,
-    ICollection<string>? SupportedArchitectures = null,
-    ICollection<string>? InstalledApplications = null);
+    IReadOnlyCollection<string>? SupportedArchitectures = null,
+    IReadOnlyCollection<string>? InstalledApplications = null);

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
 internal class AndroidGetDeviceCommandArguments : XHarnessCommandArguments
 {
-    public AppPathArgument AppPackagePath { get; } = new();
+    public OptionalAppPathArgument AppPackagePath { get; } = new();
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
     public ApiVersionArgument ApiVersion { get; } = new();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidGetDeviceCommandArguments.cs
@@ -10,10 +10,12 @@ internal class AndroidGetDeviceCommandArguments : XHarnessCommandArguments
 {
     public AppPathArgument AppPackagePath { get; } = new();
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
+    public ApiVersionArgument ApiVersion { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
-            AppPackagePath,
-            DeviceArchitecture,
+        AppPackagePath,
+        DeviceArchitecture,
+        ApiVersion,
     };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidInstallCommandArguments.cs
@@ -7,24 +7,26 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
-internal class AndroidInstallCommandArguments : XHarnessCommandArguments
+internal class AndroidInstallCommandArguments : XHarnessCommandArguments, IAndroidAppRunArguments
 {
     public AppPathArgument AppPackagePath { get; } = new();
     public PackageNameArgument PackageName { get; } = new();
     public OutputDirectoryArgument OutputDirectory { get; } = new();
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
-    public DeviceIdArgument DeviceId { get; } = new();
     public LaunchTimeoutArgument LaunchTimeout { get; } = new(TimeSpan.FromMinutes(5));
+    public DeviceIdArgument DeviceId { get; } = new();
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
+    public ApiVersionArgument ApiVersion { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
-            AppPackagePath,
-            PackageName,
-            OutputDirectory,
-            Timeout,
-            DeviceId,
-            LaunchTimeout,
-            DeviceArchitecture,
+        AppPackagePath,
+        PackageName,
+        OutputDirectory,
+        Timeout,
+        DeviceId,
+        LaunchTimeout,
+        DeviceArchitecture,
+        ApiVersion,
     };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -7,13 +7,15 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
-internal class AndroidRunCommandArguments : XHarnessCommandArguments
+internal class AndroidRunCommandArguments : XHarnessCommandArguments, IAndroidAppRunArguments
 {
     public PackageNameArgument PackageName { get; } = new();
     public OutputDirectoryArgument OutputDirectory { get; } = new();
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
     public LaunchTimeoutArgument LaunchTimeout { get; } = new(TimeSpan.FromMinutes(5));
     public DeviceIdArgument DeviceId { get; } = new();
+    public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
+    public ApiVersionArgument ApiVersion { get; } = new();
     public InstrumentationNameArgument InstrumentationName { get; } = new();
     public InstrumentationArguments InstrumentationArguments { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
@@ -22,15 +24,17 @@ internal class AndroidRunCommandArguments : XHarnessCommandArguments
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
-            PackageName,
-            OutputDirectory,
-            Timeout,
-            LaunchTimeout,
-            DeviceId,
-            InstrumentationName,
-            InstrumentationArguments,
-            ExpectedExitCode,
-            DeviceOutputFolder,
-            Wifi,
+        PackageName,
+        OutputDirectory,
+        Timeout,
+        LaunchTimeout,
+        DeviceId,
+        DeviceArchitecture, // TODO: Use this in the command
+        ApiVersion,
+        InstrumentationName,
+        InstrumentationArguments,
+        ExpectedExitCode,
+        DeviceOutputFolder,
+        Wifi,
     };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -14,7 +14,6 @@ internal class AndroidRunCommandArguments : XHarnessCommandArguments, IAndroidAp
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
     public LaunchTimeoutArgument LaunchTimeout { get; } = new(TimeSpan.FromMinutes(5));
     public DeviceIdArgument DeviceId { get; } = new();
-    public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
     public ApiVersionArgument ApiVersion { get; } = new();
     public InstrumentationNameArgument InstrumentationName { get; } = new();
     public InstrumentationArguments InstrumentationArguments { get; } = new();
@@ -29,7 +28,6 @@ internal class AndroidRunCommandArguments : XHarnessCommandArguments, IAndroidAp
         Timeout,
         LaunchTimeout,
         DeviceId,
-        DeviceArchitecture, // TODO: Use this in the command
         ApiVersion,
         InstrumentationName,
         InstrumentationArguments,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -31,7 +31,7 @@ internal class AndroidTestCommandArguments : XHarnessCommandArguments, IAndroidA
         Timeout,
         LaunchTimeout,
         DeviceArchitecture,
-        DeviceId, // TODO: Use this in the command
+        DeviceId,
         ApiVersion,
         InstrumentationName,
         InstrumentationArguments,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -7,14 +7,16 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
-internal class AndroidTestCommandArguments : XHarnessCommandArguments
+internal class AndroidTestCommandArguments : XHarnessCommandArguments, IAndroidAppRunArguments
 {
     public AppPathArgument AppPackagePath { get; } = new();
     public PackageNameArgument PackageName { get; } = new();
     public OutputDirectoryArgument OutputDirectory { get; } = new();
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
     public LaunchTimeoutArgument LaunchTimeout { get; } = new(TimeSpan.FromMinutes(5));
+    public DeviceIdArgument DeviceId { get; } = new();
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
+    public ApiVersionArgument ApiVersion { get; } = new();
     public InstrumentationNameArgument InstrumentationName { get; } = new();
     public InstrumentationArguments InstrumentationArguments { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
@@ -23,16 +25,18 @@ internal class AndroidTestCommandArguments : XHarnessCommandArguments
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
-            AppPackagePath,
-            PackageName,
-            OutputDirectory,
-            Timeout,
-            LaunchTimeout,
-            DeviceArchitecture,
-            InstrumentationName,
-            InstrumentationArguments,
-            ExpectedExitCode,
-            DeviceOutputFolder,
-            Wifi,
+        AppPackagePath,
+        PackageName,
+        OutputDirectory,
+        Timeout,
+        LaunchTimeout,
+        DeviceArchitecture,
+        DeviceId, // TODO: Use this in the command
+        ApiVersion,
+        InstrumentationName,
+        InstrumentationArguments,
+        ExpectedExitCode,
+        DeviceOutputFolder,
+        Wifi,
     };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ApiVersionArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ApiVersionArgument.cs
@@ -4,10 +4,10 @@
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
-internal class ApiVersionArgument : IntArgument
+internal class ApiVersionArgument : OptionalIntArgument
 {
     public ApiVersionArgument()
-        : base("api-version=|api=", "Target a device/emulator with given Android API version (level)", defaultValue: -1)
+        : base("api-version=|api=", "Target a device/emulator with given Android API version (level)")
     {
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ApiVersionArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/ApiVersionArgument.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
+
+internal class ApiVersionArgument : IntArgument
+{
+    public ApiVersionArgument()
+        : base("api-version=|api=", "Target a device/emulator with given Android API version (level)", defaultValue: -1)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/IAndroidAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/IAndroidAppRunArguments.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
+
+internal interface IAndroidAppRunArguments
+{
+    public PackageNameArgument PackageName { get; }
+    public OutputDirectoryArgument OutputDirectory { get; }
+    public TimeoutArgument Timeout { get; }
+    public LaunchTimeoutArgument LaunchTimeout { get; }
+    public DeviceIdArgument DeviceId { get; }
+    public DeviceArchitectureArgument DeviceArchitecture { get; }
+    public ApiVersionArgument ApiVersion { get; }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/IAndroidAppRunArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/IAndroidAppRunArguments.cs
@@ -6,11 +6,10 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 
 internal interface IAndroidAppRunArguments
 {
-    public PackageNameArgument PackageName { get; }
-    public OutputDirectoryArgument OutputDirectory { get; }
-    public TimeoutArgument Timeout { get; }
-    public LaunchTimeoutArgument LaunchTimeout { get; }
-    public DeviceIdArgument DeviceId { get; }
-    public DeviceArchitectureArgument DeviceArchitecture { get; }
-    public ApiVersionArgument ApiVersion { get; }
+    PackageNameArgument PackageName { get; }
+    OutputDirectoryArgument OutputDirectory { get; }
+    TimeoutArgument Timeout { get; }
+    LaunchTimeoutArgument LaunchTimeout { get; }
+    DeviceIdArgument DeviceId { get; }
+    ApiVersionArgument ApiVersion { get; }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
@@ -154,6 +154,25 @@ public abstract class IntArgument : Argument<int>
     }
 }
 
+public abstract class OptionalIntArgument : Argument<int?>
+{
+    public OptionalIntArgument(string prototype, string description)
+        : base(prototype, description, null)
+    {
+    }
+
+    public override void Action(string argumentValue)
+    {
+        if (int.TryParse(argumentValue, out var number))
+        {
+            Value = number;
+            return;
+        }
+
+        throw new ArgumentException($"{Prototype} must be an integer");
+    }
+}
+
 public abstract class StringArgument : Argument<string?>
 {
     public StringArgument(string prototype, string description)

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/AppPathArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/AppPathArgument.cs
@@ -13,3 +13,13 @@ internal class AppPathArgument : RequiredPathArgument
     {
     }
 }
+
+/// <summary>
+/// Path to the app bundle.
+/// </summary>
+internal class OptionalAppPathArgument : PathArgument
+{
+    public OptionalAppPathArgument() : base("app|a=", "Path to an already-packaged app", false)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidCommand.cs
@@ -20,16 +20,4 @@ internal abstract class AndroidCommand<TArguments> : XHarnessCommand<TArguments>
     {
         _diagnosticsData = new(() => Services.BuildServiceProvider().GetRequiredService<IDiagnosticsData>());
     }
-
-    protected static void FillDiagnosticData(
-        IDiagnosticsData data,
-        string deviceName,
-        int apiVersion,
-        string? deviceArchitecture)
-    {
-        data.Target = deviceArchitecture;
-        data.TargetOS = "API " + apiVersion;
-        data.Device = deviceName;
-        data.IsDevice = !deviceName.ToLowerInvariant().StartsWith("emulator");
-    }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
+using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.Logging;
 
@@ -64,8 +65,8 @@ Arguments:
             // enumerate the devices attached and their architectures
             // Tell ADB to only use that one (will always use the present one for systems w/ only 1 machine)
             var device = runner.GetDevice(
-                logger,
-                shouldGetArchitecture: true,
+                loadApiVersion: true,
+                loadArchitecture: true,
                 requiredApiVersion: Arguments.ApiVersion.Value,
                 requiredArchitectures: apkRequiredArchitecture);
 
@@ -74,9 +75,7 @@ Arguments:
                 return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
             }
 
-            runner.SetActiveDevice(device);
-
-            FillDiagnosticData(DiagnosticsData, device.DeviceSerial, runner.ApiVersion, device.Architecture);
+            DiagnosticsData.CaptureDeviceInfo(device);
 
             Console.WriteLine(device.DeviceSerial);
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetDeviceCommand.cs
@@ -66,7 +66,7 @@ Arguments:
             var device = runner.GetDevice(
                 logger,
                 shouldGetArchitecture: true,
-                requiredApiVersion: Arguments.ApiVersion.Value == -1 ? null : Arguments.ApiVersion.Value,
+                requiredApiVersion: Arguments.ApiVersion.Value,
                 requiredArchitectures: apkRequiredArchitecture);
 
             if (device is null)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -99,7 +99,7 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
 
         var state = runner.GetAdbState().Trim();
 
-        List<AndroidDevice> allDevices = runner.GetAttachedDevicesWithProperties();
+        IReadOnlyCollection<AndroidDevice> allDevices = runner.GetDevices();
 
         var emulators = allDevices.Where(d => d.DeviceSerial.StartsWith("emulator"));
         var devices = allDevices.Except(emulators);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidGetStateCommand.cs
@@ -50,11 +50,12 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
                 _ => data.DeviceState,
             };
 
-            void PrintDeviceInfo(DeviceInfo device)
+            void PrintAndroidDevice(AndroidDevice device)
             {
-                logger.LogInformation($"{device.Name}:{Environment.NewLine}" +
+                logger.LogInformation($"{device.DeviceSerial}:{Environment.NewLine}" +
                     $"  Architecture: {device.Architecture}{Environment.NewLine}" +
-                    $"  Supported architectures: {string.Join(", ", device.SupportedArchitectures)}");
+                    $"  API version: {device.ApiVersion}{Environment.NewLine}" +
+                    $"  Supported architectures: {string.Join(", ", device?.SupportedArchitectures ?? Array.Empty<string>())}");
             }
 
             logger.LogInformation($"ADB Version info:{Environment.NewLine}{string.Join(Environment.NewLine, data.AdbVersion)}");
@@ -63,18 +64,18 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
             if (data.Emulators.Any())
             {
                 logger.LogInformation($"List of emulators:");
-                foreach (DeviceInfo emulator in data.Emulators)
+                foreach (AndroidDevice emulator in data.Emulators)
                 {
-                    PrintDeviceInfo(emulator);
+                    PrintAndroidDevice(emulator);
                 }
             }
 
             if (data.Devices.Any())
             {
                 logger.LogInformation($"List of devices:");
-                foreach (DeviceInfo device in data.Devices)
+                foreach (AndroidDevice device in data.Devices)
                 {
-                    PrintDeviceInfo(device);
+                    PrintAndroidDevice(device);
                 }
             }
 
@@ -98,21 +99,13 @@ internal class AndroidGetStateCommand : GetStateCommand<AndroidGetStateCommandAr
 
         var state = runner.GetAdbState().Trim();
 
-        Dictionary<string, string?> deviceAndArchList = runner.GetAttachedDevicesWithProperties("architecture");
-        List<DeviceInfo> allDevices = deviceAndArchList
-            .Select(d => new DeviceInfo(
-                Name: d.Key,
-                Architecture: runner.GetDeviceArchitecture(logger, d.Key) ?? "unknown",
-                SupportedArchitectures: d.Value?.Split(',') ?? Enumerable.Empty<string>()))
-            .ToList();
+        List<AndroidDevice> allDevices = runner.GetAttachedDevicesWithProperties();
 
-        var emulators = allDevices.Where(d => d.Name.StartsWith("emulator"));
+        var emulators = allDevices.Where(d => d.DeviceSerial.StartsWith("emulator"));
         var devices = allDevices.Except(emulators);
 
         return new StateData(state, adbVersion, emulators, devices);
     }
 
-    private record StateData(string DeviceState, string[] AdbVersion, IEnumerable<DeviceInfo> Emulators, IEnumerable<DeviceInfo> Devices);
-
-    private record DeviceInfo(string Name, string Architecture, IEnumerable<string> SupportedArchitectures);
+    private record StateData(string DeviceState, string[] AdbVersion, IEnumerable<AndroidDevice> Emulators, IEnumerable<AndroidDevice> Devices);
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -68,7 +68,7 @@ Arguments:
                 appPackagePath: Arguments.AppPackagePath,
                 apkRequiredArchitecture: apkRequiredArchitecture,
                 deviceId: Arguments.DeviceId,
-                apiVersion: Arguments.ApiVersion.Value == -1 ? null : Arguments.ApiVersion.Value,
+                apiVersion: Arguments.ApiVersion.Value,
                 bootTimeoutSeconds: Arguments.LaunchTimeout,
                 runner: runner,
             DiagnosticsData));

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -102,23 +102,26 @@ Arguments:
             // Make sure the adb server is started
             runner.StartAdbServer();
 
-            AndroidDevice? device = runner.GetDevice(logger, true, deviceId, apiVersion, apkRequiredArchitecture);
+            AndroidDevice? device = runner.GetDevice(
+                loadArchitecture: true,
+                loadApiVersion: true,
+                deviceId,
+                apiVersion,
+                apkRequiredArchitecture);
 
             if (device is null)
             {
                 throw new NoDeviceFoundException($"Failed to find compatible device: {string.Join(", ", apkRequiredArchitecture)}");
             }
 
-            runner.SetActiveDevice(device);
-
-            FillDiagnosticData(diagnosticsData, device.DeviceSerial, runner.ApiVersion, device.Architecture);
+            diagnosticsData.CaptureDeviceInfo(device);
 
             runner.TimeToWaitForBootCompletion = bootTimeoutSeconds;
 
             // Wait till at least device(s) are ready
             runner.WaitForDevice();
 
-            logger.LogDebug($"Working with {runner.GetAdbVersion()}");
+            logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 
             // If anything changed about the app, Install will fail; uninstall it first.
             // (we'll ignore if it's not present)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -58,21 +58,15 @@ Arguments:
         runner.StartAdbServer();
 
         var device = string.IsNullOrEmpty(Arguments.DeviceId.Value)
-            ? runner.GetSingleDevice(logger, true, requiredInstalledApp: "package:" + apkPackageName)
-            : runner.GetSingleDevice(logger, true, requiredDeviceId: Arguments.DeviceId.Value);
+            ? runner.GetSingleDevice(loadArchitecture: true, loadApiVersion: true, requiredInstalledApp: "package:" + apkPackageName)
+            : runner.GetSingleDevice(loadArchitecture: true, loadApiVersion: true, requiredDeviceId: Arguments.DeviceId.Value);
 
         if (device is null)
         {
             return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
         }
 
-        runner.SetActiveDevice(device);
-
-        // For test command, this was already filled during installation
-        if (DiagnosticsData.Device == null)
-        {
-            FillDiagnosticData(DiagnosticsData, device.DeviceSerial, runner.ApiVersion, device.Architecture);
-        }
+        DiagnosticsData.CaptureDeviceInfo(device);
 
         runner.TimeToWaitForBootCompletion = Arguments.LaunchTimeout;
 
@@ -106,7 +100,7 @@ Arguments:
     {
         int instrumentationExitCode = (int)ExitCode.GENERAL_FAILURE;
 
-        logger.LogDebug($"Working with {runner.GetAdbVersion()}");
+        logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
 
         // Empty log as we'll be uploading the full logcat for this execution
         runner.ClearAdbLog();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -78,7 +78,7 @@ Arguments:
                 appPackagePath: appPackagePath,
                 apkRequiredArchitecture: apkRequiredArchitecture,
                 deviceId: Arguments.DeviceId.Value,
-                apiVersion: Arguments.ApiVersion.Value == -1 ? null : Arguments.ApiVersion.Value,
+                apiVersion: Arguments.ApiVersion.Value,
                 bootTimeoutSeconds: Arguments.LaunchTimeout,
                 runner,
                 DiagnosticsData);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -77,7 +77,8 @@ Arguments:
                 apkPackageName: apkPackageName,
                 appPackagePath: appPackagePath,
                 apkRequiredArchitecture: apkRequiredArchitecture,
-                deviceId: null,
+                deviceId: Arguments.DeviceId.Value,
+                apiVersion: Arguments.ApiVersion.Value == -1 ? null : Arguments.ApiVersion.Value,
                 bootTimeoutSeconds: Arguments.LaunchTimeout,
                 runner,
                 DiagnosticsData);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
@@ -46,8 +46,8 @@ Arguments:
                 runner.StartAdbServer();
 
                 AndroidDevice? device = runner.GetSingleDevice(
-                    logger,
-                    true,
+                    loadArchitecture: true,
+                    loadApiVersion: true,
                     requiredDeviceId: Arguments.DeviceId,
                     requiredInstalledApp: "package:" + apkPackageName);
 
@@ -56,11 +56,9 @@ Arguments:
                     return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
                 }
 
-                runner.SetActiveDevice(device);
+                DiagnosticsData.CaptureDeviceInfo(device);
 
-                FillDiagnosticData(DiagnosticsData, device.DeviceSerial, runner.ApiVersion, device.Architecture);
-
-                logger.LogDebug($"Working with {runner.GetAdbVersion()}");
+                logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 
                 runner.UninstallApk(apkPackageName);
                 return Task.FromResult(ExitCode.SUCCESS);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidUninstallCommand.cs
@@ -45,21 +45,20 @@ Arguments:
                 // Make sure the adb server is started
                 runner.StartAdbServer();
 
-                string? deviceId = Arguments.DeviceId;
+                AndroidDevice? device = runner.GetSingleDevice(
+                    logger,
+                    true,
+                    requiredDeviceId: Arguments.DeviceId,
+                    requiredInstalledApp: "package:" + apkPackageName);
 
-                if (string.IsNullOrEmpty(deviceId))
+                if (device is null)
                 {
-                    // trying to find out if there is only one device with the app installed
-                    deviceId = runner.GetUniqueDeviceToUse(logger, "package:" + apkPackageName, "app");
-                    if (string.IsNullOrEmpty(deviceId))
-                    {
-                        return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
-                    }
+                    return Task.FromResult(ExitCode.ADB_DEVICE_ENUMERATION_FAILURE);
                 }
 
-                runner.SetActiveDevice(deviceId);
-                DiagnosticsData.TargetOS = "API " + runner.APIVersion;
-                DiagnosticsData.Device = deviceId;
+                runner.SetActiveDevice(device);
+
+                FillDiagnosticData(DiagnosticsData, device.DeviceSerial, runner.ApiVersion, device.Architecture);
 
                 logger.LogDebug($"Working with {runner.GetAdbVersion()}");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/IDiagnosticDataExtensions.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/IDiagnosticDataExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Android;
+using Microsoft.DotNet.XHarness.Common;
+
+namespace Microsoft.DotNet.XHarness.CLI.Android;
+
+internal static class IDiagnosticDataExtensions
+{
+    public static void CaptureDeviceInfo(this IDiagnosticsData data, AndroidDevice device)
+    {
+        data.Target = device.Architecture;
+        data.TargetOS = "API " + device.ApiVersion;
+        data.Device = device.DeviceSerial;
+        data.IsDevice = !device.DeviceSerial.ToLowerInvariant().StartsWith("emulator");
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -214,6 +214,17 @@ public class AdbRunnerTests : IDisposable
     }
 
     [Fact]
+    public void GetDeviceWithAppAndApiVersion()
+    {
+        var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
+        var device = _fakeDeviceList.Single(d => d.ApiVersion == 31 && d.InstalledApplications.Contains("net.dot.E"));
+        var result = runner.GetDevice(_mainLog.Object, requiredInstalledApp: "net.dot.E", requiredApiVersion: 31);
+        VerifyAdbCall("devices", "-l");
+        Assert.Equal(device.DeviceSerial, result.DeviceSerial);
+        Assert.Equal(device.ApiVersion, result.ApiVersion);
+    }
+
+    [Fact]
     public void RebootAndroidDevice()
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
@@ -351,7 +362,7 @@ public class AdbRunnerTests : IDisposable
                     s_bootCompleteCheckTimes++;
                 }
 
-                if (string.Join(" ", arguments.Skip(argStart + 1).Take(5)).Equals("shell pm list packages -3"))
+                if (string.Join(" ", arguments.Skip(argStart).Take(5)).Equals("shell pm list packages -3"))
                 {
                     stdOut = "package:" + string.Join("\npackage:", _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).InstalledApplications);
                 }

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -25,8 +25,7 @@ public class AdbRunnerTests : IDisposable
     private static int s_bootCompleteCheckTimes = 0;
     private readonly Mock<ILogger> _mainLog;
     private readonly Mock<IAdbProcessManager> _processManager;
-    private readonly Dictionary<Tuple<string, string>, int> _fakeDeviceList;
-
+    private readonly List<AndroidDevice> _fakeDeviceList;
 
     public AdbRunnerTests()
     {
@@ -87,7 +86,6 @@ public class AdbRunnerTests : IDisposable
     public void DumpBugReport()
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
-        runner.SetActiveDevice(string.Empty);
         string pathToDumpBugReport = Path.Join(s_scratchAndOutputPath, Path.GetRandomFileName());
         runner.DumpBugReport(pathToDumpBugReport);
         VerifyAdbCall("bugreport", $"{pathToDumpBugReport}.zip");
@@ -101,7 +99,7 @@ public class AdbRunnerTests : IDisposable
         s_bootCompleteCheckTimes = 0; // Force simulating device is offline
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
         string fakeDeviceName = $"emulator-{new Random().Next(9999)}";
-        runner.SetActiveDevice(fakeDeviceName);
+        runner.SetActiveDevice(new AndroidDevice(fakeDeviceName));
         runner.WaitForDevice();
 
         s_bootCompleteCheckTimes = 0; // Force simulating device is offline
@@ -115,14 +113,20 @@ public class AdbRunnerTests : IDisposable
     public void ListDevicesAndArchitectures()
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
-        var result = runner.GetAttachedDevicesWithProperties("architecture");
+        var result = runner.GetAttachedDevicesWithProperties();
         VerifyAdbCall("devices", "-l");
 
         // Ensure it called, parsed the four random device names and found all four architectures
-        foreach (var fakeDeviceInfo in _fakeDeviceList.Keys)
+        foreach (var fakeDevice in _fakeDeviceList)
         {
-            VerifyAdbCall("-s", fakeDeviceInfo.Item1, "shell", "getprop", "ro.product.cpu.abilist");
-            Assert.Equal(fakeDeviceInfo.Item2, result[fakeDeviceInfo.Item1]);
+            VerifyAdbCall("-s", fakeDevice.DeviceSerial, "shell", "getprop", "ro.product.cpu.abilist");
+            Assert.Equal(fakeDevice.SupportedArchitectures, result.Single(d => d.DeviceSerial == fakeDevice.DeviceSerial).SupportedArchitectures);
+
+            VerifyAdbCall("-s", fakeDevice.DeviceSerial, "shell", "getprop", "ro.build.version.sdk");
+            Assert.Equal(fakeDevice.ApiVersion, result.Single(d => d.ApiVersion == fakeDevice.ApiVersion).ApiVersion);
+
+            VerifyAdbCall("-s", fakeDevice.DeviceSerial, "shell", "getprop", "ro.product.cpu.abi");
+            Assert.Equal(fakeDevice.Architecture, result.Single(d => d.DeviceSerial == fakeDevice.DeviceSerial).Architecture);
         }
 
         Assert.Equal(4, result.Count);
@@ -176,20 +180,31 @@ public class AdbRunnerTests : IDisposable
     }
 
     [Fact]
-    public void GetDeviceToUse()
+    public void GetDevice()
     {
         var requiredArchitecture = "x86_64";
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
-        var result = runner.GetDeviceToUse(_mainLog.Object, new[] { requiredArchitecture }, "architecture");
+        var result = runner.GetDevice(_mainLog.Object, requiredArchitectures: new[] { requiredArchitecture });
         VerifyAdbCall("devices", "-l");
-        Assert.True(_fakeDeviceList.ContainsKey(new Tuple<string, string>(result, requiredArchitecture)));
+        Assert.Contains(_fakeDeviceList, d => d.DeviceSerial == result.DeviceSerial);
+    }
+
+    [Fact]
+    public void GetDeviceWithArchitecture()
+    {
+        var requiredArchitecture = "x86";
+        var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
+        var result = runner.GetDevice(_mainLog.Object, shouldGetArchitecture: true, requiredArchitectures: new[] { requiredArchitecture });
+        VerifyAdbCall("devices", "-l");
+        VerifyAdbCall("-s", result.DeviceSerial, "shell", "getprop", "ro.product.cpu.abi");
+        Assert.Contains(_fakeDeviceList, d => d.DeviceSerial == result.DeviceSerial && d.Architecture == result.Architecture);
     }
 
     [Fact]
     public void RebootAndroidDevice()
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
-        string result = runner.RebootAndroidDevice();
+        runner.RebootAndroidDevice();
         VerifyAdbCall("reboot");
     }
 
@@ -233,17 +248,23 @@ public class AdbRunnerTests : IDisposable
 
     // Generates a list of fake devices, one per supported architecture so we can test AdbRunner's parsing of the output.
     // As with most of these tests, if adb.exe changes, this will break (we are locked into specific version) 
-    private static Dictionary<Tuple<string, string>, int> InitializeFakeDeviceList()
+    private static List<AndroidDevice> InitializeFakeDeviceList()
     {
         var r = new Random();
-        var values = new Dictionary<Tuple<string, string>, int>
-            {
-                { new Tuple<string, string>($"somedevice-{r.Next(9999)}", "x86_64"), 0 },
-                { new Tuple<string, string>($"somedevice-{r.Next(9999)}", "x86"), 0 },
-                { new Tuple<string, string>($"somedevice-{r.Next(9999)}", "arm64-v8a"), 0 },
-                { new Tuple<string, string>($"somedevice-{r.Next(9999)}", "armeabi-v7a"), 0 }
-            };
-        return values;
+        return new List<AndroidDevice>
+        {
+            new AndroidDevice($"somedevice-{r.Next(9999)}",
+                29, "x86_64", new[] { "x86_64", "x86" }),
+
+            new AndroidDevice($"somedevice-{r.Next(9999)}",
+                30, "x86", new[] { "x86" }),
+
+            new AndroidDevice($"emulator-{r.Next(9999)}",
+                31, "arm64-v8a", new[] { "arm64-v8a", "x86_64", "x86" }),
+
+            new AndroidDevice($"emulator-{r.Next(9999)}",
+                32, "armeabi-v7a", new[] { "armeabi-v7a", "x86_64", "x86" }),
+        };
     }
 
     private ProcessExecutionResults CallFakeProcessManager(string process, string[] arguments, TimeSpan timeout)
@@ -279,8 +300,8 @@ public class AdbRunnerTests : IDisposable
 
                 foreach (var device in _fakeDeviceList)
                 {
-                    string offlineMsg = _fakeDeviceList[device.Key]++ > 4 ? "offline" : "online";
-                    s.AppendLine($"{device.Key.Item1}          {offlineMsg} transportid:{transportId++}");
+                    string state = device == _fakeDeviceList.Last() ? "offline" : "online";
+                    s.AppendLine($"{device.DeviceSerial}          {state} transportid:{transportId++}");
                 }
 
                 stdOut = s.ToString();
@@ -289,7 +310,17 @@ public class AdbRunnerTests : IDisposable
             case "shell":
                 if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.product.cpu.abilist"))
                 {
-                    stdOut = _fakeDeviceList.Keys.Where(k => k.Item1 == s_currentDeviceSerial).Single().Item2;
+                    stdOut = string.Join(",", _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).SupportedArchitectures);
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.product.cpu.abi"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).Architecture;
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.build.version.sdk"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).ApiVersion + Environment.NewLine;
                 }
 
                 if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop sys.boot_completed"))
@@ -305,11 +336,6 @@ public class AdbRunnerTests : IDisposable
                         stdOut = Environment.NewLine;
                     }
                     s_bootCompleteCheckTimes++;
-                }
-
-                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.build.version.sdk"))
-                {
-                    stdOut = $"29{Environment.NewLine}";
                 }
 
                 exitCode = 0;

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -107,7 +107,8 @@ public class AdbRunnerTests : IDisposable
         runner.SetActiveDevice(null);
         runner.WaitForDevice();
         VerifyAdbCall(Times.Exactly(2), "wait-for-device");
-        VerifyAdbCall(Times.Exactly(4), "shell", "getprop", "sys.boot_completed");
+        VerifyAdbCall(Times.Exactly(2), "-s", fakeDeviceName, "shell", "getprop", "sys.boot_completed");
+        VerifyAdbCall(Times.Exactly(2), "shell", "getprop", "sys.boot_completed");
     }
 
     [Fact]


### PR DESCRIPTION
Resolves #380 

Previously, we were only querying devices and one of their properties - list of supported architectures. We were then matching this against user's wishes.
However, we also sometimes want to query by installed apps and now newly also by desired API version. I expect more device properties to come soon.

This means we needed to revamp a little bit how we query and represent Android devices - we no longer represent them as dictionaries but rather a dedicated POCO. We now also don't need to query device's architecture additionally, we can ask `AdbRunner` to get it for us right away.

The `android device` command also no longer expects app - you can specify other device properties (API version, arch).