### PR TITLE
Fix killing TCP server in netstandard 2.0

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs
@@ -45,7 +45,10 @@ public class SimpleTcpListener : SimpleListener, ITunnelListener
 
         // _server?.Stop(); was causing hangs
         // https://github.com/dotnet/xharness/issues/73
-        _server?.Server?.Shutdown(SocketShutdown.Both);
+        if (_server?.Server?.Connected ?? false)
+        {
+            _server.Server.Shutdown(SocketShutdown.Both);
+        }
     }
 
     public override int InitializeAndGetPort()


### PR DESCRIPTION
I noticed following error in the [bump PR in xamarin-macios](https://github.com/xamarin/xamarin-macios/pull/14350):
```
[0x70000d4d3000:] EXCEPTION handling: System.Net.Sockets.SocketException: The socket is not connected

"<unnamed thread>" tid=0x70000d4d3000 this=0x109f11090 , thread handle : 0x600000561d00, state : not waiting
  at System.Net.Sockets.Socket.Shutdown (System.Net.Sockets.SocketShutdown) [0x0003a] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/System/System.Net.Sockets/Socket.cs:2814
  at Microsoft.DotNet.XHarness.iOS.Shared.Listeners.SimpleTcpListener.Stop () [0x00022] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleTcpListener.cs:48
  at Microsoft.DotNet.XHarness.iOS.Shared.Listeners.SimpleListener.<StopAsync>b__20_0 () [0x00000] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs:101
  at System.Threading.ThreadHelper.ThreadStart_Context (object) [0x00014] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:74
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00071] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:968
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool) [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:910
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object) [0x0002b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:899
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:111
  at (wrapper runtime-invoke) object.runtime_invoke_void__this__ (object,intptr,intptr,intptr) [0x0002c] in <9f05bf294b414a688faec5c1afba5fac>:0
```

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5857554&view=logs&j=600d49c6-e96b-5e8b-2c3a-9f351e2e5848&t=12837421-857d-5f7a-7e12-9c60f4caaf40