### PR TITLE
Add the `--no-wait` switch to `just-run` and `run` command

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -174,12 +174,13 @@ public class AppRunner : AppRunnerBase, IAppRunner
             using (appOutputLog)
             {
                 var mlaunchArguments = GetDeviceArguments(
-                appInformation,
-                device,
-                target.Platform.IsWatchOSTarget(),
-                extraAppArguments,
-                extraEnvVariables,
-                appEndTag);
+                    appInformation,
+                    device,
+                    waitForExit: waitForExit,
+                    isWatchTarget: target.Platform.IsWatchOSTarget(),
+                    extraAppArguments,
+                    extraEnvVariables,
+                    appEndTag);
 
                 result = await RunDeviceApp(
                     mlaunchArguments,
@@ -215,8 +216,6 @@ public class AppRunner : AppRunnerBase, IAppRunner
         var envVars = new Dictionary<string, string>();
         AddExtraEnvVars(envVars, extraEnvVariables);
 
-        // TODO: Deal with --no-wait by waiting for some launch signal
-        
         return await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
             mlaunchArguments,
             _mainLog,
@@ -283,6 +282,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
     private MlaunchArguments GetDeviceArguments(
         AppBundleInformation appInformation,
         IDevice device,
+        bool waitForExit,
         bool isWatchTarget,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
@@ -314,7 +314,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
         {
             args.Add(new AttachNativeDebuggerArgument()); // this prevents the watch from backgrounding the app.
         }
-        else
+        else if (waitForExit)
         {
             args.Add(new WaitForExitArgument());
         }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -215,6 +215,8 @@ public class AppRunner : AppRunnerBase, IAppRunner
         var envVars = new Dictionary<string, string>();
         AddExtraEnvVars(envVars, extraEnvVariables);
 
+        // TODO: Deal with --no-wait by waiting for some launch signal
+        
         return await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
             mlaunchArguments,
             _mainLog,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -226,7 +226,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
             cancellationToken: cancellationToken));
     }
 
-    private MlaunchArguments GetCommonArguments(
+    private static MlaunchArguments GetCommonArguments(
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         string? appEndTag)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -4,14 +4,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
-using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
@@ -29,6 +27,7 @@ public interface IAppRunner
         IDevice? companionDevice,
         TimeSpan timeout,
         bool signalAppEnd,
+        bool waitForExit,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         CancellationToken cancellationToken = default);
@@ -37,6 +36,7 @@ public interface IAppRunner
         AppBundleInformation appInformation,
         TimeSpan timeout,
         bool signalAppEnd,
+        bool waitForExit,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         CancellationToken cancellationToken = default);
@@ -49,7 +49,6 @@ public class AppRunner : AppRunnerBase, IAppRunner
 {
     private readonly IMlaunchProcessManager _processManager;
     private readonly ICrashSnapshotReporterFactory _snapshotReporterFactory;
-    private readonly ICaptureLogFactory _captureLogFactory;
     private readonly IDeviceLogCapturerFactory _deviceLogCapturerFactory;
     private readonly IFileBackedLog _mainLog;
     private readonly ILogs _logs;
@@ -68,7 +67,6 @@ public class AppRunner : AppRunnerBase, IAppRunner
     {
         _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
         _snapshotReporterFactory = snapshotReporterFactory ?? throw new ArgumentNullException(nameof(snapshotReporterFactory));
-        _captureLogFactory = captureLogFactory ?? throw new ArgumentNullException(nameof(captureLogFactory));
         _deviceLogCapturerFactory = deviceLogCapturerFactory ?? throw new ArgumentNullException(nameof(deviceLogCapturerFactory));
         _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
@@ -79,6 +77,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
         AppBundleInformation appInformation,
         TimeSpan timeout,
         bool signalAppEnd,
+        bool waitForExit,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         CancellationToken cancellationToken = default)
@@ -101,6 +100,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
                 appInformation,
                 appOutputLog,
                 timeout,
+                waitForExit,
                 extraAppArguments ?? Enumerable.Empty<string>(),
                 envVariables,
                 cancellationToken));
@@ -114,6 +114,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
         IDevice? companionDevice,
         TimeSpan timeout,
         bool signalAppEnd,
+        bool waitForExit,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         CancellationToken cancellationToken = default)
@@ -158,6 +159,7 @@ public class AppRunner : AppRunnerBase, IAppRunner
                 simulator,
                 companionSimulator,
                 timeout,
+                waitForExit,
                 cancellationToken);
         }
         else

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -174,13 +174,7 @@ public abstract class AppRunnerBase
 
         await crashReporter.StartCaptureAsync();
 
-        if (!waitForExit)
-        {
-            // Booting the simulator can take time and we want to fire&forget as close to the app launch as possible
-            await simulator.Boot(_mainLog, cancellationToken);
-        }
-
-        _mainLog.WriteLine("Starting the app");
+        _mainLog.WriteLine("Launching the app");
 
         if (waitForExit)
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -189,7 +189,6 @@ public abstract class AppRunnerBase
             return result;
         }
 
-        ILog log = _mainLog;
         TaskCompletionSource appLaunched = new();
         var scanLog = new ScanLog($"Launched {appInformation.BundleIdentifier} with pid", () =>
         {
@@ -199,7 +198,7 @@ public abstract class AppRunnerBase
 
         _mainLog.WriteLine("Waiting for the app to launch..");
 
-        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
+        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, Log.CreateAggregatedLog(_mainLog, scanLog), timeout, cancellationToken: cancellationToken);
         Task.WaitAny(
             new Task[]
             {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -82,7 +82,10 @@ public abstract class AppRunnerBase
         var lsRegisterPath = @"/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
         await _processManager.ExecuteCommandAsync(lsRegisterPath, new[] { "-f", appInfo.LaunchAppPath }, _mainLog, TimeSpan.FromSeconds(10), cancellationToken: cancellationToken);
 
-        var arguments = new List<string>();
+        var arguments = new List<string>
+        {
+            "-n" // Open a new instance of the application(s) even if one is already running.
+        };
 
         if (waitForExit)
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -292,6 +292,7 @@ public class AppTester : AppRunnerBase, IAppTester
             simulator,
             companionSimulator,
             timeout,
+            waitForExit: true,
             cancellationToken);
 
         await testReporter.CollectSimulatorResult(result);
@@ -433,7 +434,7 @@ public class AppTester : AppRunnerBase, IAppTester
 
             await crashReporter.StartCaptureAsync();
 
-            var result = await RunMacCatalystApp(appInformation, appOutputLog, timeout, extraAppArguments, envVariables, combinedCancellationToken.Token);
+            var result = await RunMacCatalystApp(appInformation, appOutputLog, timeout, waitForExit: true, extraAppArguments, envVariables, combinedCancellationToken.Token);
             await testReporter.CollectSimulatorResult(result);
         }
         finally

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -113,6 +113,12 @@ public abstract class BaseOrchestrator : IDisposable
             _logger.LogWarning("Including wireless devices while targeting a simulator has no effect");
         }
 
+        if (resetSimulator && !target.Platform.IsSimulator())
+        {
+            _logger.LogWarning("Targeting device but requesting simulator reset has no effect");
+            resetSimulator = false;
+        }
+
         ExitCode exitCode;
         IDevice device;
         IDevice? companionDevice;

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
@@ -28,6 +28,7 @@ public interface IJustRunOrchestrator
         bool includeWirelessDevices,
         bool enableLldb,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken);
@@ -68,6 +69,7 @@ public class JustRunOrchestrator : RunOrchestrator, IJustRunOrchestrator
         bool includeWirelessDevices,
         bool enableLldb,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -75,13 +77,14 @@ public class JustRunOrchestrator : RunOrchestrator, IJustRunOrchestrator
             (target, device, cancellationToken) => GetAppBundleFromId(target, device, bundleIdentifier, cancellationToken),
             target,
             deviceName,
-            timeout,
-            launchTimeout,
+            timeout: timeout,
+            launchTimeout: launchTimeout,
             expectedExitCode,
-            includeWirelessDevices,
+            includeWirelessDevices: includeWirelessDevices,
             resetSimulator: false, // No simulator reset for just- commands
-            enableLldb,
-            signalAppEnd,
+            enableLldb: enableLldb,
+            signalAppEnd: signalAppEnd,
+            waitForExit: waitForExit,
             environmentalVariables,
             passthroughArguments,
             cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -247,6 +247,12 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             environmentalVariables,
             cancellationToken);
 
+        if (!waitForExit)
+        {
+            _logger.LogInformation("Not waiting for app to exit");
+            return ExitCode.SUCCESS;
+        }
+
         return ParseResult(_iOSExitCodeDetector, expectedExitCode, appBundleInfo, result);
     }
 
@@ -270,6 +276,12 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             passthroughArguments,
             environmentalVariables,
             cancellationToken: cancellationToken);
+
+        if (!waitForExit)
+        {
+            _logger.LogInformation("Not waiting for app to exit");
+            return ExitCode.SUCCESS;
+        }
 
         return ParseResult(_macCatalystExitCodeDetector, expectedExitCode, appBundleInfo, result);
     }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -121,6 +121,16 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         return base.UninstallApp(target, bundleIdentifier, device, isPreparation, cancellationToken);
     }
 
+    protected override Task CleanUpSimulators(IDevice device, IDevice? companionDevice)
+    {
+        if (!_waitForExit)
+        {
+            return Task.FromResult(ExitCode.SUCCESS);
+        }
+
+        return base.CleanUpSimulators(device, companionDevice);
+    }
+
     protected async Task<ExitCode> OrchestrateRun(
         GetAppBundleInfoFunc getAppBundleInfo,
         TestTargetOs target,
@@ -137,6 +147,11 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
     {
+        if (signalAppEnd && !waitForExit)
+        {
+            throw new InvalidOperationException("Cannot receive app end signal without waiting for it to exit");
+        }
+
         _waitForExit = waitForExit;
 
         // The --launch-timeout option must start counting now and not complete before we start running tests to succeed.

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -31,6 +31,7 @@ public interface IRunOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken);
@@ -88,6 +89,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -95,13 +97,14 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             (target, device, ct) => GetAppBundleFromPath(target, appBundlePath, ct),
             target,
             deviceName,
-            timeout,
-            launchTimeout,
+            timeout: timeout,
+            launchTimeout: launchTimeout,
             expectedExitCode,
-            includeWirelessDevices,
-            resetSimulator,
-            enableLldb,
-            signalAppEnd,
+            includeWirelessDevices: includeWirelessDevices,
+            resetSimulator: resetSimulator,
+            enableLldb: enableLldb,
+            signalAppEnd: signalAppEnd,
+            waitForExit: waitForExit,
             environmentalVariables,
             passthroughArguments,
             cancellationToken);
@@ -117,6 +120,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -149,6 +153,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
                 timeout,
                 expectedExitCode,
                 signalAppEnd,
+                waitForExit,
                 environmentalVariables,
                 passthroughArguments,
                 cancellationToken);
@@ -176,7 +181,8 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
                 companionDevice,
                 timeout,
                 expectedExitCode,
-                signalAppEnd,
+                signalAppEnd: signalAppEnd,
+                waitForExit: waitForExit,
                 environmentalVariables,
                 passthroughArguments,
                 cancellationToken);
@@ -185,9 +191,9 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         return await OrchestrateOperation(
             target,
             deviceName,
-            includeWirelessDevices,
-            resetSimulator,
-            enableLldb,
+            includeWirelessDevices: includeWirelessDevices,
+            resetSimulator: resetSimulator,
+            enableLldb: enableLldb,
             getAppBundleInfo,
             ExecuteMacCatalystApp,
             ExecuteApp,
@@ -202,6 +208,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         TimeSpan timeout,
         int expectedExitCode,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -212,7 +219,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             _logger.LogWarning("The --signal-app-end option is used for device tests and has no effect on simulators");
         }
 
-        _logger.LogInformation($"Starting application '{appBundleInfo.AppName}' on '{device.Name}'");
+        _logger.LogInformation($"Starting '{appBundleInfo.AppName}' on '{device.Name}'");
 
         ProcessExecutionResult result = await _appRunner.RunApp(
             appBundleInfo,
@@ -220,7 +227,8 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
             device,
             companionDevice,
             timeout,
-            signalAppEnd,
+            signalAppEnd: signalAppEnd,
+            waitForExit: waitForExit,
             passthroughArguments,
             environmentalVariables,
             cancellationToken);
@@ -233,6 +241,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         TimeSpan timeout,
         int expectedExitCode,
         bool signalAppEnd,
+        bool waitForExit,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -242,7 +251,8 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         ProcessExecutionResult result = await _appRunner.RunMacCatalystApp(
             appBundleInfo,
             timeout,
-            signalAppEnd,
+            signalAppEnd: signalAppEnd,
+            waitForExit: waitForExit,
             passthroughArguments,
             environmentalVariables,
             cancellationToken: cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -113,7 +113,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
 
     protected override Task<ExitCode> UninstallApp(TestTarget target, string bundleIdentifier, IDevice device, bool isPreparation, CancellationToken cancellationToken)
     {
-        if (_waitForExit && !isPreparation)
+        if (!_waitForExit && !isPreparation)
         {
             return Task.FromResult(ExitCode.SUCCESS);
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -51,7 +51,7 @@ internal class AppleJustRunCommandArguments : XHarnessCommandArguments, IAppleAp
             throw new ArgumentException("This command is not supported with the maccatalyst target");
         }
 
-        if (SignalAppEnd && !NoWait)
+        if (SignalAppEnd && NoWait)
         {
             throw new ArgumentException("--signal-app-end cannot be used in combination with --no-wait");
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustRunCommandArguments.cs
@@ -23,6 +23,7 @@ internal class AppleJustRunCommandArguments : XHarnessCommandArguments, IAppleAp
     public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)ExitCode.SUCCESS);
     public SignalAppEndArgument SignalAppEnd { get; } = new();
+    public NoWaitArgument NoWait { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
@@ -37,6 +38,7 @@ internal class AppleJustRunCommandArguments : XHarnessCommandArguments, IAppleAp
         MlaunchPath,
         EnableLldb,
         SignalAppEnd,
+        NoWait,
         EnvironmentalVariables,
     };
 
@@ -47,6 +49,11 @@ internal class AppleJustRunCommandArguments : XHarnessCommandArguments, IAppleAp
         if (Target.Value.Platform == TestTarget.MacCatalyst)
         {
             throw new ArgumentException("This command is not supported with the maccatalyst target");
+        }
+
+        if (SignalAppEnd && !NoWait)
+        {
+            throw new ArgumentException("--signal-app-end cannot be used in combination with --no-wait");
         }
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
@@ -24,22 +24,34 @@ internal class AppleRunCommandArguments : XHarnessCommandArguments, IAppleAppRun
     public ResetSimulatorArgument ResetSimulator { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)ExitCode.SUCCESS);
     public SignalAppEndArgument SignalAppEnd { get; } = new();
+    public NoWaitArgument NoWait { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
-            AppBundlePath,
-            Target,
-            OutputDirectory,
-            DeviceName,
-            IncludeWireless,
-            Timeout,
-            LaunchTimeout,
-            ExpectedExitCode,
-            XcodeRoot,
-            MlaunchPath,
-            EnableLldb,
-            SignalAppEnd,
-            EnvironmentalVariables,
-            ResetSimulator,
+        AppBundlePath,
+        Target,
+        OutputDirectory,
+        DeviceName,
+        IncludeWireless,
+        Timeout,
+        LaunchTimeout,
+        ExpectedExitCode,
+        XcodeRoot,
+        MlaunchPath,
+        EnableLldb,
+        SignalAppEnd,
+        NoWait,
+        ResetSimulator,
+        EnvironmentalVariables,
     };
+
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (SignalAppEnd && !NoWait)
+        {
+            throw new ArgumentException("--signal-app-end cannot be used in combination with --no-wait");
+        }
+    }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleRunCommandArguments.cs
@@ -49,7 +49,7 @@ internal class AppleRunCommandArguments : XHarnessCommandArguments, IAppleAppRun
     {
         base.Validate();
 
-        if (SignalAppEnd && !NoWait)
+        if (SignalAppEnd && NoWait)
         {
             throw new ArgumentException("--signal-app-end cannot be used in combination with --no-wait");
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/NoWaitArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/NoWaitArgument.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Apple;
+
+internal class NoWaitArgument : SwitchArgument
+{
+    public NoWaitArgument() : base("no-wait|nowait", "Don't wait for the app to shut down", false)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustRunCommand.cs
@@ -27,16 +27,17 @@ internal class AppleJustRunCommand : AppleAppCommand<AppleJustRunCommandArgument
     protected override Task<ExitCode> InvokeInternal(ServiceProvider serviceProvider, CancellationToken cancellationToken) =>
         serviceProvider.GetRequiredService<IJustRunOrchestrator>()
             .OrchestrateRun(
-                Arguments.BundleIdentifier,
-                Arguments.Target,
-                Arguments.DeviceName,
-                Arguments.Timeout,
-                Arguments.Timeout,
-                Arguments.ExpectedExitCode,
-                Arguments.IncludeWireless,
-                Arguments.EnableLldb,
-                Arguments.SignalAppEnd,
-                Arguments.EnvironmentalVariables.Value,
-                PassThroughArguments,
+                bundleIdentifier: Arguments.BundleIdentifier,
+                target: Arguments.Target,
+                deviceName: Arguments.DeviceName,
+                timeout: Arguments.Timeout,
+                launchTimeout: Arguments.Timeout,
+                expectedExitCode: Arguments.ExpectedExitCode,
+                includeWirelessDevices: Arguments.IncludeWireless,
+                enableLldb: Arguments.EnableLldb,
+                signalAppEnd: Arguments.SignalAppEnd,
+                waitForExit: !Arguments.NoWait,
+                environmentalVariables: Arguments.EnvironmentalVariables.Value,
+                passthroughArguments: PassThroughArguments,
                 cancellationToken);
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleRunCommand.cs
@@ -30,17 +30,18 @@ internal class AppleRunCommand : AppleAppCommand<AppleRunCommandArguments>
     protected override Task<ExitCode> InvokeInternal(ServiceProvider serviceProvider, CancellationToken cancellationToken) =>
         serviceProvider.GetRequiredService<IRunOrchestrator>()
             .OrchestrateRun(
-                Arguments.AppBundlePath,
-                Arguments.Target,
-                Arguments.DeviceName,
-                Arguments.Timeout,
-                Arguments.LaunchTimeout,
-                Arguments.ExpectedExitCode,
-                Arguments.IncludeWireless,
-                Arguments.ResetSimulator,
-                Arguments.EnableLldb,
-                Arguments.SignalAppEnd,
-                Arguments.EnvironmentalVariables.Value,
-                PassThroughArguments,
+                appBundlePath: Arguments.AppBundlePath,
+                target: Arguments.Target,
+                deviceName: Arguments.DeviceName,
+                timeout: Arguments.Timeout,
+                launchTimeout: Arguments.LaunchTimeout,
+                expectedExitCode: Arguments.ExpectedExitCode,
+                includeWirelessDevices: Arguments.IncludeWireless,
+                resetSimulator: Arguments.ResetSimulator,
+                enableLldb: Arguments.EnableLldb,
+                signalAppEnd: Arguments.SignalAppEnd,
+                waitForExit: !Arguments.NoWait,
+                environmentalVariables: Arguments.EnvironmentalVariables.Value,
+                passthroughArguments: PassThroughArguments,
                 cancellationToken);
 }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -324,7 +324,280 @@ public class AppRunnerTests : AppRunTestBase
         captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
     }
 
-    private string GetExpectedDeviceMlaunchArgs() =>
+    [Fact]
+    public async Task RunOnDeviceNoWaitTest()
+    {
+        var deviceSystemLog = new Mock<IFileBackedLog>();
+        deviceSystemLog.SetupGet(x => x.FullPath).Returns(AppBundleIdentifier + "system.log");
+        deviceSystemLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
+
+        SetupLogList(new[] { deviceSystemLog.Object, _stdoutLog, _stderrLog });
+
+        _logs
+            .Setup(x => x.Create("device-" + DeviceName + "-mocked_timestamp.log", LogType.SystemLog.ToString(), It.IsAny<bool?>()))
+            .Returns(deviceSystemLog.Object);
+
+        var deviceLogCapturer = new Mock<IDeviceLogCapturer>();
+
+        var deviceLogCapturerFactory = new Mock<IDeviceLogCapturerFactory>();
+        deviceLogCapturerFactory
+            .Setup(x => x.Create(_mainLog.Object, deviceSystemLog.Object, DeviceName))
+            .Returns(deviceLogCapturer.Object);
+
+        var x = _logs.Object.First();
+
+        // Act
+        var appRunner = new AppRunner(
+            _processManager.Object,
+            _snapshotReporterFactory,
+            Mock.Of<ICaptureLogFactory>(),
+            deviceLogCapturerFactory.Object,
+            _mainLog.Object,
+            _logs.Object,
+            _helpers.Object);
+
+        var result = await appRunner.RunApp(
+            _appBundleInfo,
+            new TestTargetOs(TestTarget.Device_iOS, null),
+            s_mockDevice,
+            null,
+            timeout: TimeSpan.FromSeconds(30),
+            signalAppEnd: false,
+            waitForExit: false,
+            extraAppArguments: new[] { "--foo=bar", "--xyz" },
+            extraEnvVariables: new[] { ("appArg1", "value1") });
+
+        // Verify
+        Assert.True(result.Succeeded);
+
+        var expectedArgs = GetExpectedDeviceMlaunchArgs();
+
+        _processManager
+            .Verify(
+                x => x.ExecuteCommandAsync(
+                   It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs.Replace(" --wait-for-exit", null)),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>>(),
+                   It.IsAny<int>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
+
+        deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task RunOnSimulatorNoWaitTest()
+    {
+        var captureLog = new Mock<ICaptureLog>();
+        captureLog.SetupGet(x => x.FullPath).Returns(_simulatorLogPath);
+        captureLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
+
+        var captureLogFactory = new Mock<ICaptureLogFactory>();
+        captureLogFactory
+            .Setup(x => x.Create(
+               Path.Combine(_logs.Object.Directory, _mockSimulator.Name + ".log"),
+               _mockSimulator.SystemLog,
+               false,
+               LogType.SystemLog))
+            .Returns(captureLog.Object);
+
+        SetupLogList(new[] { captureLog.Object, _stdoutLog, _stderrLog });
+
+        var expectedArgs = GetExpectedSimulatorMlaunchArgs();
+
+        var appLaunchedTask = new TaskCompletionSource();
+        ILog? appLog = null;
+
+        _processManager
+            .Setup(
+                x => x.ExecuteCommandAsync(
+                   It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>>(),
+                   It.IsAny<int>(),
+                   It.IsAny<CancellationToken>()))
+            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            {
+                appLog = log;
+                appLaunchedTask.SetResult();
+            })
+            .Returns(new TaskCompletionSource<ProcessExecutionResult>().Task); // This task must never complete (it represents running app)
+
+        // Act
+        var appRunner = new AppRunner(
+            _processManager.Object,
+            _snapshotReporterFactory,
+            captureLogFactory.Object,
+            Mock.Of<IDeviceLogCapturerFactory>(),
+            _mainLog.Object,
+            _logs.Object,
+            _helpers.Object);
+
+        var runTask = appRunner.RunApp(
+            _appBundleInfo,
+            new TestTargetOs(TestTarget.Simulator_tvOS, null),
+            _mockSimulator,
+            null,
+            timeout: TimeSpan.FromSeconds(30),
+            signalAppEnd: false,
+            waitForExit: false,
+            extraAppArguments: new[] { "--foo=bar", "--xyz" },
+            extraEnvVariables: new[] { ("appArg1", "value1") });
+
+        // No we wait for the launch of the app (which will then hang and the ScanLog will start waiting for the launch signal)
+        await appLaunchedTask.Task;
+
+        Assert.False(runTask.IsCompleted);
+
+        // Now we send the signal that the app has launched
+        Assert.NotNull(appLog);
+        appLog!.WriteLine($"Some message");
+        appLog!.WriteLine($"Xamarin.Hosting: Launched {AppBundleIdentifier} with pid 39402");
+        appLog!.WriteLine($"Some other message");
+
+        // We should now be able to return from here since the ScanLog will finish
+        var result = await runTask;
+
+        // Verify
+        Assert.True(result.Succeeded);
+
+        _processManager
+            .Verify(
+                x => x.ExecuteCommandAsync(
+                   It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>>(),
+                   It.IsAny<int>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        _processManager
+            .Verify(
+                x => x.ExecuteXcodeCommandAsync(
+                   "simctl",
+                   It.Is<IList<string>>(args => args.Contains("log") && args.Contains(_mockSimulator.UDID) && args.Contains("stream") && args.Any(a => a.Contains(BundleExecutable))),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task RunOnSimulatorNoWaitNoLaunchSignalTest()
+    {
+        var captureLog = new Mock<ICaptureLog>();
+        captureLog.SetupGet(x => x.FullPath).Returns(_simulatorLogPath);
+        captureLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
+
+        var captureLogFactory = new Mock<ICaptureLogFactory>();
+        captureLogFactory
+            .Setup(x => x.Create(
+               Path.Combine(_logs.Object.Directory, _mockSimulator.Name + ".log"),
+               _mockSimulator.SystemLog,
+               false,
+               LogType.SystemLog))
+            .Returns(captureLog.Object);
+
+        SetupLogList(new[] { captureLog.Object, _stdoutLog, _stderrLog });
+
+        var expectedArgs = GetExpectedSimulatorMlaunchArgs();
+
+        var appLaunchedTask = new TaskCompletionSource();
+        var appRunTask = new TaskCompletionSource<ProcessExecutionResult>();
+
+        _processManager
+            .Setup(
+                x => x.ExecuteCommandAsync(
+                   It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>>(),
+                   It.IsAny<int>(),
+                   It.IsAny<CancellationToken>()))
+            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            {
+                appLaunchedTask.SetResult();
+            })
+            .Returns(appRunTask.Task); // This task will complete and the ScanLog task won't (we won't log the "app launched" message)
+
+        // Act
+        var appRunner = new AppRunner(
+            _processManager.Object,
+            _snapshotReporterFactory,
+            captureLogFactory.Object,
+            Mock.Of<IDeviceLogCapturerFactory>(),
+            _mainLog.Object,
+            _logs.Object,
+            _helpers.Object);
+
+        var runTask = appRunner.RunApp(
+            _appBundleInfo,
+            new TestTargetOs(TestTarget.Simulator_tvOS, null),
+            _mockSimulator,
+            null,
+            timeout: TimeSpan.FromSeconds(30),
+            signalAppEnd: false,
+            waitForExit: false,
+            extraAppArguments: new[] { "--foo=bar", "--xyz" },
+            extraEnvVariables: new[] { ("appArg1", "value1") });
+
+        // No we wait for the code to start launching the app
+        await appLaunchedTask.Task;
+
+        Assert.False(runTask.IsCompleted);
+
+        // In this phase, the code waits for both ScanLog or the app run task
+        // We will simulate a case when the app never reports back (never launches)
+        appRunTask.SetResult(new ProcessExecutionResult
+        {
+            ExitCode = 137, // This is what we get when app run times out and is killed by our timeout
+            TimedOut = true,
+        });
+
+        var result = await runTask;
+
+        // Verify
+        Assert.False(result.Succeeded);
+        Assert.True(result.TimedOut);
+
+        _processManager
+            .Verify(
+                x => x.ExecuteCommandAsync(
+                   It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>>(),
+                   It.IsAny<int>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        _processManager
+            .Verify(
+                x => x.ExecuteXcodeCommandAsync(
+                   "simctl",
+                   It.Is<IList<string>>(args => args.Contains("log") && args.Contains(_mockSimulator.UDID) && args.Contains("stream") && args.Any(a => a.Contains(BundleExecutable))),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
+        captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
+    }
+
+    private static string GetExpectedDeviceMlaunchArgs() =>
         "-argument=--foo=bar " +
         "-argument=--xyz " +
         "-setenv=appArg1=value1 " +

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -16,7 +16,6 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Moq;
 using Xunit;
 
-#nullable enable
 namespace Microsoft.DotNet.XHarness.Apple.Tests.AppOperations;
 
 public class AppRunnerTests : AppRunTestBase
@@ -56,6 +55,7 @@ public class AppRunnerTests : AppRunTestBase
             null,
             timeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            waitForExit: true,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -129,6 +129,7 @@ public class AppRunnerTests : AppRunTestBase
             null,
             timeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            waitForExit: true,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -228,6 +229,7 @@ public class AppRunnerTests : AppRunTestBase
             null,
             timeout: TimeSpan.FromSeconds(30),
             signalAppEnd: true,
+            waitForExit: true,
             Array.Empty<string>(),
             Array.Empty<(string, string)>());
 
@@ -297,6 +299,7 @@ public class AppRunnerTests : AppRunTestBase
             _appBundleInfo,
             timeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            waitForExit: true,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -312,7 +312,7 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args[0] == "-W" && args[1] == s_appPath),
+                   It.Is<IList<string>>(args => args[0] == "-n" && args[1] == "-W" && args[2] == s_appPath),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
@@ -642,7 +642,7 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args.Count == 1 && args[0] == s_appPath),
+                   It.Is<IList<string>>(args => args.Count == 2 && args[0] == "-n" && args[1] == s_appPath),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustRunOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustRunOrchestratorTests.cs
@@ -73,6 +73,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<CancellationToken>()))
@@ -94,6 +95,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: false,
             signalAppEnd: false,
+            waitForExit: true,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -139,6 +141,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -160,6 +163,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: true,
             enableLldb: false,
             signalAppEnd: false,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -195,6 +199,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -218,6 +223,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: true,
             signalAppEnd: false,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             new CancellationToken());
@@ -263,6 +269,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 true,
+                true,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -290,6 +297,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: true,
             enableLldb: false,
             signalAppEnd: true,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -333,6 +341,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
                 It.Is<AppBundleInformation>(info => info.BundleIdentifier == BundleIdentifier),
                 TimeSpan.FromMinutes(30),
                 true,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<CancellationToken>()))
@@ -354,6 +363,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: false,
             signalAppEnd: true,
+            waitForExit: true,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
@@ -82,6 +82,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<CancellationToken>()))
@@ -104,6 +105,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: true,
             enableLldb: false,
             signalAppEnd: false,
+            waitForExit: true,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -148,6 +150,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -170,6 +173,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: false,
             signalAppEnd: false,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -207,6 +211,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 false,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -231,6 +236,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: true,
             signalAppEnd: false,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             new CancellationToken());
@@ -275,6 +281,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 true,
+                true,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<CancellationToken>()))
@@ -303,6 +310,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: false,
             signalAppEnd: true,
+            waitForExit: true,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -348,6 +356,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 _appBundleInformation,
                 TimeSpan.FromMinutes(30),
                 true,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<CancellationToken>()))
@@ -370,6 +379,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: true,
             enableLldb: false,
             signalAppEnd: true,
+            waitForExit: true,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -409,6 +419,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
                 _appBundleInformation,
                 TimeSpan.FromMinutes(30),
                 true,
+                true,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<CancellationToken>()))
@@ -431,6 +442,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             resetSimulator: true,
             enableLldb: false,
             signalAppEnd: true,
+            waitForExit: true,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
@@ -459,4 +459,138 @@ public class RunOrchestratorTests : OrchestratorTestBase
         _appInstaller.VerifyNoOtherCalls();
         _appUninstaller.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public async Task OrchestrateNoWaitDeviceRunTest()
+    {
+        // Setup
+        var testTarget = new TestTargetOs(TestTarget.Device_iOS, "14.2");
+
+        var extraArguments = new[] { "--some arg1", "--some arg2" };
+
+        _appRunner
+            .Setup(x => x.RunApp(
+                _appBundleInformation,
+                testTarget,
+                _device.Object,
+                null,
+                TimeSpan.FromMinutes(30),
+                false,
+                false,
+                extraArguments,
+                It.IsAny<IEnumerable<(string, string)>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                TimedOut = false,
+            })
+            .Verifiable();
+
+        // Act
+        var result = await _runOrchestrator.OrchestrateRun(
+            AppPath,
+            testTarget,
+            DeviceName,
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(3),
+            expectedExitCode: 100,
+            includeWirelessDevices: true,
+            resetSimulator: true,
+            enableLldb: false,
+            signalAppEnd: false,
+            waitForExit: false,
+            Array.Empty<(string, string)>(),
+            extraArguments,
+            new CancellationToken());
+
+        // Verify
+        Assert.Equal(ExitCode.SUCCESS, result);
+
+        _deviceFinder.Verify(
+            x => x.FindDevice(testTarget, DeviceName, It.IsAny<ILog>(), true),
+            Times.Once);
+
+        VerifySimulatorReset(false);
+        VerifySimulatorCleanUp(false);
+        VerifyDiagnosticData(testTarget);
+
+        _appInstaller.Verify(
+            x => x.InstallApp(_appBundleInformation, testTarget, _device.Object, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _appUninstaller.Verify(
+            x => x.UninstallDeviceApp(_device.Object, BundleIdentifier, It.IsAny<CancellationToken>()),
+            Times.Once); // Once in preparation, but not a second time after we're done
+
+        _appRunner.VerifyAll();
+        _iOSExitCodeDetector.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OrchestrateNoWaitSimulatorRunTest()
+    {
+        // Setup
+        var testTarget = new TestTargetOs(TestTarget.Simulator_iOS64, "13.5");
+
+        var extraArguments = new[] { "--some arg1", "--some arg2" };
+
+        _appRunner
+            .Setup(x => x.RunApp(
+                _appBundleInformation,
+                testTarget,
+                _simulator.Object,
+                null,
+                TimeSpan.FromMinutes(30),
+                false,
+                false,
+                extraArguments,
+                It.IsAny<IEnumerable<(string, string)>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProcessExecutionResult
+            {
+                ExitCode = 0,
+                TimedOut = false,
+            })
+            .Verifiable();
+
+        // Act
+        var result = await _runOrchestrator.OrchestrateRun(
+            AppPath,
+            testTarget,
+            null,
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(3),
+            expectedExitCode: 100,
+            includeWirelessDevices: true,
+            resetSimulator: true,
+            enableLldb: false,
+            signalAppEnd: false,
+            waitForExit: false,
+            Array.Empty<(string, string)>(),
+            extraArguments,
+            new CancellationToken());
+
+        // Verify
+        Assert.Equal(ExitCode.SUCCESS, result);
+
+        _deviceFinder.Verify(
+            x => x.FindDevice(testTarget, null, It.IsAny<ILog>(), true),
+            Times.Once);
+
+        VerifySimulatorReset(true);
+        VerifySimulatorCleanUp(false);
+        VerifyDiagnosticData(testTarget);
+
+        _appInstaller.Verify(
+            x => x.InstallApp(_appBundleInformation, testTarget, _simulator.Object, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _appUninstaller.Verify(
+            x => x.UninstallSimulatorApp(_simulator.Object, BundleIdentifier, It.IsAny<CancellationToken>()),
+            Times.Never); // No preparation uninstall (because of reset), and then not at the end
+
+        _appRunner.VerifyAll();
+        _iOSExitCodeDetector.VerifyNoOtherCalls();
+    }
 }


### PR DESCRIPTION
- Devices were easy (mlaunch has `--wait-for-exit`)
- MacCatalyst was easy (there is `-W`)
- Simulators were a bit more work because we need to wait for the launch to finish and only then we can quit

Resolves #846 