### PR TITLE
Use `log stream` to capture MacCatalyst logs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -275,9 +275,17 @@ public abstract class AppRunnerBase
         return result;
     }
 
+    /// <summary>
+    /// This method kicks off a process that scans a log stream coming from the running app and stores it into a log file.
+    /// This method does not wait for the scan process to end but returns a cancellation token that can be used to cancel the scan.
+    /// </summary>
     protected CancellationTokenSource CaptureMacCatalystLog(AppBundleInformation appInformation, CancellationToken cancellationToken) =>
         CaptureLogStream(appInformation.BundleExecutable ?? appInformation.AppName, false, Array.Empty<string>(), cancellationToken);
 
+    /// <summary>
+    /// This method kicks off a process that scans a log stream coming from the running app and stores it into a log file.
+    /// This method does not wait for the scan process to end but returns a cancellation token that can be used to cancel the scan.
+    /// </summary>
     protected async Task<CancellationTokenSource> CaptureSimulatorLog(
         ISimulatorDevice simulator,
         AppBundleInformation appInformation,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -321,6 +321,19 @@ public class AppRunnerTests : AppRunTestBase
                    It.IsAny<CancellationToken>()),
                 Times.Once);
 
+        _processManager
+            .Verify(
+                x => x.ExecuteCommandAsync(
+                   "log",
+                   It.Is<IList<string>>(args => args.Contains("stream") && args.Any(a => a.Contains(BundleExecutable))),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<TimeSpan>(),
+                   It.IsAny<Dictionary<string, string>?>(),
+                   It.IsAny<CancellationToken>()),
+                Times.Once);
+
         captureLog.Verify(x => x.StartCapture(), Times.AtLeastOnce);
     }
 

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -4,9 +4,8 @@
   <ItemGroup>
     <HelixTargetQueue Include="osx.1015.amd64.open"/>
     <HelixTargetQueue Include="osx.1100.amd64.open"/>
-    <!-- TODO (https://github.com/dotnet/xharness/issues/848): MacCatalyst exit code detection is failing on OSX 12.00 -->
-    <!-- <HelixTargetQueue Include="osx.1200.amd64.open"/> -->
-    <!-- <HelixTargetQueue Include="osx.1200.arm64.open"/> -->
+    <HelixTargetQueue Include="osx.1200.amd64.open"/>
+    <HelixTargetQueue Include="osx.1200.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
@@ -25,7 +24,7 @@
 
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Buffers.Tests.app;IncludesTestRunner=false;ExpectedExitCode=43</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / tvos-simulator -->

--- a/tests/integration-tests/Apple/TestAppBundle.proj
+++ b/tests/integration-tests/Apple/TestAppBundle.proj
@@ -23,7 +23,8 @@
     <Message Text="Extracted to $(TestAppDestinationDir)" Importance="High" />
 
     <ItemGroup>
-      <XHarnessAppFoldersToTest Include="$(TestAppDestinationDir)\$(TestAppBundleName)">
+      <XHarnessAppFoldersToTest Include="$(TestTarget)-$(TestAppBundleName)">
+        <AppBundlePath>$(TestAppDestinationDir)\$(TestAppBundleName)</AppBundlePath>
         <TestTarget>$(TestTarget)</TestTarget>
         <WorkItemTimeout>00:07:00</WorkItemTimeout>
         <TestTimeout>00:03:00</TestTimeout>


### PR DESCRIPTION
This uses the same method to pull application logs as iOS simulator and gets the exit code from the stdout of the app that logs it from the [dotnet/runtime wrapper](https://github.com/dotnet/runtime/blob/a883caa0803778084167b978281c34db8e753246/src/tasks/AppleAppBuilder/Templates/runtime.m).

Resolves #848 