### PR TITLE
Handle token cancellation in between Apple operations

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -104,9 +104,9 @@ public abstract class BaseOrchestrator : IDisposable
                 executeApp,
                 cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e)
         {
-            _logger.LogError("Application failed to launch in time");
+            _logger.LogDebug(e.ToString());
             return ExitCode.APP_LAUNCH_TIMEOUT;
         }
     }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -166,6 +166,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         {
             if (!appRunStarted)
             {
+                _logger.LogError("Cancelling the run as application failed to launch in time");
                 launchTimeoutCancellation.Cancel();
             }
         });

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -132,11 +132,12 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         // we didn't manage to start the app run until then.
         using var launchTimeoutCancellation = new CancellationTokenSource();
         var appRunStarted = false;
-        var task = Task.Delay(launchTimeout < timeout ? launchTimeout : timeout).ContinueWith(t =>
+        var shorterTimeout = launchTimeout < timeout ? launchTimeout : timeout;
+        var task = Task.Delay(shorterTimeout).ContinueWith(t =>
         {
             if (!appRunStarted)
             {
-                _logger.LogError("Cancelling the run as application failed to launch in time");
+                _logger.LogError($"Cancelling the run after {Math.Ceiling(shorterTimeout.TotalSeconds)} seconds as application failed to launch in time");
                 launchTimeoutCancellation.Cancel();
             }
         });

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -136,6 +136,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         {
             if (!appRunStarted)
             {
+                _logger.LogError("Cancelling the run as application failed to launch in time");
                 launchTimeoutCancellation.Cancel();
             }
         });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,6 +60,10 @@ internal abstract class AppleAppCommand<TArguments> : AppleCommand<TArguments> w
 
         var cts = new CancellationTokenSource();
         cts.CancelAfter(Arguments.Timeout);
+        cts.Token.Register(() =>
+        {
+            logger.LogError("Run timed out after {timeout} seconds", Math.Ceil(Arguments.Timeout.Value.TotalSeconds));
+        });
 
         return await InvokeInternal(serviceProvider, cts.Token);
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleAppCommand.cs
@@ -62,7 +62,7 @@ internal abstract class AppleAppCommand<TArguments> : AppleCommand<TArguments> w
         cts.CancelAfter(Arguments.Timeout);
         cts.Token.Register(() =>
         {
-            logger.LogError("Run timed out after {timeout} seconds", Math.Ceil(Arguments.Timeout.Value.TotalSeconds));
+            logger.LogError("Run timed out after {timeout} seconds", Math.Ceiling(Arguments.Timeout.Value.TotalSeconds));
         });
 
         return await InvokeInternal(serviceProvider, cts.Token);


### PR DESCRIPTION
Some operations do not accept the cancellation token (but they are shared with Xamarin so cannot change this) and some operations do not throw but return a "timed out" result.

This change takes that into account and returns `APP_LAUNCH_FAILURE` if we time out before we reach app start.

Fixes #855