### PR TITLE
Clasify case when no XML results were sent as `APP_CRASH`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -335,7 +335,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 return LogProblem("Failed to launch the application", ExitCode.APP_LAUNCH_FAILURE);
 
             case TestExecutingResult.Crashed:
-                return LogProblem("Application test run crashed", ExitCode.APP_LAUNCH_FAILURE);
+                return LogProblem("Application test run crashed", ExitCode.APP_CRASH);
 
             case TestExecutingResult.LaunchTimedOut:
                 _logger.LogError("Application launch timed out before the test execution has started");

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -610,7 +610,7 @@ public class TestReporter : ITestReporter
         else
         {
             WrenchLog.WriteLine("AddSummary: <b><i>{0} crashed at startup (no log)</i></b><br/>", _runMode);
-            _mainLog.WriteLine("Test run crashed before it started (no log file produced)");
+            _mainLog.WriteLine("Test run started but crashed and no test results were reported");
             result.ResultMessage = "No test log file was produced";
             crashed = true;
             Success = false;


### PR DESCRIPTION
This case, when app already connected over TCP, means, we already had a successful launch and we should categorize it as `APP_CRASH` so that the work item is not retried. This most likely means the runtime crashed while executing the tests