### PR TITLE
Extract logic to InstrumentationRunner and improve exit code detection

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.DotNet.XHarness.Android.Execution;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Android.Execution;
 using System.Collections.Generic;
 using System.IO;
 using System;

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -1,0 +1,225 @@
+﻿using Microsoft.DotNet.XHarness.Android.Execution;
+using System.Collections.Generic;
+using System.IO;
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.XHarness.Common.CLI;
+
+namespace Microsoft.DotNet.XHarness.Android;
+
+public class InstrumentationRunner
+{
+    public const string ReturnCodeVariableName = "return-code";
+
+    // nunit2 one should go away eventually
+    private static readonly string[] s_xmlOutputVariableNames = { "nunit2-results-path", "test-results-path" };
+    private const string TestRunSummaryVariableName = "test-execution-summary";
+    private const string ShortMessageVariableName = "shortMsg";
+    private const string ProcessCrashedShortMessage = "Process crashed";
+
+    private readonly ILogger _logger;
+    private readonly AdbRunner _runner;
+    
+    public InstrumentationRunner(ILogger logger, AdbRunner runner)
+    {
+        _logger = logger;
+        _runner = runner;
+    }
+    
+    public ExitCode RunApkInstrumentation(
+        string apkPackageName,
+        string? instrumentationName,
+        Dictionary<string, string> instrumentationArguments,
+        string outputDirectory,
+        string? deviceOutputFolder,
+        TimeSpan timeout,
+        int expectedExitCode)
+    {
+        int? instrumentationExitCode = null;
+
+        // No class name = default Instrumentation
+        ProcessExecutionResults result = _runner.RunApkInstrumentation(apkPackageName, instrumentationName, instrumentationArguments, timeout);
+
+        bool processCrashed = false;
+        bool failurePullingFiles = false;
+
+        using (_logger.BeginScope("Post-test copy and cleanup"))
+        {
+            if (result.ExitCode == (int)ExitCode.SUCCESS)
+            {
+                (instrumentationExitCode, processCrashed, failurePullingFiles) = ParseInstrumentationResult(apkPackageName, outputDirectory, result.StandardOutput);
+            }
+
+            // Optionally copy off an entire folder
+            if (!string.IsNullOrEmpty(deviceOutputFolder))
+            {
+                try
+                {
+                    var logs = _runner.PullFiles(apkPackageName, deviceOutputFolder, outputDirectory);
+                    foreach (string log in logs)
+                    {
+                        _logger.LogDebug($"Found output file: {log}");
+                    }
+                }
+                catch (Exception toLog)
+                {
+                    _logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", deviceOutputFolder);
+                    failurePullingFiles = true;
+                }
+            }
+
+            _runner.DumpAdbLog(Path.Combine(outputDirectory, $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log"));
+
+            if (processCrashed)
+            {
+                _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
+            }
+        }
+
+        if (processCrashed)
+        {
+            return ExitCode.APP_CRASH;
+        }
+
+        if (failurePullingFiles)
+        {
+            _logger.LogError($"Received expected instrumentation exit code ({instrumentationExitCode}), " +
+                             "but we hit errors pulling files from the device (see log for details.)");
+            return ExitCode.DEVICE_FILE_COPY_FAILURE;
+        }
+
+        if (!instrumentationExitCode.HasValue)
+        {
+            return ExitCode.RETURN_CODE_NOT_SET;
+        }
+
+        if (instrumentationExitCode != expectedExitCode)
+        {
+            _logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {expectedExitCode}");
+            return ExitCode.TESTS_FAILED;
+        }
+
+        return ExitCode.SUCCESS;
+    }
+
+    private (int?, bool, bool) ParseInstrumentationResult(string apkPackageName, string outputDirectory, string result)
+    {
+        int? instrumentationExitCode;
+        Dictionary<string, string> resultValues;
+        // This is where test instrumentation can communicate outwardly that test execution failed
+        (resultValues, instrumentationExitCode) = ParseInstrumentationOutputs(result);
+
+        // Pull XUnit result XMLs off the device
+        bool failurePullingFiles = PullResultXMLs(apkPackageName, outputDirectory, resultValues)!;
+        bool processCrashed = false;
+
+        if (resultValues.TryGetValue(TestRunSummaryVariableName, out string? testRunSummary))
+        {
+            _logger.LogInformation($"Test execution summary:{Environment.NewLine}{testRunSummary}");
+        }
+
+        if (resultValues.TryGetValue(ShortMessageVariableName, out string? shortMessage))
+        {
+            _logger.LogInformation($"Short message:{Environment.NewLine}{shortMessage}");
+            processCrashed = shortMessage.Contains(ProcessCrashedShortMessage);
+        }
+
+        // Due to the particulars of how instrumentations work, ADB will report a 0 exit code for crashed instrumentations
+        // We'll change that to a specific value and print a message explaining why.
+        if (resultValues.TryGetValue(ReturnCodeVariableName, out string? returnCode))
+        {
+            if (int.TryParse(returnCode, out int bundleExitCode))
+            {
+                _logger.LogInformation($"Instrumentation finished normally with exit code {bundleExitCode}");
+                instrumentationExitCode = bundleExitCode;
+            }
+            else
+            {
+                _logger.LogError($"Un-parse-able value for '{ReturnCodeVariableName}' : '{returnCode}'");
+                instrumentationExitCode = null;
+            }
+        }
+        else
+        {
+            _logger.LogError($"No value for '{ReturnCodeVariableName}' provided in instrumentation result. This may indicate a crashed test (see log)");
+            instrumentationExitCode ??= null;
+        }
+
+        return (instrumentationExitCode, processCrashed, failurePullingFiles);
+    }
+
+    private bool PullResultXMLs(string apkPackageName, string outputDirectory, Dictionary<string, string> resultValues)
+    {
+        bool success = false;
+
+        foreach (string possibleResultKey in s_xmlOutputVariableNames)
+        {
+            if (!resultValues.TryGetValue(possibleResultKey, out string? resultFile))
+            {
+                continue;
+            }
+
+            _logger.LogInformation($"Found XML result file: '{resultFile}'(key: {possibleResultKey})");
+
+            try
+            {
+                _runner.PullFiles(apkPackageName, resultFile, outputDirectory);
+            }
+            catch (Exception toLog)
+            {
+                _logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", resultFile);
+                success = true;
+            }
+        }
+
+        return success;
+    }
+
+    private (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(string stdout)
+    {
+        // If ADB.exe's output changes (which we control when we take updates in this repo), we'll need to fix this.
+        string resultPrefix = "INSTRUMENTATION_RESULT:";
+        string exitCodePrefix = "INSTRUMENTATION_CODE:";
+        int exitCode = -1;
+        var outputs = new Dictionary<string, string>();
+        string[] lines = stdout.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (string line in lines)
+        {
+            if (line.StartsWith(resultPrefix))
+            {
+                var subString = line.Substring(resultPrefix.Length);
+                string[] results = subString.Trim().Split('=');
+                if (results.Length == 2)
+                {
+                    if (outputs.ContainsKey(results[0]))
+                    {
+                        _logger.LogWarning($"Key '{results[0]}' defined more than once");
+                        outputs[results[0]] = results[1];
+                    }
+                    else
+                    {
+                        outputs.Add(results[0], results[1]);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning($"Skipping output line due to key-value-pair parse failure: '{line}'");
+                }
+            }
+            else if (line.StartsWith(exitCodePrefix))
+            {
+                if (!int.TryParse(line.Substring(exitCodePrefix.Length).Trim(), out var ec))
+                {
+                    _logger.LogError($"Failure parsing ADB Exit code from line: '{line}'");
+                }
+                else
+                {
+                    exitCode = ec;
+                }
+            }
+        }
+
+        return (outputs, exitCode);
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessTestCommandArguments.cs
@@ -21,7 +21,6 @@ internal class AndroidHeadlessTestCommandArguments : XHarnessCommandArguments, I
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
     public ApiVersionArgument ApiVersion { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
-    public DeviceOutputFolderArgument DeviceOutputFolder { get; } = new();
     public WifiArgument Wifi { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
@@ -37,7 +36,6 @@ internal class AndroidHeadlessTestCommandArguments : XHarnessCommandArguments, I
         DeviceId,
         ApiVersion,
         ExpectedExitCode,
-        DeviceOutputFolder,
         Wifi,
     };
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.DotNet.XHarness.Android;
-using Microsoft.DotNet.XHarness.Android.Execution;
 using Microsoft.DotNet.XHarness.CLI.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
@@ -16,13 +12,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Android;
 
 internal class AndroidRunCommand : AndroidCommand<AndroidRunCommandArguments>
 {
-    // nunit2 one should go away eventually
-    private static readonly string[] s_xmlOutputVariableNames = { "nunit2-results-path", "test-results-path" };
-    private const string TestRunSummaryVariableName = "test-execution-summary";
-    private const string ShortMessageVariableName = "shortMsg";
-    private const string ReturnCodeVariableName = "return-code";
-    private const string ProcessCrashedShortMessage = "Process crashed";
-
     protected override AndroidRunCommandArguments Arguments { get; } = new();
 
     protected override string CommandUsage { get; } = "android run --output-directory=... --package-name=... [OPTIONS]";
@@ -34,7 +23,7 @@ internal class AndroidRunCommand : AndroidCommand<AndroidRunCommandArguments>
 APKs can communicate status back to XHarness using the parameters:
 
 Required:
-{ReturnCodeVariableName} - Exit code for instrumentation. Necessary because a crashing instrumentation may be indistinguishable from a passing one based solely on the exit code.
+{InstrumentationRunner.ReturnCodeVariableName} - Exit code for instrumentation. Necessary because a crashing instrumentation may be indistinguishable from a passing one based solely on the exit code.
  
 Arguments:
 ";
@@ -66,193 +55,24 @@ Arguments:
         // Wait till at least device(s) are ready
         runner.WaitForDevice();
 
-        return InvokeHelper(
-            logger,
+        logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
+
+        // Empty log as we'll be uploading the full logcat for this execution
+        runner.ClearAdbLog();
+        
+        if (Arguments.Wifi != WifiStatus.Unknown)
+        {
+            runner.EnableWifi(Arguments.Wifi == WifiStatus.Enable);
+        }
+
+        var instrumentationRunner = new InstrumentationRunner(logger, runner);
+        return instrumentationRunner.RunApkInstrumentation(
             Arguments.PackageName,
             Arguments.InstrumentationName,
             Arguments.InstrumentationArguments,
             Arguments.OutputDirectory,
             Arguments.DeviceOutputFolder,
             Arguments.Timeout,
-            Arguments.ExpectedExitCode,
-            Arguments.Wifi,
-            runner);
-    }
-
-    public static ExitCode InvokeHelper(
-        ILogger logger,
-        string apkPackageName,
-        string? instrumentationName,
-        Dictionary<string, string> instrumentationArguments,
-        string outputDirectory,
-        string? deviceOutputFolder,
-        TimeSpan timeout,
-        int expectedExitCode,
-        WifiStatus wifi,
-        AdbRunner runner)
-    {
-        int instrumentationExitCode = (int)ExitCode.GENERAL_FAILURE;
-
-        logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
-
-        // Empty log as we'll be uploading the full logcat for this execution
-        runner.ClearAdbLog();
-
-        if (wifi != WifiStatus.Unknown)
-        {
-            runner.EnableWifi(wifi == WifiStatus.Enable);
-        }
-
-        // No class name = default Instrumentation
-        ProcessExecutionResults? result = runner.RunApkInstrumentation(
-            apkPackageName,
-            instrumentationName,
-            instrumentationArguments,
-            timeout);
-
-        bool processCrashed = false;
-        bool failurePullingFiles = false;
-
-        using (logger.BeginScope("Post-test copy and cleanup"))
-        {
-            if (result.ExitCode == (int)ExitCode.SUCCESS)
-            {
-                Dictionary<string, string> resultValues;
-                // This is where test instrumentation can communicate outwardly that test execution failed
-                (resultValues, instrumentationExitCode) = ParseInstrumentationOutputs(logger, result.StandardOutput);
-
-                // Pull XUnit result XMLs off the device
-                foreach (string possibleResultKey in s_xmlOutputVariableNames)
-                {
-                    if (resultValues.ContainsKey(possibleResultKey))
-                    {
-                        logger.LogInformation($"Found XML result file: '{resultValues[possibleResultKey]}'(key: {possibleResultKey})");
-                        try
-                        {
-                            runner.PullFiles(apkPackageName, resultValues[possibleResultKey], outputDirectory);
-                        }
-                        catch (Exception toLog)
-                        {
-                            logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", resultValues[possibleResultKey]);
-                            failurePullingFiles = true;
-                        }
-                    }
-                }
-
-                if (resultValues.ContainsKey(TestRunSummaryVariableName))
-                {
-                    logger.LogInformation($"Test execution summary:{Environment.NewLine}{resultValues[TestRunSummaryVariableName]}");
-                }
-
-                if (resultValues.ContainsKey(ShortMessageVariableName))
-                {
-                    logger.LogInformation($"Short Message: {Environment.NewLine}{resultValues[ShortMessageVariableName]}");
-                    processCrashed = resultValues[ShortMessageVariableName].Contains(ProcessCrashedShortMessage);
-                }
-
-                // Due to the particulars of how instrumentations work, ADB will report a 0 exit code for crashed instrumentations
-                // We'll change that to a specific value and print a message explaining why.
-                if (resultValues.ContainsKey(ReturnCodeVariableName))
-                {
-                    if (int.TryParse(resultValues[ReturnCodeVariableName], out int bundleExitCode))
-                    {
-                        logger.LogInformation($"Instrumentation finished normally with exit code {bundleExitCode}");
-                        instrumentationExitCode = bundleExitCode;
-                    }
-                    else
-                    {
-                        logger.LogError($"Un-parse-able value for '{ReturnCodeVariableName}' : '{resultValues[ReturnCodeVariableName]}'");
-                        instrumentationExitCode = (int)ExitCode.RETURN_CODE_NOT_SET;
-                    }
-                }
-                else
-                {
-                    logger.LogError($"No value for '{ReturnCodeVariableName}' provided in instrumentation result.  This may indicate a crashed test (see log)");
-                    instrumentationExitCode = (int)ExitCode.RETURN_CODE_NOT_SET;
-                }
-            }
-
-            // Optionally copy off an entire folder
-            if (!string.IsNullOrEmpty(deviceOutputFolder))
-            {
-                try
-                {
-                    var logs = runner.PullFiles(apkPackageName, deviceOutputFolder, outputDirectory);
-                    foreach (string log in logs)
-                    {
-                        logger.LogDebug($"Found output file: {log}");
-                    }
-                }
-                catch (Exception toLog)
-                {
-                    logger.LogError(toLog, "Hit error (typically permissions) trying to pull {filePathOnDevice}", deviceOutputFolder);
-                    failurePullingFiles = true;
-                }
-            }
-
-            runner.DumpAdbLog(Path.Combine(outputDirectory, $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log"));
-
-            if (processCrashed)
-            {
-                runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
-            }
-        }
-
-        if (instrumentationExitCode != expectedExitCode)
-        {
-            logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {expectedExitCode}");
-            return ExitCode.TESTS_FAILED;
-        }
-        else if (failurePullingFiles)
-        {
-            logger.LogError($"Received expected instrumentation exit code ({instrumentationExitCode}), but we hit errors pulling files from the device (see log for details.)");
-            return ExitCode.DEVICE_FILE_COPY_FAILURE;
-        }
-
-        return ExitCode.SUCCESS;
-    }
-
-    private static (Dictionary<string, string> values, int exitCode) ParseInstrumentationOutputs(ILogger logger, string stdOut)
-    {
-        // If ADB.exe's output changes (which we control when we take updates in this repo), we'll need to fix this.
-        string resultPrefix = "INSTRUMENTATION_RESULT:";
-        string exitCodePrefix = "INSTRUMENTATION_CODE:";
-        int exitCode = -1;
-        var outputs = new Dictionary<string, string>();
-        string[] lines = stdOut.Split(Environment.NewLine);
-
-        foreach (string line in lines)
-        {
-            if (line.StartsWith(resultPrefix))
-            {
-                var subString = line.Substring(resultPrefix.Length);
-                string[] results = subString.Trim().Split('=');
-                if (results.Length == 2)
-                {
-                    if (outputs.ContainsKey(results[0]))
-                    {
-                        logger.LogWarning($"Key '{results[0]}' defined more than once");
-                        outputs[results[0]] = results[1];
-                    }
-                    else
-                    {
-                        outputs.Add(results[0], results[1]);
-                    }
-                }
-                else
-                {
-                    logger.LogWarning($"Skipping output line due to key-value-pair parse failure: '{line}'");
-                }
-            }
-            else if (line.StartsWith(exitCodePrefix))
-            {
-                if (!int.TryParse(line.Substring(exitCodePrefix.Length).Trim(), out exitCode))
-                {
-                    logger.LogError($"Failure parsing ADB Exit code from line: '{line}'");
-                }
-            }
-        }
-
-        return (outputs, exitCode);
+            Arguments.ExpectedExitCode);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -64,22 +64,31 @@ Arguments:
             runner,
             DiagnosticsData);
 
-        if (exitCode == ExitCode.SUCCESS)
+        if (Arguments.Wifi != WifiStatus.Unknown)
         {
-            exitCode = AndroidRunCommand.InvokeHelper(
-                logger: logger,
-                apkPackageName: Arguments.PackageName,
-                instrumentationName: Arguments.InstrumentationName,
-                instrumentationArguments: Arguments.InstrumentationArguments,
-                outputDirectory: Arguments.OutputDirectory,
-                deviceOutputFolder: Arguments.DeviceOutputFolder,
-                timeout: Arguments.Timeout,
-                expectedExitCode: Arguments.ExpectedExitCode,
-                wifi: Arguments.Wifi,
-                runner: runner);
+            runner.EnableWifi(Arguments.Wifi == WifiStatus.Enable);
         }
 
-        runner.UninstallApk(Arguments.PackageName);
+        try
+        {
+            if (exitCode == ExitCode.SUCCESS)
+            {
+                var instrumentationRunner = new InstrumentationRunner(logger, runner);
+                exitCode = instrumentationRunner.RunApkInstrumentation(
+                    Arguments.PackageName,
+                    Arguments.InstrumentationName,
+                    Arguments.InstrumentationArguments,
+                    Arguments.OutputDirectory,
+                    Arguments.DeviceOutputFolder,
+                    Arguments.Timeout,
+                    Arguments.ExpectedExitCode);
+            }
+        }
+        finally
+        {
+            runner.UninstallApk(Arguments.PackageName);
+        }
+
         return exitCode;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessTestCommand.cs
@@ -7,8 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.Android;
-using Microsoft.DotNet.XHarness.CLI.AndroidHeadless;
-using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments.AndroidHeadless;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.Logging;
@@ -17,8 +15,6 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.AndroidHeadless;
 
 internal class AndroidHeadlessTestCommand : AndroidCommand<AndroidHeadlessTestCommandArguments>
 {
-    private const string ReturnCodeVariableName = "return-code";
-
     protected override AndroidHeadlessTestCommandArguments Arguments { get; } = new();
 
     protected override string CommandUsage { get; } = "android-headless test --output-directory=... --test-folder=... --test-command=... [OPTIONS]";
@@ -73,7 +69,6 @@ Arguments:
                 testAssembly: Arguments.TestAssembly,
                 testScript: Arguments.TestScript,
                 outputDirectory: Arguments.OutputDirectory,
-                deviceOutputFolder: Arguments.DeviceOutputFolder,
                 timeout: Arguments.Timeout,
                 expectedExitCode: Arguments.ExpectedExitCode,
                 wifi: Arguments.Wifi,

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
@@ -104,7 +104,6 @@ public enum ExitCode
     /// <summary>
     /// This timeout occurs when the Apple app has been launched but hasn't
     /// connected yet over TCP and --launch-timeout expires
-
     /// </summary>
     APP_LAUNCH_TIMEOUT = 90,
 


### PR DESCRIPTION
This change:
- Extracts logic for running APK instrumentations so that `AndroidTestCommand` doesn't have to call into `AndroidRunCommand` anymore
- Stops parsing the `INSTRUMENTATION_CODE` whose value was not used anywhere
- Improves the code in several places
- Floats some exit codes that were getting lost
- Distinguishes between no exit code returned and tests failed (fixes #872)
- Removes some dead code