### PR TITLE
Add E2E tests for the scouting queue

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -1,0 +1,34 @@
+<Project DefaultTargets="Test">
+  <Import Project="../Helix.SDK.configuration.props"/>
+
+  <ItemGroup>
+    <HelixTargetQueue Include="osx.1200.amd64.scouting.open"/>
+
+    <!-- apple test / ios-simulator-64 -->
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+    </XHarnessAppleProject>
+
+    <!-- apple run / ios-simlator-64 -->
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+    </XHarnessAppleProject>
+
+    <!-- apple test / maccatalyst -->
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+    </XHarnessAppleProject>
+
+    <!-- apple run / maccatalyst -->
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+    </XHarnessAppleProject>
+
+    <!-- apple test / tvos-simulator -->
+    <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=tvos-simulator;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+    </XHarnessAppleProject>
+  </ItemGroup>
+
+  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
+</Project>


### PR DESCRIPTION
This test project will be used when testing new Xcode. It is linked to [from the wiki](https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/870/Install-new-version-of-Xcode-on-Helix-machines)