### PR TITLE
Bump mlaunch to `13.3.0-22255.12.9e3f1f1440`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -255,12 +255,6 @@ public class AppRunner : AppRunnerBase, IAppRunner
 
         args.Add(new SimulatorUDIDArgument(simulator.UDID));
 
-        var stdoutLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stdout.log", LogType.ApplicationLog);
-        var stderrLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stderr.log", LogType.ApplicationLog);
-        
-        args.Add(new SetStdoutArgument(stdoutLog));
-        args.Add(new SetStderrArgument(stderrLog));
-
         if (appInformation.Extension.HasValue)
         {
             switch (appInformation.Extension)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -255,9 +255,11 @@ public class AppRunner : AppRunnerBase, IAppRunner
 
         args.Add(new SimulatorUDIDArgument(simulator.UDID));
 
-        var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
-        args.Add(new SetStdoutArgument(appLog));
-        args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data, however stderr captures stdout of the app too
+        var stdoutLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stdout.log", LogType.ApplicationLog);
+        var stderrLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stderr.log", LogType.ApplicationLog);
+        
+        args.Add(new SetStdoutArgument(stdoutLog));
+        args.Add(new SetStderrArgument(stderrLog));
 
         if (appInformation.Extension.HasValue)
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -558,12 +558,6 @@ public class AppTester : AppRunnerBase, IAppTester
         args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "127.0.0.1"));
         args.Add(new SimulatorUDIDArgument(simulator));
 
-        var stdoutLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stdout.log", LogType.ApplicationLog);
-        var stderrLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stderr.log", LogType.ApplicationLog);
-
-        args.Add(new SetStdoutArgument(stdoutLog));
-        args.Add(new SetStderrArgument(stderrLog));
-
         if (appInformation.Extension.HasValue)
         {
             switch (appInformation.Extension)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -558,9 +558,11 @@ public class AppTester : AppRunnerBase, IAppTester
         args.Add(new SetEnvVariableArgument(EnviromentVariables.HostName, "127.0.0.1"));
         args.Add(new SimulatorUDIDArgument(simulator));
 
-        var appLog = _logs.CreateFile(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog);
-        args.Add(new SetStdoutArgument(appLog));
-        args.Add(new SetStderrArgument(appLog)); // Seems like mlaunch only redirects stderr, stdout doesn't produce any data, however stderr captures stdout of the app too
+        var stdoutLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stdout.log", LogType.ApplicationLog);
+        var stderrLog = _logs.CreateFile(appInformation.BundleIdentifier + ".stderr.log", LogType.ApplicationLog);
+
+        args.Add(new SetStdoutArgument(stdoutLog));
+        args.Add(new SetStderrArgument(stderrLog));
 
         if (appInformation.Extension.HasValue)
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/ErrorKnowledgeBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/ErrorKnowledgeBase.cs
@@ -40,6 +40,14 @@ public class ErrorKnowledgeBase : IErrorKnowledgeBase
             new("Failed to launch the Simulator as XHarness was most likely started from a user session without GUI capabilities (e.g. from a launchd daemon). " +
                 "Please start XHarness from a full user session or bind the run to one via `sudo launchctl asuser`",
                 suggestedExitCode: (int)ExitCode.APP_LAUNCH_FAILURE),
+
+        ["error HE0018: Could not launch the simulator application"] =
+            new("Failed to launch the Simulator, please try again. If the problem persists, try rebooting MacOS",
+                suggestedExitCode: (int)ExitCode.SIMULATOR_FAILURE),
+
+        ["error HE0042: Could not launch the app"] =
+            new("Failed to launch the application, please try again. If the problem persists, try rebooting MacOS",
+                suggestedExitCode: (int)ExitCode.APP_LAUNCH_FAILURE),
     };
 
     private static readonly Dictionary<string, KnownIssue> s_buildErrorMaps = new();

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22255.12.9e3f1f1440">
+    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22256.31.aa97df54bb">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22181.16.cf9f7409e9">
+    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22255.12.9e3f1f1440">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22256.31.aa97df54bb">
+    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22260.5.29a1c1382e">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
@@ -72,12 +72,12 @@ public abstract class AppRunTestBase : IDisposable
 
         _snapshotReporter = new Mock<ICrashSnapshotReporter>();
 
-        _stdoutLog = Mock.Of<IFileBackedLog>(
-            x => x.FullPath == $"./{AppBundleIdentifier}.log" && x.Description == LogType.ApplicationLog.ToString());
         _appLog = Mock.Of<IFileBackedLog>(
             x => x.FullPath == $"./{BundleExecutable}.log" && x.Description == LogType.ApplicationLog.ToString());
+        _stdoutLog = Mock.Of<IFileBackedLog>(
+            x => x.FullPath == $"./{AppBundleIdentifier}.stdout.log" && x.Description == LogType.ApplicationLog.ToString());
         _stderrLog = Mock.Of<IFileBackedLog>(
-            x => x.FullPath == $"./{AppBundleIdentifier}.err.log" && x.Description == LogType.ApplicationLog.ToString());
+            x => x.FullPath == $"./{AppBundleIdentifier}.stderr.log" && x.Description == LogType.ApplicationLog.ToString());
 
         _logs = new Mock<ILogs>();
         _logs
@@ -87,16 +87,16 @@ public abstract class AppRunTestBase : IDisposable
             .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
             .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
         _logs
-            .Setup(x => x.CreateFile(AppBundleIdentifier + ".log", LogType.ApplicationLog))
+            .Setup(x => x.CreateFile(AppBundleIdentifier + ".stdout.log", LogType.ApplicationLog))
             .Returns(_stdoutLog.FullPath);
         _logs
-            .Setup(x => x.Create(AppBundleIdentifier + ".log", LogType.ApplicationLog.ToString(), It.IsAny<bool?>()))
-            .Returns(_stdoutLog);
-        _logs
-            .Setup(x => x.Create(AppBundleIdentifier + ".err.log", LogType.ApplicationLog.ToString(), It.IsAny<bool?>()))
-            .Returns(_stderrLog);
+            .Setup(x => x.CreateFile(AppBundleIdentifier + ".stderr.log", LogType.ApplicationLog))
+            .Returns(_stderrLog.FullPath);
         _logs
             .Setup(x => x.Create(BundleExecutable + ".log", It.IsAny<string>(), It.IsAny<bool?>()))
+            .Returns(_appLog);
+        _logs
+            .Setup(x => x.Create(AppBundleIdentifier + ".log", It.IsAny<string>(), It.IsAny<bool?>()))
             .Returns(_appLog);
 
         var factory2 = new Mock<ICrashSnapshotReporterFactory>();

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
@@ -59,8 +59,6 @@ public abstract class AppRunTestBase : IDisposable
     protected readonly Mock<IHelpers> _helpers;
 
     protected readonly ICrashSnapshotReporterFactory _snapshotReporterFactory;
-    protected readonly IFileBackedLog _stdoutLog;
-    protected readonly IFileBackedLog _stderrLog;
     protected readonly IFileBackedLog _appLog;
 
     protected AppRunTestBase()
@@ -74,10 +72,6 @@ public abstract class AppRunTestBase : IDisposable
 
         _appLog = Mock.Of<IFileBackedLog>(
             x => x.FullPath == $"./{BundleExecutable}.log" && x.Description == LogType.ApplicationLog.ToString());
-        _stdoutLog = Mock.Of<IFileBackedLog>(
-            x => x.FullPath == $"./{AppBundleIdentifier}.stdout.log" && x.Description == LogType.ApplicationLog.ToString());
-        _stderrLog = Mock.Of<IFileBackedLog>(
-            x => x.FullPath == $"./{AppBundleIdentifier}.stderr.log" && x.Description == LogType.ApplicationLog.ToString());
 
         _logs = new Mock<ILogs>();
         _logs
@@ -86,12 +80,6 @@ public abstract class AppRunTestBase : IDisposable
         _logs
             .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
             .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
-        _logs
-            .Setup(x => x.CreateFile(AppBundleIdentifier + ".stdout.log", LogType.ApplicationLog))
-            .Returns(_stdoutLog.FullPath);
-        _logs
-            .Setup(x => x.CreateFile(AppBundleIdentifier + ".stderr.log", LogType.ApplicationLog))
-            .Returns(_stderrLog.FullPath);
         _logs
             .Setup(x => x.Create(BundleExecutable + ".log", It.IsAny<string>(), It.IsAny<bool?>()))
             .Returns(_appLog);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -681,8 +681,8 @@ public class AppRunnerTests : AppRunTestBase
         "-argument=--xyz " +
         "-setenv=appArg1=value1 " +
         $"--device=:v2:udid={_mockSimulator.UDID} " +
-        $"--stdout=./{AppBundleIdentifier}.log " +
-        $"--stderr=./{AppBundleIdentifier}.log " +
+        $"--stdout=./{AppBundleIdentifier}.stdout.log " +
+        $"--stderr=./{AppBundleIdentifier}.stderr.log " +
         $"--launchsimbundleid={AppBundleIdentifier}";
 
     private void SetupLogList(IEnumerable<IFileBackedLog> logs)

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -36,7 +36,7 @@ public class AppRunnerTests : AppRunTestBase
                LogType.SystemLog))
             .Returns(captureLog.Object);
 
-        SetupLogList(new[] { captureLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { captureLog.Object });
 
         // Act
         var appRunner = new AppRunner(
@@ -97,7 +97,7 @@ public class AppRunnerTests : AppRunTestBase
         deviceSystemLog.SetupGet(x => x.FullPath).Returns(AppBundleIdentifier + "system.log");
         deviceSystemLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
 
-        SetupLogList(new[] { deviceSystemLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { deviceSystemLog.Object });
 
         _logs
             .Setup(x => x.Create("device-" + DeviceName + "-mocked_timestamp.log", LogType.SystemLog.ToString(), It.IsAny<bool?>()))
@@ -163,7 +163,7 @@ public class AppRunnerTests : AppRunTestBase
         deviceSystemLog.SetupGet(x => x.FullPath).Returns(AppBundleIdentifier + "system.log");
         deviceSystemLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
 
-        SetupLogList(new[] { deviceSystemLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { deviceSystemLog.Object });
 
         _logs
             .Setup(x => x.Create("device-" + DeviceName + "-mocked_timestamp.log", LogType.SystemLog.ToString(), It.IsAny<bool?>()))
@@ -344,7 +344,7 @@ public class AppRunnerTests : AppRunTestBase
         deviceSystemLog.SetupGet(x => x.FullPath).Returns(AppBundleIdentifier + "system.log");
         deviceSystemLog.SetupGet(x => x.Description).Returns(LogType.SystemLog.ToString());
 
-        SetupLogList(new[] { deviceSystemLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { deviceSystemLog.Object });
 
         _logs
             .Setup(x => x.Create("device-" + DeviceName + "-mocked_timestamp.log", LogType.SystemLog.ToString(), It.IsAny<bool?>()))
@@ -419,7 +419,7 @@ public class AppRunnerTests : AppRunTestBase
                LogType.SystemLog))
             .Returns(captureLog.Object);
 
-        SetupLogList(new[] { captureLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { captureLog.Object });
 
         var expectedArgs = GetExpectedSimulatorMlaunchArgs();
 
@@ -522,7 +522,7 @@ public class AppRunnerTests : AppRunTestBase
                LogType.SystemLog))
             .Returns(captureLog.Object);
 
-        SetupLogList(new[] { captureLog.Object, _stdoutLog, _stderrLog });
+        SetupLogList(new[] { captureLog.Object });
 
         var expectedArgs = GetExpectedSimulatorMlaunchArgs();
 
@@ -681,8 +681,6 @@ public class AppRunnerTests : AppRunTestBase
         "-argument=--xyz " +
         "-setenv=appArg1=value1 " +
         $"--device=:v2:udid={_mockSimulator.UDID} " +
-        $"--stdout=./{AppBundleIdentifier}.stdout.log " +
-        $"--stderr=./{AppBundleIdentifier}.stderr.log " +
         $"--launchsimbundleid={AppBundleIdentifier}";
 
     private void SetupLogList(IEnumerable<IFileBackedLog> logs)

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -644,7 +644,5 @@ public class AppTesterTests : AppRunTestBase
         "-argument=--xyz " +
         "-setenv=NUNIT_HOSTNAME=127.0.0.1 " +
         $"--device=:v2:udid={_mockSimulator.UDID} " +
-        $"--stdout=./{AppBundleIdentifier}.stdout.log " +
-        $"--stderr=./{AppBundleIdentifier}.stderr.log " +
         $"--launchsimbundleid={AppBundleIdentifier}";
 }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -644,7 +644,7 @@ public class AppTesterTests : AppRunTestBase
         "-argument=--xyz " +
         "-setenv=NUNIT_HOSTNAME=127.0.0.1 " +
         $"--device=:v2:udid={_mockSimulator.UDID} " +
-        $"--stdout=./{AppBundleIdentifier}.log " +
-        $"--stderr=./{AppBundleIdentifier}.log " +
+        $"--stdout=./{AppBundleIdentifier}.stdout.log " +
+        $"--stderr=./{AppBundleIdentifier}.stderr.log " +
         $"--launchsimbundleid={AppBundleIdentifier}";
 }


### PR DESCRIPTION
- Bumping mlaunch
- Removing `--stdout` and `--stderr` because new mlaunch changed behaviour around them but we also don't really utilize them as we use `log stream` instead
- Adding new failures to error knowledge base