### PR TITLE
Bump mlaunch to `13.3.0-22181.16.cf9f7409e9`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22181.16.cf9f7409e9">
+    <PackageReference Include="Microsoft.DotNet.Mlaunch" Version="13.3.0-22260.5.29a1c1382e">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
Reverts dotnet/xharness#888 (the reported bug was on an older version of XHarness)