### PR TITLE
Categorize Android emulator crash as `SIMULATOR_FAILURE`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -85,14 +85,13 @@ public class InstrumentationRunner
 
         if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
         {
-            // In case emulator crashes halfway through, it sometimes manifests as a timeout too
-            // However, in this case, we usually fail to pull the log which means the emulator did indeed crash
-            if (!logCatSucceeded)
-            {
-                return ExitCode.SIMULATOR_FAILURE;
-            }
-
             return ExitCode.TIMED_OUT;
+        }
+
+        // In case emulator crashes halfway through, we can tell by failing to pull ADB logs from it
+        if (!logCatSucceeded)
+        {
+            return ExitCode.SIMULATOR_FAILURE;
         }
 
         if (processCrashed)

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -83,15 +83,15 @@ public class InstrumentationRunner
             }
         }
 
-        if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
-        {
-            return ExitCode.TIMED_OUT;
-        }
-
         // In case emulator crashes halfway through, we can tell by failing to pull ADB logs from it
         if (!logCatSucceeded)
         {
             return ExitCode.SIMULATOR_FAILURE;
+        }
+
+        if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
+        {
+            return ExitCode.TIMED_OUT;
         }
 
         if (processCrashed)


### PR DESCRIPTION
Resolves #899 