### PR TITLE
Give access to `kTCCServiceCamera` in simulator's TCC database

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/TCCDatabase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/TCCDatabase.cs
@@ -105,6 +105,7 @@ public class TCCDatabase : ITCCDatabase
                 "kTCCServiceAll", // You'd think 'All' means all prompts, but some prompts still show up.
 				"kTCCServiceAddressBook",
                 "kTCCServiceCalendar",
+                "kTCCServiceCamera",
                 "kTCCServicePhotos",
                 "kTCCServiceMediaLibrary",
                 "kTCCServiceMicrophone",

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/TCCDatabaseTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/TCCDatabaseTests.cs
@@ -84,13 +84,14 @@ public class TCCDatabaseTests
     [InlineData("com.apple.CoreSimulator.SimRuntime.iOS-12-1", 3)]
     [InlineData("com.apple.CoreSimulator.SimRuntime.iOS-10-1", 2)]
     [InlineData("com.apple.CoreSimulator.SimRuntime.iOS-7-1", 1)]
-    public async Task AgreeToPropmtsAsyncSuccessTest(string runtime, int dbVersion)
+    public async Task AgreeToPromptsAsyncSuccessTest(string runtime, int dbVersion)
     {
         string bundleIdentifier = "my-bundle-identifier";
         var services = new string[] {
                     "kTCCServiceAll",
                     "kTCCServiceAddressBook",
                     "kTCCServiceCalendar",
+                    "kTCCServiceCamera",
                     "kTCCServicePhotos",
                     "kTCCServiceMediaLibrary",
                     "kTCCServiceMicrophone",


### PR DESCRIPTION
This isn't a new permission, but for some reason it seems this becomes a problem in iOS 16 / Xcode 14 if it's not set (when it worked previously).