### PR TITLE
Fix logic to determine if a test has started execution

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -76,7 +76,7 @@ public class TestReporter : ITestReporter
 
     public bool ResultsUseXml => _xmlJargon != XmlResultJargon.Missing;
 
-    private bool TestExecutionStarted => _listener.ConnectedTask.IsCompleted && _listener.ConnectedTask.Result;
+    private bool TestExecutionStarted => _listener.ConnectedTask.Status == TaskStatus.RanToCompletion && _listener.ConnectedTask.Result;
 
     public TestReporter(
         IMlaunchProcessManager processManager,


### PR DESCRIPTION
The 'ConnectedTask' must not only have completed, it must have completed successfully (run to completion) for a test to have started.

Fixes this type of exceptions:

    Harness exception for 'introspection': System.AggregateException: One or more errors occurred. (A task was canceled.) ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
    --- End of inner exception stack trace ---
    at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00013] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs:2029
    at System.Threading.Tasks.Task`1[TResult].GetResultCore (System.Boolean waitCompletionNotification) [0x0002b] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:496
    at System.Threading.Tasks.Task`1[TResult].get_Result () [0x00000] in /Users/builder/jenkins/workspace/build-package-osx-mono/2020-02/external/bockbuild/builds/mono-x64/external/corert/src/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs:466
    at Microsoft.DotNet.XHarness.iOS.Shared.TestReporter.get_TestExecutionStarted () [0x00000] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs:79
    at Microsoft.DotNet.XHarness.iOS.Shared.TestReporter.ParseResult () [0x002d9] in /_/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs:639
    at Xharness.AppRunner.RunAsync () [0x01b78] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/AppRunner.cs:453
    at Xharness.Jenkins.TestTasks.RunSimulator.RunTestAsync () [0x002b1] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunSimulator.cs:128
    at Xharness.Jenkins.TestTasks.RunTest.ExecuteAsync () [0x001b9] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/RunTest.cs:113
    at Xharness.Jenkins.TestTasks.TestTasks.RunInternalAsync () [0x00226] in /Users/builder/azdo/_work/1/s/xamarin-macios/tests/xharness/Jenkins/TestTasks/TestTask.cs:269
    ---> (Inner Exception #0) System.Threading.Tasks.TaskCanceledException: A task was canceled.<---