### PR TITLE
Fix SpecialFolder.Personal usage

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.Apple;
 /// </summary>
 public abstract class BaseOrchestrator : IDisposable
 {
-    protected static readonly string s_mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".mtouch-launch-with-lldb");
+    protected static readonly string s_mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), ".mtouch-launch-with-lldb");
 
     private readonly IAppBundleInformationParser _appBundleInformationParser;
     private readonly IAppInstaller _appInstaller;


### PR DESCRIPTION
SpecialFolder Personal is the same value as MyDocuments. I am proposing to obsolete/deprecate SpecialFolder.Personal in https://github.com/dotnet/runtime/issues/75563. Since these two names have the same underlying value, it is more understandable/readable to use MyDocuments in code. This way readers fully understand what folder is being referenced.

Changing Personal to MyDocuments here.