### PR TITLE
[wasm] Misc improvements

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -200,17 +200,23 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
 
         options.AddArguments(new[]
         {
-                // added based on https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts#L159-L181
-                "--allow-insecure-localhost",
-                "--disable-breakpad",
-                "--disable-component-extensions-with-background-pages",
-                "--disable-dev-shm-usage",
-                "--disable-extensions",
-                "--disable-features=TranslateUI",
-                "--disable-ipc-flooding-protection",
-                "--force-color-profile=srgb",
-                "--metrics-recording-only"
-            });
+            // added based on https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts#L159-L181
+            "--allow-insecure-localhost",
+            "--disable-breakpad",
+            "--disable-component-extensions-with-background-pages",
+            "--disable-dev-shm-usage",
+            "--disable-extensions",
+            "--disable-features=TranslateUI",
+            "--disable-ipc-flooding-protection",
+            "--force-color-profile=srgb",
+            "--metrics-recording-only"
+        });
+
+        if (File.Exists("/.dockerenv"))
+        {
+            // Use --no-sandbox for containers, and codespaces
+            options.AddArguments("--no-sandbox");
+        }
 
         if (Arguments.NoQuit)
             options.LeaveBrowserRunning = true;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -72,7 +72,7 @@ public class WasmTestMessagesProcessor
         }
         catch (Exception ex)
         {
-            _channelWriter.TryComplete();
+            _channelWriter.TryComplete(ex);
 
             // surface the exception from task for this method
             // and from _completed
@@ -195,7 +195,8 @@ public class WasmTestMessagesProcessor
         if (line.StartsWith("WASM EXIT"))
         {
             _logger.LogDebug("Reached wasm exit");
-            WasmExitReceivedTcs.SetResult();
+            if (!WasmExitReceivedTcs.TrySetResult())
+                _logger.LogDebug("Got a duplicate exit message.");
         }
     }
 


### PR DESCRIPTION
- Add `--no-sandbox` to chrome arguments when running in codespaces, or a container
- Don't fail if more than one `WASM EXIT` is received