### PR TITLE
[wasm] Don't throw if messages are received after the message processor

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -83,11 +83,20 @@ public class WasmTestMessagesProcessor
 
     public void Invoke(string message, bool isError = false)
     {
-        if (!_isRunning)
-            throw new InvalidOperationException("Message processor is not running. Make sure to call RunAsync first");
+        string? logMsg = null;
 
-        if (!_channelWriter.TryWrite((message, isError)))
-            _logger.LogInformation($"Could not process message: {message}");
+        if (!_isRunning)
+            logMsg = $"{message} (this message could not be processed because the message processor isn't running)";
+        else if (!_channelWriter.TryWrite((message, isError)))
+            logMsg = $"{message} (Could not process message)";
+
+        if (logMsg is not null)
+        {
+            if (isError)
+                _logger.LogError(logMsg);
+            else
+                _logger.LogInformation(logMsg);
+        }
     }
 
     public Task InvokeAsync(string message, bool isError = false)


### PR DESCRIPTION
.. has stopped running, so we don't miss any messages.

In some cases a wasm test app can emit `WASM EXIT` message more than once. First one triggers shutting down the whole thing, and any messages received after that can end up throwing because the message processor is no longer running.

Example failure:
```
[11:19:06] fail: 218355552
[11:19:06] info: WASM EXIT 1
[11:19:06] info: Waiting to flush log messages with a timeout of 120 secs ..
[11:19:06] info: WASM EXIT 1
fail: Microsoft.AspNetCore.Server.Kestrel[13]
      Connection id "0HMKQV6N2NQ5F", Request id "0HMKQV6N2NQ5F:00000001": An unhandled exception was thrown by the application.
      System.InvalidOperationException: Message processor is not running. Make sure to call RunAsync first
         at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestMessagesProcessor.InvokeAsync(String message, Boolean isError) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs:line 94
         at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmBrowserTestRunner.RunConsoleMessagesPump(WebSocket socket, CancellationToken token) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs:line 196
         at Microsoft.DotNet.XHarness.CLI.Commands.WebServer.TestWebServerStartup.<>c__DisplayClass3_0.<<Configure>b__2>d.MoveNext() in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs:line 163
      --- End of stack trace from previous location ---
         at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
[11:19:06] fail: Application has finished with exit code TESTS_FAILED but 0 was expected
```