### PR TITLE
[wasm] Improve error handling in message processor

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-rc.1.22431.12"
+    "dotnet": "7.0.100-preview.7.22377.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22473.1",

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -178,7 +178,7 @@ internal class WasmBrowserTestRunner
                     var line = Encoding.UTF8.GetString(mem.GetBuffer(), 0, (int)mem.Length);
                     line += Environment.NewLine;
 
-                    await _messagesProcessor.InvokeAsync(line);
+                    await _messagesProcessor.InvokeAsync(line, token);
                     mem.SetLength(0);
                     mem.Seek(0, SeekOrigin.Begin);
                 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -30,8 +30,8 @@ public class WasmTestMessagesProcessor
     private readonly ChannelReader<(string, bool)> _channelReader;
     private readonly ChannelWriter<(string, bool)> _channelWriter;
     private readonly TaskCompletionSource _completed = new ();
-    private bool IsRunning => !_completed.Task.IsCompleted;
-    private bool loggedProcessorStopped = false;
+    private bool _isRunning => !_completed.Task.IsCompleted;
+    private bool _loggedProcessorStopped = false;
 
     public string? LineThatMatchedErrorPattern { get; private set; }
 
@@ -85,7 +85,7 @@ public class WasmTestMessagesProcessor
     {
         WarnOnceIfStopped();
 
-        if (IsRunning && _channelWriter.TryWrite((message, isError)))
+        if (_isRunning && _channelWriter.TryWrite((message, isError)))
             return;
 
         LogMessage(message.TrimEnd(), isError);
@@ -97,7 +97,7 @@ public class WasmTestMessagesProcessor
         try
         {
             WarnOnceIfStopped();
-            if (IsRunning)
+            if (_isRunning)
                 return _channelWriter.WriteAsync((message, isError), token).AsTask();
 
             logMsg = message.TrimEnd();
@@ -113,10 +113,10 @@ public class WasmTestMessagesProcessor
 
     private void WarnOnceIfStopped()
     {
-        if (!IsRunning && !loggedProcessorStopped)
+        if (!_isRunning && !_loggedProcessorStopped)
         {
             _logger.LogWarning($"Message processor is not running anymore.");
-            loggedProcessorStopped = true;
+            _loggedProcessorStopped = true;
         }
     }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.Logging;
 
 #nullable enable
+
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm;
 
 public class WasmTestMessagesProcessor
@@ -28,8 +29,9 @@ public class WasmTestMessagesProcessor
     private readonly WasmSymbolicatorBase? _symbolicator;
     private readonly ChannelReader<(string, bool)> _channelReader;
     private readonly ChannelWriter<(string, bool)> _channelWriter;
-    private bool _isRunning;
     private readonly TaskCompletionSource _completed = new ();
+    private bool IsRunning => !_completed.Task.IsCompleted;
+    private bool loggedProcessorStopped = false;
 
     public string? LineThatMatchedErrorPattern { get; private set; }
 
@@ -62,12 +64,10 @@ public class WasmTestMessagesProcessor
     {
         try
         {
-            _isRunning = true;
             await foreach ((string line, bool isError) in _channelReader.ReadAllAsync(token))
             {
                 ProcessMessage(line, isError);
             }
-            _isRunning = false;
             _completed.SetResult();
         }
         catch (Exception ex)
@@ -83,26 +83,50 @@ public class WasmTestMessagesProcessor
 
     public void Invoke(string message, bool isError = false)
     {
-        string? logMsg = null;
+        WarnOnceIfStopped();
 
-        if (!_isRunning)
-            logMsg = $"{message} (this message could not be processed because the message processor isn't running)";
-        else if (!_channelWriter.TryWrite((message, isError)))
-            logMsg = $"{message} (Could not process message)";
+        if (IsRunning && _channelWriter.TryWrite((message, isError)))
+            return;
 
-        if (logMsg is not null)
+        LogMessage(message.TrimEnd(), isError);
+    }
+
+    public Task InvokeAsync(string message, CancellationToken token, bool isError = false)
+    {
+        string? logMsg;
+        try
         {
-            if (isError)
-                _logger.LogError(logMsg);
-            else
-                _logger.LogInformation(logMsg);
+            WarnOnceIfStopped();
+            if (IsRunning)
+                return _channelWriter.WriteAsync((message, isError), token).AsTask();
+
+            logMsg = message.TrimEnd();
+        }
+        catch (ChannelClosedException cce)
+        {
+            logMsg = $"Failed to write to the channel - {cce.Message}. Message: {message}";
+        }
+
+        LogMessage(logMsg, isError);
+        return Task.CompletedTask;
+    }
+
+    private void WarnOnceIfStopped()
+    {
+        if (!IsRunning && !loggedProcessorStopped)
+        {
+            _logger.LogWarning($"Message processor is not running anymore.");
+            loggedProcessorStopped = true;
         }
     }
 
-    public Task InvokeAsync(string message, bool isError = false)
-        => _isRunning
-                ? _channelWriter.WriteAsync((message, false)).AsTask()
-                : throw new InvalidOperationException("Message processor is not running. Make sure to call RunAsync first");
+    private void LogMessage(string message, bool isError)
+    {
+        if (isError)
+            _logger.LogError(message);
+        else
+            _logger.LogInformation(message);
+    }
 
     public async Task<ExitCode> CompleteAndFlushAsync(TimeSpan? timeout = null)
     {


### PR DESCRIPTION
- if messages are received when the message processor isn't running, then log a warning once, instead of appending a `"message processor is not running"` to every message.