### PR TITLE
Don't 'NotExecuted' trx tests as failures.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TrxTestReportGenerator.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/XmlResults/TrxTestReportGenerator.cs
@@ -20,7 +20,7 @@ public class TrxTestReportGenerator : TestReportGenerator
     public override void GenerateTestReport(TextWriter writer, XmlReader reader)
     {
         var tests = TrxResultParser.ParseTrxXml(reader);
-        var failedTests = tests.Where(v => v.Outcome != "Passed");
+        var failedTests = tests.Where(v => v.Outcome != "Passed" && v.Outcome != "NotExecuted");
 
         if (failedTests.Any())
         {


### PR DESCRIPTION
It's confusing to get a long list of failed-looking tests just to realize they
were all ignored (and then having to go through the list looking for the test
that actually failed).