### PR TITLE
[wasm] Add new `--js-engine-path` argument

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineLocationArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/JavaScriptEngineLocationArgument.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
+
+internal class JavaScriptEngineLocationArgument : StringArgument
+{
+    public JavaScriptEngineLocationArgument() : base("js-engine-path=", "Path to the JS engine to be used. This must correspond to the engine specified with -e")
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
 internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerArguments
 {
     public JavaScriptEngineArgument Engine { get; } = new();
+    public JavaScriptEngineLocationArgument EnginePath { get; } = new();
     public JavaScriptEngineArguments EngineArgs { get; } = new();
     public JavaScriptFileArgument JSFile { get; } = new("runtime.js");
     public ErrorPatternsFileArgument ErrorPatternsFile { get; } = new();
@@ -30,6 +31,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
             Engine,
+            EnginePath,
             EngineArgs,
             JSFile,
             ErrorPatternsFile,


### PR DESCRIPTION
.. which can be used to specify path to js engines, like V8.