### PR TITLE
Disable chatty on Android runs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -130,7 +130,7 @@ public class AdbRunner
     {
         RunAdbCommand("logcat", "-b", "all", "-c");
 
-        // Android logs can unnecessarily hide log entires, so disable
+        // Android logs can unnecessarily hide log entries, so disable
         DisableChatty();
     }
 
@@ -1075,7 +1075,7 @@ public class AdbRunner
 
         if (!result.Succeeded)
         {
-            _log.LogWarning($"Unable to disable chatty. Logcat may hide what it finds to be repeating entires.");
+            _log.LogWarning($"Unable to disable chatty. Logcat may hide what it finds to be repeating entries.");
         }
     }
 

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -126,7 +126,13 @@ public class AdbRunner
         return result.StandardOutput;
     }
 
-    public void ClearAdbLog() => RunAdbCommand("logcat", "-b", "all", "-c");
+    public void ClearAdbLog()
+    {
+        RunAdbCommand("logcat", "-b", "all", "-c");
+
+        // Android logs can unnecessarily hide log entires, so disable
+        DisableChatty();
+    }
 
     public void EnableWifi(bool enable) => RunAdbCommand("shell", "svc", "wifi", enable ? "enable" : "disable")
         .ThrowIfFailed($"Failed to {(enable ? "enable" : "disable")} WiFi on the device");
@@ -251,9 +257,6 @@ public class AdbRunner
         {
             throw new AdbFailureException("Failed to start the ADB server");
         }
-
-        // Android logs can unnecessarily hide log entires, so disable
-        DisableChatty();
     }
 
     public void KillAdbServer() => RunAdbCommand(new[] { "kill-server" }).ThrowIfFailed("Error killing ADB Server");
@@ -1068,7 +1071,7 @@ public class AdbRunner
 
     private void DisableChatty()
     {
-        var result = RunAdbCommand(new[] { "shell", "logcat", "-P", "'\"\"'" }, TimeSpan.FromMinutes(1));
+        var result = RunAdbCommand(new[] { "logcat", "-P", "'\"\"'" }, TimeSpan.FromMinutes(1));
 
         if (!result.Succeeded)
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -39,6 +39,8 @@ Arguments:
     {
         var runner = new AdbRunner(logger);
 
+        runner.ClearAdbLog();
+
         var exitCode = AndroidInstallCommand.InvokeHelper(
             logger: logger,
             apkPackageName: Arguments.PackageName,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -39,8 +39,6 @@ Arguments:
     {
         var runner = new AdbRunner(logger);
 
-        runner.ClearAdbLog();
-
         var exitCode = AndroidInstallCommand.InvokeHelper(
             logger: logger,
             apkPackageName: Arguments.PackageName,
@@ -61,6 +59,8 @@ Arguments:
         {
             if (exitCode == ExitCode.SUCCESS)
             {
+                runner.ClearAdbLog();
+
                 var instrumentationRunner = new InstrumentationRunner(logger, runner);
                 exitCode = instrumentationRunner.RunApkInstrumentation(
                     Arguments.PackageName,

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -69,7 +69,7 @@ public class AdbRunnerTests : IDisposable
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
         runner.ClearAdbLog();
-        VerifyAdbCall("logcat", "-c");
+        VerifyAdbCall("logcat", "-b", "all", "-c");
     }
     [Fact]
     public void DumpAdbLog()


### PR DESCRIPTION
Chatty is a service which tries to limit repeating entries in logcat output. This impacts us negatively more often than not as it will hide important entries that show what went wrong in a test.  This tries to disable chatty for all processes on the device.

Fixes https://github.com/dotnet/xharness/issues/937