### PR TITLE
Serve .webcil as application/octet-stream

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -120,7 +120,7 @@ public class WebServer
             provider.Mappings[".cjs"] = "text/javascript";
             provider.Mappings[".mjs"] = "text/javascript";
 
-            foreach (var extn in new string[] { ".dll", ".pdb", ".dat", ".blat" })
+            foreach (var extn in new string[] { ".dll", ".pdb", ".dat", ".blat", ".webcil" })
             {
                 provider.Mappings[extn] = "application/octet-stream";
             }


### PR DESCRIPTION
WebCIL is a new container format for .NET assemblies used when publishing WebAssembly apps (see https://github.com/dotnet/runtime/pull/79416)

Related to https://github.com/dotnet/runtime/issues/80807