### PR TITLE
Run tests with requested locale.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
@@ -5,9 +5,9 @@
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
 using System;
 
-internal class LocaleArgument : StringArgument
+internal class LocaleArgument : RequiredStringArgument
 {
     public LocaleArgument(string defaultValue)
-        : base("locale=", $"Sets LANG environment variable, default value {defaultValue}")
+        : base("locale=", $"Sets LANG environment variable, default value {defaultValue}", defaultValue)
     {}
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
@@ -8,6 +8,6 @@ using System;
 internal class LocaleArgument : RequiredStringArgument
 {
     public LocaleArgument(string defaultValue)
-        : base("locale=", $"Sets LANG environment variable, default value {defaultValue}", defaultValue)
+        : base("locale=", $"Sets the browser's/node's language through an environment variable, default value {defaultValue}", defaultValue)
     {}
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/LocaleArgument.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
+using System;
+
+internal class LocaleArgument : StringArgument
+{
+    public LocaleArgument(string defaultValue)
+        : base("locale=", $"Sets LANG environment variable, default value {defaultValue}")
+    {}
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -25,6 +25,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
     public NoHeadlessArgument NoHeadless { get; } = new();
     public NoQuitArgument NoQuit { get; } = new();
     public BackgroundThrottlingArgument BackgroundThrottling { get; } = new();
+    public LocaleArgument Locale { get; } = new("en-US");
 
     public SymbolMapFileArgument SymbolMapFileArgument { get; } = new();
     public SymbolicatePatternsFileArgument SymbolicatePatternsFileArgument { get; } = new();

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -17,6 +17,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
     public OutputDirectoryArgument OutputDirectory { get; } = new();
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
+    public LocaleArgument Locale { get; } = new("en-US");
 
     public SymbolMapFileArgument SymbolMapFileArgument { get; } = new();
     public SymbolicatePatternsFileArgument SymbolicatePatternsFileArgument { get; } = new();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -61,6 +61,8 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                             logProcessor,
                             logger);
 
+        // Browser respects LANGUAGE in the first place, only if empty it checks LANG
+        Environment.SetEnvironmentVariable("LANGUAGE", Arguments.Locale);
         (DriverService driverService, IWebDriver driver) = Arguments.Browser.Value switch
         {
             Browser.Chrome => GetChromeDriver(logger),
@@ -71,8 +73,6 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             // shouldn't reach here
             _ => throw new ArgumentException($"Unknown browser : {Arguments.Browser}")
         };
-        // Browser respects LANGUAGE in the first place, only if empty it checks LANG
-        Environment.SetEnvironmentVariable("BROWSER_LANGUAGE", Arguments.Locale);
 
         try
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -71,6 +71,8 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             // shouldn't reach here
             _ => throw new ArgumentException($"Unknown browser : {Arguments.Browser}")
         };
+        // Browser respects LANGUAGE in the first place, only if empty it checks LANG
+        Environment.SetEnvironmentVariable("LANGUAGE", Arguments.Locale);
 
         try
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -61,14 +61,12 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                             logProcessor,
                             logger);
 
-        // Browser respects LANGUAGE in the first place, only if empty it checks LANG
-        Environment.SetEnvironmentVariable("LANGUAGE", Arguments.Locale);
         (DriverService driverService, IWebDriver driver) = Arguments.Browser.Value switch
         {
-            Browser.Chrome => GetChromeDriver(logger),
+            Browser.Chrome => GetChromeDriver(Arguments.Locale, logger),
             Browser.Safari => GetSafariDriver(logger),
             Browser.Firefox => GetFirefoxDriver(logger),
-            Browser.Edge => GetEdgeDriver(logger),
+            Browser.Edge => GetEdgeDriver(Arguments.Locale, logger),
 
             // shouldn't reach here
             _ => throw new ArgumentException($"Unknown browser : {Arguments.Browser}")
@@ -144,14 +142,16 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                     (driverService) => new FirefoxDriver(driverService, options, Arguments.Timeout));
     }
 
-    private (DriverService, IWebDriver) GetChromeDriver(ILogger logger)
+    private (DriverService, IWebDriver) GetChromeDriver(string sessionLanguage, ILogger logger)
         => GetChromiumDriver<ChromeOptions, ChromeDriver, ChromeDriverService>(
+                    sessionLanguage,
                     "chromedriver",
                     options => ChromeDriverService.CreateDefaultService(),
                     logger);
 
-    private (DriverService, IWebDriver) GetEdgeDriver(ILogger logger)
+    private (DriverService, IWebDriver) GetEdgeDriver(string sessionLanguage, ILogger logger)
         => GetChromiumDriver<EdgeOptions, EdgeDriver, EdgeDriverService>(
+                    sessionLanguage,
                     "edgedriver",
                     options =>
                     {
@@ -160,7 +160,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                     }, logger);
 
     private (DriverService, IWebDriver) GetChromiumDriver<TDriverOptions, TDriver, TDriverService>(
-        string driverName, Func<TDriverOptions, TDriverService> getDriverService, ILogger logger)
+        string driverName, string sessionLanguage, Func<TDriverOptions, TDriverService> getDriverService, ILogger logger)
         where TDriver : ChromiumDriver
         where TDriverOptions : ChromiumOptions
         where TDriverService : ChromiumDriverService
@@ -253,6 +253,11 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             try
             {
                 driverService = getDriverService(options);
+                driverService.DriverProcessStarting += (object? sender, DriverProcessStartingEventArgs e) =>
+                {
+                    // Browser respects LANGUAGE in the first place, only if empty it checks LANG
+                    e.DriverServiceProcessStartInfo.EnvironmentVariables["LANGUAGE"] = sessionLanguage;
+                };
 
                 driverService.EnableAppendLog = false;
                 driverService.EnableVerboseLogging = true;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -72,7 +72,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             _ => throw new ArgumentException($"Unknown browser : {Arguments.Browser}")
         };
         // Browser respects LANGUAGE in the first place, only if empty it checks LANG
-        Environment.SetEnvironmentVariable("LANGUAGE", Arguments.Locale);
+        Environment.SetEnvironmentVariable("BROWSER_LANGUAGE", Arguments.Locale);
 
         try
         {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -113,8 +113,6 @@ internal class WasmTestCommand : XHarnessCommand<WasmTestCommandArguments>
             }
 
             engineArgs.AddRange(PassThroughArguments);
-            // Node respects LANG only, ignores LANGUAGE
-            Environment.SetEnvironmentVariable("LANG", Arguments.Locale);
 
             var xmlResultsFilePath = Path.Combine(Arguments.OutputDirectory, "testResults.xml");
             File.Delete(xmlResultsFilePath);
@@ -137,6 +135,8 @@ internal class WasmTestCommand : XHarnessCommand<WasmTestCommandArguments>
             var processTask = processManager.ExecuteCommandAsync(
                 engineBinary,
                 engineArgs,
+                // Node respects LANG only, ignores LANGUAGE
+                environmentVariables: new Dictionary<string,string>() { "LANG", Arguments.Locale }
                 log: new CallbackLog(m => logger.LogInformation(m)),
                 stdoutLog: new CallbackLog(msg => logProcessor.Invoke(msg)),
                 stderrLog: new CallbackLog(logProcessor.ProcessErrorMessage),

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -113,6 +113,8 @@ internal class WasmTestCommand : XHarnessCommand<WasmTestCommandArguments>
             }
 
             engineArgs.AddRange(PassThroughArguments);
+            // Node respects LANG only, ignores LANGUAGE
+            Environment.SetEnvironmentVariable("LANG", Arguments.Locale);
 
             var xmlResultsFilePath = Path.Combine(Arguments.OutputDirectory, "testResults.xml");
             File.Delete(xmlResultsFilePath);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -140,7 +140,9 @@ internal class WasmTestCommand : XHarnessCommand<WasmTestCommandArguments>
                 stderrLog: new CallbackLog(logProcessor.ProcessErrorMessage),
                 Arguments.Timeout,
                 // Node respects LANG only, ignores LANGUAGE
-                environmentVariables: new Dictionary<string,string>() { {"LANG", Arguments.Locale} });
+                environmentVariables: Arguments.Engine.Value == JavaScriptEngine.NodeJS ?
+                                    new Dictionary<string, string>() { {"LANG", Arguments.Locale} } :
+                                    null);
 
             var tasks = new Task[]
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/JS/WasmTestCommand.cs
@@ -135,12 +135,12 @@ internal class WasmTestCommand : XHarnessCommand<WasmTestCommandArguments>
             var processTask = processManager.ExecuteCommandAsync(
                 engineBinary,
                 engineArgs,
-                // Node respects LANG only, ignores LANGUAGE
-                environmentVariables: new Dictionary<string,string>() { "LANG", Arguments.Locale }
                 log: new CallbackLog(m => logger.LogInformation(m)),
                 stdoutLog: new CallbackLog(msg => logProcessor.Invoke(msg)),
                 stderrLog: new CallbackLog(logProcessor.ProcessErrorMessage),
-                Arguments.Timeout);
+                Arguments.Timeout,
+                // Node respects LANG only, ignores LANGUAGE
+                environmentVariables: new Dictionary<string,string>() { {"LANG", Arguments.Locale} });
 
             var tasks = new Task[]
             {

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Options;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands;
 
@@ -66,10 +65,6 @@ public class WebServer
                     }
                 });
             })
-            .UseConfiguration(
-                new ConfigurationBuilder()
-                .AddEnvironmentVariables(prefix: "BROWSER_")
-                .Build())
             .UseUrls(urls);
 
         if (contentRoot != null)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Options;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands;
 
@@ -65,6 +66,10 @@ public class WebServer
                     }
                 });
             })
+            .UseConfiguration(
+                new ConfigurationBuilder()
+                .AddEnvironmentVariables(prefix: "BROWSER_")
+                .Build())
             .UseUrls(urls);
 
         if (contentRoot != null)


### PR DESCRIPTION
For https://github.com/dotnet/runtime/pull/80421/ we need tests to run with specific locale set, otherwise we won't be able to test the mechanism of loading different internationalization data based on the client's locale.
I added `-locale=xx-YY` flag that will set environment variable before the test on Browser / Node is launched. Default is "en-US".
