### PR TITLE
Fixing `Run tests with requested locale.`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -53,6 +53,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
             NoHeadless,
             NoQuit,
             BackgroundThrottling,
+            Locale,
             SymbolMapFileArgument,
             SymbolicatePatternsFileArgument,
             SymbolicatorArgument,


### PR DESCRIPTION
Follow-up for #992.
I missed this change, without it `Locale` will be always passed to `WasmTest*Command` in the default form.
