### PR TITLE
Fixing `Run tests with requested locale`.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -39,6 +39,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
             OutputDirectory,
             Timeout,
             ExpectedExitCode,
+            Locale,
             SymbolMapFileArgument,
             SymbolicatePatternsFileArgument,
             SymbolicatorArgument,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -144,15 +144,15 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
 
     private (DriverService, IWebDriver) GetChromeDriver(string sessionLanguage, ILogger logger)
         => GetChromiumDriver<ChromeOptions, ChromeDriver, ChromeDriverService>(
-                    sessionLanguage,
                     "chromedriver",
+                    sessionLanguage,
                     options => ChromeDriverService.CreateDefaultService(),
                     logger);
 
     private (DriverService, IWebDriver) GetEdgeDriver(string sessionLanguage, ILogger logger)
         => GetChromiumDriver<EdgeOptions, EdgeDriver, EdgeDriverService>(
-                    sessionLanguage,
                     "edgedriver",
+                    sessionLanguage,
                     options =>
                     {
                         options.UseChromium = true;


### PR DESCRIPTION
Follow up for https://github.com/dotnet/xharness/pull/992.