### PR TITLE
Categorize crash as TCP problem when connection never happens

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -22,6 +22,8 @@ namespace Microsoft.DotNet.XHarness.Apple;
 
 public interface IAppTester
 {
+    bool ListenerConnected { get; }
+
     Task<(TestExecutingResult Result, string ResultMessage)> TestApp(
         AppBundleInformation appInformation,
         TestTargetOs target,
@@ -66,6 +68,12 @@ public class AppTester : AppRunnerBase, IAppTester
     private readonly ILogs _logs;
     private readonly IHelpers _helpers;
 
+    /// <summary>
+    /// Denotes whether we had a successful connection over TCP during the run.
+    /// This is used later to determine if a cause for a failed run is a failing TCP connection.
+    /// </summary>
+    public bool ListenerConnected { get; private set; }
+
     public AppTester(
         IMlaunchProcessManager processManager,
         ISimpleListenerFactory simpleListenerFactory,
@@ -106,6 +114,7 @@ public class AppTester : AppRunnerBase, IAppTester
         var testLog = _logs.Create($"test-{TestTarget.MacCatalyst.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
         var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
+        ListenerConnected = false;
         var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
             RunMode.MacOS,
             log: _mainLog,
@@ -163,6 +172,7 @@ public class AppTester : AppRunnerBase, IAppTester
 
         var testLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
 
+        ListenerConnected = false;
         var (deviceListenerTransport, deviceListener, deviceListenerTmpFile) = _listenerFactory.Create(
             runMode,
             log: _mainLog,
@@ -207,6 +217,10 @@ public class AppTester : AppRunnerBase, IAppTester
                     if (!deviceListener.ConnectedTask.IsCompleted)
                     {
                         await deviceListener.StopAsync();
+                    }
+                    else if (task.IsCompleted && task.Result)
+                    {
+                        ListenerConnected = true;
                     }
                 }, cancellationToken)
                 .DoNotAwait();
@@ -430,6 +444,10 @@ public class AppTester : AppRunnerBase, IAppTester
                 if (!deviceListener.ConnectedTask.IsCompleted)
                 {
                     await deviceListener.StopAsync();
+                }
+                else if (task.IsCompleted && task.Result)
+                {
+                    ListenerConnected = true;
                 }
             }, cancellationToken)
             .DoNotAwait();

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -250,7 +250,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             skippedTestClasses: classMethodFilters?.ToArray(),
             cancellationToken: cancellationToken);
 
-        return ParseResult(testResult, resultMessage);
+        return ParseResult(testResult, resultMessage, appTester.ListenerConnected);
     }
 
     private async Task<ExitCode> ExecuteMacCatalystApp(
@@ -280,7 +280,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             skippedTestClasses: classMethodFilters?.ToArray(),
             cancellationToken: cancellationToken);
 
-        return ParseResult(testResult, resultMessage);
+        return ParseResult(testResult, resultMessage, appTester.ListenerConnected);
     }
 
     private IAppTester GetAppTester(CommunicationChannel communicationChannel, bool isSimulator)
@@ -291,7 +291,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         return _appTesterFactory.Create(communicationChannel, isSimulator, _mainLog, _logs, logCallback);
     }
 
-    private ExitCode ParseResult(TestExecutingResult testResult, string resultMessage)
+    private ExitCode ParseResult(TestExecutingResult testResult, string resultMessage, bool listenerConnected)
     {
         string newLine = Environment.NewLine;
         const string checkLogsMessage = "Check logs for more information";
@@ -303,11 +303,10 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             {
                 if (_errorKnowledgeBase.IsKnownTestIssue(log, out var issue))
                 {
-                    if (issue.SuggestedExitCode.HasValue && (ExitCode)issue.SuggestedExitCode.Value == ExitCode.TCP_CONNECTION_FAILED)
+                    if (!listenerConnected && issue.SuggestedExitCode.HasValue && (ExitCode)issue.SuggestedExitCode.Value == ExitCode.TCP_CONNECTION_FAILED)
                     {
                         tcpErrorFound = true;
                     }
-
                     else
                     {
                         _logger.LogError(message + newLine + issue.HumanMessage);
@@ -325,8 +324,8 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 _logger.LogError(message + newLine + checkLogsMessage);
             }
 
-            //TCP errors are encounter all the time but they are not always the cause of the failure
-            //If the app crashed, TCP_CONNECTION_FAILED and there was not other exit code we will return TCP_CONNECTION_FAILED
+            // TCP errors are encounter all the time but they are not always the cause of the failure
+            // If the app crashed, TCP_CONNECTION_FAILED and there was not other exit code we will return TCP_CONNECTION_FAILED
             if (defaultExitCode == ExitCode.APP_CRASH && tcpErrorFound)
             {
                 return ExitCode.TCP_CONNECTION_FAILED;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -76,7 +76,7 @@ public class TestReporter : ITestReporter
 
     public bool ResultsUseXml => _xmlJargon != XmlResultJargon.Missing;
 
-    private bool TestExecutionStarted => _listener.ConnectedTask.Status == TaskStatus.RanToCompletion && _listener.ConnectedTask.Result;
+    private bool TestExecutionStarted => _listener.ConnectedTask.IsCompleted && _listener.ConnectedTask.Result;
 
     public TestReporter(
         IMlaunchProcessManager processManager,


### PR DESCRIPTION
The TCP message, that we use to tell if TCP connection is to blame, can be faulty but once it connects, it's actually usually OK and the crash is an actual crash. This means we only have to categorize the result if the app never connects. It can still happen the app crashes and never connects and then we are not able to tell anyway.

The underlying issue with the TCP connection is still a problem somewhere in mlaunch and the real fix would have to come there but this PR improves categorization after https://github.com/dotnet/xharness/pull/987 was introduced.

https://github.com/dotnet/arcade/issues/11683