### PR TITLE
Stop using 10.15 queues in repo's E2E tests

### DIFF
--- a/tests/integration-tests/Apple/Device.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Device.Commands.Tests.proj
@@ -2,7 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1015.amd64.iphone.open"/>
+    <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/integration-tests/Apple/Device.iOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.iOS.Tests.proj
@@ -2,7 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1015.amd64.iphone.open"/>
+    <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
     <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
 
     <!-- apple test / ios-device -->

--- a/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.tvOS.Tests.proj
@@ -2,7 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1015.amd64.appletv.open"/>
+    <HelixTargetQueue Include="osx.1100.amd64.appletv.open"/>
     <HelixTargetQueue Include="osx.1100.amd64.appletv.open"/>
 
     <!-- apple test / tvos-device -->


### PR DESCRIPTION
The 10.15 queue is getting deprecated soon and devices were already moved out of the queue.