### PR TITLE
Fix AppleTV helix target queue names

### DIFF
--- a/tests/integration-tests/Apple/Device.iOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.iOS.Tests.proj
@@ -3,7 +3,6 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
-    <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
 
     <!-- apple test / ios-device -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">

--- a/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.tvOS.Tests.proj
@@ -2,8 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1100.amd64.appletv.open"/>
-    <HelixTargetQueue Include="osx.1100.amd64.appletv.open"/>
+    <HelixTargetQueue Include="osx.13.amd64.appletv.open"/>
 
     <!-- apple test / tvos-device -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">


### PR DESCRIPTION
We're using a new queue now.
Also remove a duplicated queue.