### PR TITLE
[release/6.0] Fix servicing pool name for internal builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ stages:
       - job: Windows_NT
         pool:
           ${{ if eq(variables._RunAsInternal, True) }}:
-            name: $(DncEngInternalBuildPool)
+            name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals windows.vs2019.amd64
           ${{ if eq(variables._RunAsPublic, True) }}:
             vmImage: windows-2019


### PR DESCRIPTION
Failed here https://dev.azure.com/dnceng/internal/_build/results?buildId=2172601&view=logs&j=eacd36fa-ad88-57eb-d560-13c9c5f594cc

#1010