### PR TITLE
[iOS] Move tests to the OSX 13 queue

### DIFF
--- a/tests/integration-tests/Apple/Device.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Device.Commands.Tests.proj
@@ -2,7 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
+    <HelixTargetQueue Include="osx.13.amd64.iphone.open"/>
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/integration-tests/Apple/Device.iOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.iOS.Tests.proj
@@ -2,7 +2,7 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.iphone.open"/>
+    <HelixTargetQueue Include="osx.13.amd64.iphone.open"/>
 
     <!-- apple test / ios-device -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">


### PR DESCRIPTION
Since https://github.com/dotnet/arcade/issues/13622 was completed, we can move to the new queue.