### PR TITLE
Support the new URLs for simulators

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -180,7 +180,7 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
 
         foreach (string argument in ExtraArguments)
         {
-            if (argument.StartsWith("com.apple.pkg."))
+            if (argument.StartsWith("com.apple.pkg.") || argument.StartsWith("com.apple.dmg."))
             {
                 simulators.Add(argument);
                 continue;


### PR DESCRIPTION
Apple appears to have changed the URL format in newer simulator IDs. This PR makes a small change to allow for these newer ID formats.

Fixes #1043