### PR TITLE
[iOS] TCCDatabase - even if we cannot create the trigger call the privacy tool

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/TCCDatabase.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/TCCDatabase.cs
@@ -128,7 +128,7 @@ public class TCCDatabase : ITCCDatabase
 
                 if (!rv.Succeeded)
                 {
-                    // print a warning, but do not set it to failure and how that the simctl privacy command will work
+                    // print a warning, but do not set it to failure and hope that the simctl privacy command will work
                     log.WriteLine("Failed to create trigger on TCC.db, some tests might timeout.");
                 }
             }


### PR DESCRIPTION
Some bots give errors when we try to edit the db, if we fail creating the trigger, continue and hope that the privacy tool does work.