### PR TITLE
Set explicit service tree id in tsaoptions

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -6,5 +6,6 @@
     "iterationPath": "DevDiv",
     "notificationAliases": [ "dnceng@microsoft.com" ],
     "repositoryName":"dotnet-xharness",
-    "codebaseName": "dotnet-xharness"
+    "codebaseName": "dotnet-xharness",
+    "serviceTreeId": "4cac191f-8b27-4d55-abee-2eafb6470803"
 }


### PR DESCRIPTION
TSA violations are being assigned to the wrong service tree entry since TSA by default uses the area path to determine ownership, and the configured area path is a child of the .NET Framework service. We'd prefer not to change the area path, so let's try changing just the service tree id and see if that overrides TSA's default lookup logic.

The GUID `{4cac191f-8b27-4d55-abee-2eafb6470803}` corresponds specifically to the .NET Core service.