### PR TITLE
[wasm] Print message arguments in forwarded console

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmLogMessage.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmLogMessage.cs
@@ -4,4 +4,5 @@ class WasmLogMessage
 {
     public string? method { get; set; }
     public string? payload { get; set; }
+    public object[]? arguments { get; set; }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -161,17 +162,26 @@ public class WasmTestMessagesProcessor
             try
             {
                 logMessage = JsonSerializer.Deserialize<WasmLogMessage>(message);
-                line = logMessage?.payload ?? message.TrimEnd();
+                if (logMessage != null)
+                {
+                    line = logMessage.payload + " " + string.Join(" ", logMessage.arguments ?? Enumerable.Empty<object>());
+                }
+                else
+                {
+                    line = message;
+                }
             }
             catch (JsonException)
             {
-                line = message.TrimEnd();
+                line = message;
             }
         }
         else
         {
-            line = message.TrimEnd();
+            line = message;
         }
+
+        line = line.TrimEnd();
 
         var match = xmlRx.Match(line);
         if (match.Success)


### PR DESCRIPTION
Duplicate of https://github.com/dotnet/runtime/pull/91315

---

- Print arguments for forwarded console messages from browser to apphost console
- It matches the behavior with log to actual browser console

Previous
```
dbug: MONO_WASM [0x5f4244-main]: afterLoadWasmModuleToWorker added message event handler
```
New
```
dbug: MONO_WASM [0x5f4244-main]: afterLoadWasmModuleToWorker added message event handler {"workerID":1}
```