### PR TITLE
Add a new enable relay argument

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -32,6 +32,7 @@ public interface IAppTester
         TimeSpan timeout,
         TimeSpan testLaunchTimeout,
         bool signalAppEnd,
+        bool enableRelay,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
@@ -44,6 +45,7 @@ public interface IAppTester
         TimeSpan timeout,
         TimeSpan testLaunchTimeout,
         bool signalAppEnd,
+        bool enableRelay,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
@@ -104,6 +106,7 @@ public class AppTester : AppRunnerBase, IAppTester
         TimeSpan timeout,
         TimeSpan testLaunchTimeout,
         bool signalAppEnd,
+        bool enableRelay,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
@@ -121,7 +124,8 @@ public class AppTester : AppRunnerBase, IAppTester
             testLog: testLog,
             isSimulator: true,
             autoExit: true,
-            xmlOutput: true);
+            xmlOutput: true,
+            enableRelay);
 
         string? appEndTag = null;
         if (signalAppEnd)
@@ -160,6 +164,7 @@ public class AppTester : AppRunnerBase, IAppTester
         TimeSpan timeout,
         TimeSpan testLaunchTimeout,
         bool signalAppEnd,
+        bool enableRelay,
         IEnumerable<string> extraAppArguments,
         IEnumerable<(string, string)> extraEnvVariables,
         XmlResultJargon xmlResultJargon = XmlResultJargon.xUnit,
@@ -179,7 +184,8 @@ public class AppTester : AppRunnerBase, IAppTester
             testLog: testLog,
             isSimulator: isSimulator,
             autoExit: true,
-            xmlOutput: true); // cli always uses xml
+            xmlOutput: true,
+            enableRelay); // cli always uses xml
 
         using (testLog)
         using (deviceListener)

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -31,6 +31,7 @@ public interface IJustTestOrchestrator
         bool includeWirelessDevices,
         bool enableLldb,
         bool signalAppEnd,
+        bool enableRelay,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken);
@@ -75,6 +76,7 @@ public class JustTestOrchestrator : TestOrchestrator, IJustTestOrchestrator
         bool includeWirelessDevices,
         bool enableLldb,
         bool signalAppEnd,
+        bool enableRelay,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -92,6 +94,7 @@ public class JustTestOrchestrator : TestOrchestrator, IJustTestOrchestrator
             resetSimulator: false, // No simulator reset for just- commands
             enableLldb,
             signalAppEnd,
+            enableRelay,
             environmentalVariables,
             passthroughArguments,
             cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -34,6 +34,7 @@ public interface ITestOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool enableRelay,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken);
@@ -85,6 +86,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool enableRelay,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -102,6 +104,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             resetSimulator: resetSimulator,
             enableLldb,
             signalAppEnd,
+            enableRelay: enableRelay,
             environmentalVariables,
             passthroughArguments,
             cancellationToken);
@@ -120,6 +123,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         bool resetSimulator,
         bool enableLldb,
         bool signalAppEnd,
+        bool enableRelay,
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         CancellationToken cancellationToken)
@@ -163,6 +167,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 environmentalVariables,
                 passthroughArguments,
                 signalAppEnd,
+                enableRelay,
                 cancellationToken); // This cancellation token doesn't include the launch-timeout one
         }
 
@@ -183,6 +188,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 environmentalVariables,
                 passthroughArguments,
                 signalAppEnd,
+                enableRelay,
                 cancellationToken); // This cancellation token doesn't include the launch-timeout one
         }
 
@@ -212,6 +218,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         bool signalAppEnd,
+        bool enableRelay,
         CancellationToken cancellationToken)
     {
         var runMode = target.Platform.ToRunMode();
@@ -243,6 +250,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             timeout,
             launchTimeout,
             signalAppEnd,
+            enableRelay: enableRelay,
             passthroughArguments,
             environmentalVariables,
             xmlResultJargon,
@@ -264,6 +272,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         IReadOnlyCollection<(string, string)> environmentalVariables,
         IEnumerable<string> passthroughArguments,
         bool signalAppEnd,
+        bool enableRelay,
         CancellationToken cancellationToken)
     {
         var appTester = GetAppTester(communicationChannel, TestTarget.MacCatalyst.IsSimulator());
@@ -273,6 +282,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             timeout,
             launchTimeout,
             signalAppEnd,
+            enableRelay: enableRelay,
             passthroughArguments,
             environmentalVariables,
             xmlResultJargon,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidRunCommandArguments.cs
@@ -18,6 +18,7 @@ internal class AndroidRunCommandArguments : XHarnessCommandArguments, IAndroidAp
     public InstrumentationNameArgument InstrumentationName { get; } = new();
     public InstrumentationArguments InstrumentationArguments { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
+    public EnableRelayArgument EnableRelay { get; } = new();
     public DeviceOutputFolderArgument DeviceOutputFolder { get; } = new();
     public WifiArgument Wifi { get; } = new();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -21,6 +21,7 @@ internal class AndroidTestCommandArguments : XHarnessCommandArguments, IAndroidA
     public InstrumentationNameArgument InstrumentationName { get; } = new();
     public InstrumentationArguments InstrumentationArguments { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
+    public EnableRelayArgument EnableRelay { get; } = new();
     public DeviceOutputFolderArgument DeviceOutputFolder { get; } = new();
     public WifiArgument Wifi { get; } = new();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessRunCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessRunCommandArguments.cs
@@ -20,6 +20,7 @@ internal class AndroidHeadlessRunCommandArguments : XHarnessCommandArguments, IA
     public DeviceIdArgument DeviceId { get; } = new();
     public ApiVersionArgument ApiVersion { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
+    public EnableRelayArgument EnableRelay { get; } = new();
     public DeviceOutputFolderArgument DeviceOutputFolder { get; } = new();
     public WifiArgument Wifi { get; } = new();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/AndroidHeadless/AndroidHeadlessTestCommandArguments.cs
@@ -21,6 +21,7 @@ internal class AndroidHeadlessTestCommandArguments : XHarnessCommandArguments, I
     public DeviceArchitectureArgument DeviceArchitecture { get; } = new();
     public ApiVersionArgument ApiVersion { get; } = new();
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
+    public EnableRelayArgument EnableRelay { get; } = new();
     public WifiArgument Wifi { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleJustTestCommandArguments.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -24,6 +24,7 @@ internal class AppleJustTestCommandArguments : XHarnessCommandArguments, IAppleA
     public SingleMethodFilters SingleMethodFilters { get; } = new();
     public ClassMethodFilters ClassMethodFilters { get; } = new();
     public EnableLldbArgument EnableLldb { get; } = new();
+    public EnableRelayArgument EnableRelay { get; } = new();
     public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
     public SignalAppEndArgument SignalAppEnd { get; } = new();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/AppleTestCommandArguments.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -26,6 +26,7 @@ internal class AppleTestCommandArguments : XHarnessCommandArguments, IAppleAppRu
     public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
     public ResetSimulatorArgument ResetSimulator { get; } = new();
     public SignalAppEndArgument SignalAppEnd { get; } = new();
+    public EnableRelayArgument EnableRelay { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/EnableRelayArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/EnableRelayArgument.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments;
+
+/// <summary>
+/// Enable xharness to function as a relay when communicating with the appliecation
+/// </summary>
+internal class EnableRelayArgument : SwitchArgument
+{
+    public EnableRelayArgument() : base("enable-relay", "Allow to communicate with the launched application", false)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleJustTestCommand.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -38,6 +38,7 @@ internal class AppleJustTestCommand : AppleAppCommand<AppleJustTestCommandArgume
                 includeWirelessDevices: Arguments.IncludeWireless,
                 enableLldb: Arguments.EnableLldb,
                 signalAppEnd: Arguments.SignalAppEnd,
+                enableRelay: Arguments.EnableRelay,
                 Arguments.EnvironmentalVariables.Value,
                 PassThroughArguments,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleTestCommand.cs
@@ -43,6 +43,7 @@ internal class AppleTestCommand : AppleAppCommand<AppleTestCommandArguments>
                 resetSimulator: Arguments.ResetSimulator,
                 enableLldb: Arguments.EnableLldb,
                 signalAppEnd: Arguments.SignalAppEnd,
+                enableRelay: Arguments.EnableRelay,
                 Arguments.EnvironmentalVariables.Value,
                 PassThroughArguments,
                 cancellationToken);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListenerFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -12,6 +12,7 @@ public enum ListenerTransport
     Tcp,
     Http,
     File,
+    Relay,
 }
 
 public interface ISimpleListenerFactory
@@ -22,7 +23,8 @@ public interface ISimpleListenerFactory
         IFileBackedLog testLog,
         bool isSimulator,
         bool autoExit,
-        bool xmlOutput);
+        bool xmlOutput,
+        bool relay);
 
     ITunnelBore TunnelBore { get; }
     bool UseTunnel { get; }
@@ -44,7 +46,8 @@ public class SimpleListenerFactory : ISimpleListenerFactory
         IFileBackedLog testLog,
         bool isSimulator,
         bool autoExit,
-        bool xmlOutput)
+        bool xmlOutput,
+        bool relay)
     {
         string listenerTempFile = null;
         ISimpleListener listener;
@@ -61,6 +64,9 @@ public class SimpleListenerFactory : ISimpleListenerFactory
 
         switch (transport)
         {
+            case ListenerTransport.Relay:
+                listener = new SimpleTcpListener(log, testLog, autoExit, UseTunnel);
+                break;
             case ListenerTransport.File:
                 listenerTempFile = testLog.FullPath + ".tmp";
                 listener = new SimpleFileListener(listenerTempFile, log, testLog, xmlOutput);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -115,6 +115,7 @@ public class AppTesterTests : AppRunTestBase
             TimeSpan.FromSeconds(30),
             TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            enableRelay: false,
             extraAppArguments: new string[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -212,6 +213,7 @@ public class AppTesterTests : AppRunTestBase
             timeout: TimeSpan.FromSeconds(30),
             testLaunchTimeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            enableRelay: false,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -300,6 +302,7 @@ public class AppTesterTests : AppRunTestBase
             timeout: TimeSpan.FromSeconds(30),
             testLaunchTimeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            enableRelay: false,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") },
             skippedMethods: skippedTests);
@@ -383,6 +386,7 @@ public class AppTesterTests : AppRunTestBase
             timeout: TimeSpan.FromSeconds(30),
             testLaunchTimeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            enableRelay: false,
             skippedTestClasses: skippedClasses);
 
         // Verify
@@ -455,6 +459,7 @@ public class AppTesterTests : AppRunTestBase
             timeout: TimeSpan.FromSeconds(30),
             testLaunchTimeout: TimeSpan.FromSeconds(30),
             signalAppEnd: false,
+            enableRelay: false,
             extraAppArguments: new[] { "--foo=bar", "--xyz" },
             extraEnvVariables: new[] { ("appArg1", "value1") });
 
@@ -572,6 +577,7 @@ public class AppTesterTests : AppRunTestBase
             timeout: TimeSpan.FromMinutes(30),
             testLaunchTimeout: TimeSpan.FromMinutes(30),
             signalAppEnd: true,
+            false,
             Array.Empty<string>(),
             Array.Empty<(string, string)>());
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustTestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustTestOrchestratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -64,6 +64,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                It.IsAny<bool>(),
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<XmlResultJargon>(),
@@ -87,6 +88,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: false,
             signalAppEnd: false,
+            enableRelay: false,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -126,6 +128,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                false,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -149,6 +152,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: true,
             enableLldb: false,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -183,6 +187,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                false,
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -212,6 +217,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: true,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             new CancellationToken());
@@ -252,6 +258,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 true,
+                false,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -275,6 +282,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: true,
             enableLldb: false,
             signalAppEnd: true,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -312,6 +320,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 true,
+                false,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<XmlResultJargon>(),
@@ -335,6 +344,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             includeWirelessDevices: false,
             enableLldb: false,
             signalAppEnd: true,
+            enableRelay: false,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -74,6 +74,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                false,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<XmlResultJargon>(),
@@ -98,6 +99,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: true,
             enableLldb: false,
             signalAppEnd: false,
+            enableRelay: false,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -137,6 +139,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                false,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -161,6 +164,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: false,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -198,6 +202,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 false,
+                false,
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -228,6 +233,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: true,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             new CancellationToken());
@@ -265,6 +271,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
+                false,
                 false,
                 It.IsAny<IEnumerable<string>>(),
                 It.IsAny<IEnumerable<(string, string)>>(),
@@ -304,6 +311,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: true,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             cts.Token);
@@ -341,6 +349,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: true,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             Array.Empty<string>(),
             new CancellationToken());
@@ -369,6 +378,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 true,
+                false,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
                 It.IsAny<XmlResultJargon>(),
@@ -393,6 +403,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: false,
             signalAppEnd: true,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());
@@ -433,6 +444,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
                 true,
+                false,
                 It.IsAny<IEnumerable<string>>(),
                 envVars,
                 It.IsAny<XmlResultJargon>(),
@@ -457,6 +469,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: true,
             enableLldb: false,
             signalAppEnd: true,
+            enableRelay: false,
             envVars,
             Array.Empty<string>(),
             new CancellationToken());
@@ -489,6 +502,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 null,
                 TimeSpan.FromMinutes(30),
                 It.IsAny<TimeSpan>(),
+                false,
                 false,
                 extraArguments,
                 It.IsAny<IEnumerable<(string, string)>>(),
@@ -523,6 +537,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             resetSimulator: false,
             enableLldb: false,
             signalAppEnd: false,
+            enableRelay: false,
             Array.Empty<(string, string)>(),
             extraArguments,
             new CancellationToken());

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Listeners/SimpleListenerFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -26,22 +26,33 @@ public class SimpleListenerFactoryTest
         _ = new SimpleListenerFactory(null); // if it throws, test fails ;)
     }
 
-    [Fact]
-    public void CreateNotWatchListener()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateNotWatchListener(bool isRelay)
     {
-        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true);
+        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.iOS, _log.Object, _log.Object, true, true, true, isRelay);
         Assert.Equal(ListenerTransport.Tcp, transport);
-        Assert.IsType<SimpleTcpListener>(listener);
+        if (isRelay)
+        {
+            Assert.IsType<SimpleTcpListener>(listener);
+        }
+        else
+        {
+            Assert.IsType<SimpleTcpListener>(listener);
+        }
         Assert.Null(listenerTmpFile);
     }
 
-    [Fact]
-    public void CreateWatchOSSimulator()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CreateWatchOSSimulator(bool isRelay)
     {
         var logFullPath = "myfullpath.txt";
         _ = _log.Setup(l => l.FullPath).Returns(logFullPath);
 
-        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true);
+        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, true, true, true, relay: isRelay);
         Assert.Equal(ListenerTransport.File, transport);
         Assert.IsType<SimpleFileListener>(listener);
         Assert.NotNull(listenerTmpFile);
@@ -54,7 +65,7 @@ public class SimpleListenerFactoryTest
     [Fact]
     public void CreateWatchOSDevice()
     {
-        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true);
+        var (transport, listener, listenerTmpFile) = _factory.Create(RunMode.WatchOS, _log.Object, _log.Object, false, true, true, false);
         Assert.Equal(ListenerTransport.Http, transport);
         Assert.IsType<SimpleHttpListener>(listener);
         Assert.Null(listenerTmpFile);


### PR DESCRIPTION
This PR contains only the CLI changes to allow xharness to know that a relay is needed. The idea behind this is that we want to be able to open a relay port with the device so that we can use a protocol to interact with the tests on an application. This way we will add support to integrating the test runner in the device with an IDE.

There is no platform specific implementation in this PR, that will come in the following days, the aim is to show the new argument and how it will be passed, once we agree on that, we can move to the actual implementation. 