### PR TITLE
[mlaunch] Add support for devicectl

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Tools.Mlaunch" Version="1.0.69">
+    <PackageReference Include="Microsoft.Tools.Mlaunch" Version="1.0.76">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
Ref: xamarin/maccore#2716

devicectl was added as part of Xcode 15 and it is now used to launch Apps on device.