### PR TITLE
[apple] Fix how we slected the DeviceType based on iOSVersion

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -38,27 +38,25 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         return target.Platform switch
         {
-            TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
-            TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
-            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X"),
+            TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
+            TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
+            TestTarget.Simulator_iOS64 => GetiOSDeviceType(Version.Parse(target.OSVersion)),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
-            TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm"),
-            TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",
+            TestTarget.Simulator_watchOS => GetWatchOSDeviceType(Version.Parse(target.OSVersion)),
             _ => throw new Exception(string.Format("Invalid simulator target: {0}", target))
         };
     }
 
     public virtual void GetCompanionRuntimeAndDeviceType(TestTargetOs target, bool minVersion, out string? companionRuntime, out string? companionDeviceType)
     {
+        companionRuntime = null;
+        companionDeviceType = null;
+
         if (target.Platform == TestTarget.Simulator_watchOS)
         {
-            companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
-            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X");
-        }
-        else
-        {
-            companionRuntime = null;
-            companionDeviceType = null;
+            var companionVersion = minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator;
+            companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + companionVersion.Replace('.', '-');
+            companionDeviceType = GetiOSDeviceType(Version.Parse(companionVersion));
         }
     }
 
@@ -66,5 +64,28 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         // Put Booted/Booting in front of Shutdown/Unknown
         return simulators.OrderByDescending(s => s.State).First();
+    }
+
+    string GetiOSDeviceType(Version iOSVersion)
+    {
+        if (iOSVersion.Major < 13)
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-7";
+        if (iOSVersion.Major < 14)
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-8";
+        if (iOSVersion.Major < 15)
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
+        if (iOSVersion.Major < 16)
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
+
+        return "com.apple.CoreSimulator.SimDeviceType.iPhone-14";
+    }
+
+    string GetWatchOSDeviceType(Version watchOSVersion)
+    {
+        if (watchOSVersion.Major < 7)
+            return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-3-38mm";
+        if (watchOSVersion.Major < 8)
+            return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-4-40mm";
+        return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-7-41mm";
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -68,7 +68,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
 
     string GetiOSDeviceType(Version iOSVersion)
     {
-        if (iOSVersion.Major < 16)
+        if (iOSVersion.Major < 17)
             return "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
         
         return "com.apple.CoreSimulator.SimDeviceType.iPhone-15";

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -68,16 +68,10 @@ public class DefaultSimulatorSelector : ISimulatorSelector
 
     string GetiOSDeviceType(Version iOSVersion)
     {
-        if (iOSVersion.Major < 13)
-            return "com.apple.CoreSimulator.SimDeviceType.iPhone-7";
-        if (iOSVersion.Major < 14)
-            return "com.apple.CoreSimulator.SimDeviceType.iPhone-8";
-        if (iOSVersion.Major < 15)
-            return "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
         if (iOSVersion.Major < 16)
-            return "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
-
-        return "com.apple.CoreSimulator.SimDeviceType.iPhone-14";
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-X";
+        
+        return "com.apple.CoreSimulator.SimDeviceType.iPhone-15";
     }
 
     string GetWatchOSDeviceType(Version watchOSVersion)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -38,8 +38,8 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         return target.Platform switch
         {
-            TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
-            TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5s",
+            TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
+            TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
             TestTarget.Simulator_iOS64 => GetiOSDeviceType(Version.Parse(target.OSVersion)),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
             TestTarget.Simulator_watchOS => GetWatchOSDeviceType(Version.Parse(target.OSVersion)),
@@ -80,6 +80,6 @@ public class DefaultSimulatorSelector : ISimulatorSelector
             return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-3-38mm";
         if (watchOSVersion.Major < 8)
             return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-4-40mm";
-        return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-7-41mm";
+        return "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-38mm";
     }
 }


### PR DESCRIPTION
I ported over some changes from Xamarin-macios to improve how we selected the devicetype. For example iPhoneX seems is not supported anymore on 17.0

I think we also need a way to override this device type if needed

https://github.com/xamarin/xamarin-macios/blob/a8bc174b26b67323feac2f0dd71a0ba117261778/tests/xharness/SimulatorLoaderFactory.cs#L45

Fixes #1090 1090