### PR TITLE
Fail early when Android device is not booted

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -188,7 +188,7 @@ public class AdbRunner
         return apiVersion;
     }
 
-    public void WaitForDevice()
+    public bool WaitForDevice()
     {
         // This command waits for ANY kind of device to be available (emulator or real)
         // Needed because emulators start up asynchronously and take a while.
@@ -215,10 +215,12 @@ public class AdbRunner
         if (bootCompleted)
         {
             _log.LogDebug($"Waited {(int)watch.Elapsed.TotalSeconds} seconds for device boot completion");
+            return true;
         }
         else
         {
-            _log.LogWarning($"Did not detect boot completion variable on device; device may be in a bad state");
+            _log.LogError($"Did not detect boot completion variable on device; device may be in a bad state");
+            return false;
         }
     }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -108,7 +108,10 @@ Arguments:
             runner.TimeToWaitForBootCompletion = bootTimeoutSeconds;
 
             // Wait till at least device(s) are ready
-            runner.WaitForDevice();
+            if (!runner.WaitForDevice())
+            {
+                return ExitCode.DEVICE_NOT_FOUND;
+            }
 
             logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -53,7 +53,10 @@ Arguments:
         runner.TimeToWaitForBootCompletion = Arguments.LaunchTimeout;
 
         // Wait till at least device(s) are ready
-        runner.WaitForDevice();
+        if (!runner.WaitForDevice())
+        {
+            return ExitCode.DEVICE_NOT_FOUND;
+        }
 
         logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessInstallCommand.cs
@@ -103,7 +103,10 @@ Arguments:
             runner.TimeToWaitForBootCompletion = bootTimeoutSeconds;
 
             // Wait till at least device(s) are ready
-            runner.WaitForDevice();
+            if (!runner.WaitForDevice())
+            {
+                return ExitCode.DEVICE_NOT_FOUND;
+            }
 
             logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/AndroidHeadless/AndroidHeadlessRunCommand.cs
@@ -52,7 +52,10 @@ Arguments:
         runner.TimeToWaitForBootCompletion = Arguments.LaunchTimeout;
 
         // Wait till at least device(s) are ready
-        runner.WaitForDevice();
+        if (!runner.WaitForDevice())
+        {
+            return ExitCode.DEVICE_NOT_FOUND;
+        }
 
         return InvokeHelper(
             logger,


### PR DESCRIPTION
When an emulator/device doesn't boot (`sys.boot_completed` is not `1`) then it is generally not usable and we run into all sorts of failures like not being able to install APKs: https://github.com/dotnet/dnceng/issues/1448.

Fail early in cases like this and return `DEVICE_NOT_FOUND` exit code which will also trigger Helix infrastructure logic to e.g. reboot an emulator VM.