### PR TITLE
Apple: Fix NRE when listing devices that are not paired

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleStateCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/AppleStateCommand.cs
@@ -30,13 +30,15 @@ internal class AppleStateCommand : GetStateCommand<AppleStateCommandArguments>
         public string UDID { get; }
         public string Type { get; }
         public string OSVersion { get; }
+        public bool IsPaired { get; }
 
-        public DeviceInfo(string name, string uDID, string type, string oSVersion)
+        public DeviceInfo(string name, string uDID, string type, string oSVersion, bool isPaired = true)
         {
             Name = name;
             UDID = uDID;
             Type = type;
             OSVersion = oSVersion;
+            IsPaired = isPaired;
         }
     }
 
@@ -129,7 +131,8 @@ internal class AppleStateCommand : GetStateCommand<AppleStateCommandArguments>
             foreach (var dev in info.Devices)
             {
                 var uuid = Arguments.ShowDevicesUUID ? $" {dev.UDID}   " : "";
-                Console.WriteLine($"  {dev.Name.PadRight(maxLength)}{uuid} {dev.OSVersion,-13} {dev.Type}");
+                var notPaired = dev.IsPaired ? "" : "(not paired) ";
+                Console.WriteLine($"  {notPaired}{dev.Name.PadRight(maxLength)}{uuid} {dev.OSVersion,-13} {dev.Type}");
             }
         }
         else
@@ -213,7 +216,8 @@ internal class AppleStateCommand : GetStateCommand<AppleStateCommandArguments>
                 name: dev.Name,
                 uDID: dev.DeviceIdentifier,
                 type: $"{dev.DeviceClass} {dev.DevicePlatform}",
-                oSVersion: dev.OSVersion));
+                oSVersion: dev.OSVersion,
+                isPaired: dev.IsPaired));
         }
 
         if (Arguments.UseJson)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/Device.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/Device.cs
@@ -23,11 +23,11 @@ public class Device : IHardwareDevice
         string deviceIdentifier,
         DeviceClass deviceClass,
         string name,
-        string buildVersion,
-        string productVersion,
-        string productType,
+        string? buildVersion,
+        string? productVersion,
+        string? productType,
         string interfaceType,
-        string companionIdentifier = null,
+        string? companionIdentifier = null,
         bool? isUsableForDebugging = null,
         bool isLocked = false,
         bool isPaired = false)
@@ -47,11 +47,11 @@ public class Device : IHardwareDevice
 
     public string DeviceIdentifier { get; }
     public DeviceClass DeviceClass { get; }
-    public string CompanionIdentifier { get; }
+    public string? CompanionIdentifier { get; }
     public string Name { get; }
-    public string BuildVersion { get; }
-    public string ProductVersion { get; }
-    public string ProductType { get; }
+    public string? BuildVersion { get; }
+    public string? ProductVersion { get; }
+    public string? ProductType { get; }
     public string InterfaceType { get; }
     public bool? IsUsableForDebugging { get; }
     public bool IsLocked { get; }
@@ -59,7 +59,7 @@ public class Device : IHardwareDevice
 
     public string UDID => DeviceIdentifier;
 
-    public string OSVersion => ProductVersion;
+    public string? OSVersion => ProductVersion;
 
     // Add a speed property that can be used to sort a list of devices according to speed.
     public int DebugSpeed => InterfaceType?.ToLowerInvariant() switch
@@ -83,7 +83,7 @@ public class Device : IHardwareDevice
 
     public bool Supports32Bit => DevicePlatform switch
     {
-        DevicePlatform.iOS => Version.Parse(ProductVersion).Major < 11,
+        DevicePlatform.iOS => ProductVersion != null && Version.Parse(ProductVersion).Major < 11,
         DevicePlatform.tvOS => false,
         DevicePlatform.watchOS => true,
         DevicePlatform.xrOS => false,
@@ -95,6 +95,11 @@ public class Device : IHardwareDevice
         get
         {
             var model = ProductType;
+
+            if (model == null)
+            {
+                return Architecture.Unknown;
+            }
 
             // https://www.theiphonewiki.com/wiki/Models
             if (model.StartsWith("iPhone", StringComparison.Ordinal))

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IDevice.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 
 public enum Architecture
 {
+    Unknown,
     ARMv6,
     ARMv7,
     ARMv7k,

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IHardwareDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IHardwareDevice.cs
@@ -8,10 +8,10 @@ public interface IHardwareDevice : IDevice
 {
     string DeviceIdentifier { get; }
     DeviceClass DeviceClass { get; }
-    string CompanionIdentifier { get; }
-    string BuildVersion { get; }
-    string ProductVersion { get; }
-    string ProductType { get; }
+    string? CompanionIdentifier { get; }
+    string? BuildVersion { get; }
+    string? ProductVersion { get; }
+    string? ProductType { get; }
     string InterfaceType { get; }
     bool? IsUsableForDebugging { get; }
     bool IsLocked { get; }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Microsoft.DotNet.XHarness.iOS.Shared.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <!-- Disable the nullable warnings when compiling for .NET Standard 2.0 -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604;8632</NoWarn>
   </PropertyGroup>
 
   <!-- Remove files that are only included inside of the packaged iOS app and are not to be compiled as part of this project -->


### PR DESCRIPTION
When a device is not paired (trusted) then some data like the architecture is not available.
Prevent a NullReferenceException when trying to access that data.

Fixes https://github.com/dotnet/xharness/issues/1126