### PR TITLE
Distribute xunit.runner.utility for netcoreapp so we avoid NS1.x dependencies

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/Microsoft.DotNet.XHarness.TestRunners.Xunit.csproj
@@ -9,6 +9,16 @@
   <ItemGroup>
     <PackageReference Include="xunit.analyzers" VersionOverride="$(XUnitAnalyzersVersion)" />
     <PackageReference Include="xunit.extensibility.execution" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetMinimum)'">
+    <!-- Reference xunit.runner.utility directly via PackageDownload+Reference to avoid its netstandard1.x dependencies. -->
+    <PackageDownload Include="xunit.runner.utility" Version="[$(XUnitVersion)]" />
+    <Reference Include="$(NuGetPackageRoot)xunit.runner.utility\$(XUnitVersion)\lib\netcoreapp1.0\xunit.runner.utility.netcoreapp10.dll" />
+    <TfmSpecificPackageFile Include="@(Reference->WithMetadataValue('Filename', 'xunit.runner.utility.netcoreapp10'))" PackagePath="lib/$(NetMinimum)/" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="xunit.runner.utility" />
   </ItemGroup>
 

--- a/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/Microsoft.DotNet.XHarness.TestRunners.Tests.csproj
+++ b/tests/Microsoft.DotNet.XHarness.TestRunners.Tests/Microsoft.DotNet.XHarness.TestRunners.Tests.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" />
-    <PackageReference Include="xunit.runner.utility" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is how we do it for Microsoft.DotNet.XUnitConsoleRunner in arcade.