### PR TITLE
[iOS] Use a more modern device for XCode 15.2

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -38,7 +38,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         return target.Platform switch
         {
-            TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
+            TestTarget.Simulator_iOS => GetiOSDeviceType(target, minVersion),
             TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
             TestTarget.Simulator_iOS64 => GetiOSDeviceType(target, minVersion),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
@@ -53,7 +53,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         if (target.Platform == TestTarget.Simulator_watchOS)
         {
             companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
-            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-SE-3rd-generation");
+            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-X");
         }
         else
         {
@@ -79,6 +79,6 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         }
         return iOSVersion.Major >= 17
             ? "com.apple.CoreSimulator.SimDeviceType.iPhone-15"
-            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-SE-3rd-generation");
+            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-X");
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -53,7 +53,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         if (target.Platform == TestTarget.Simulator_watchOS)
         {
             companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
-            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-X");
+            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-XS");
         }
         else
         {
@@ -79,6 +79,6 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         }
         return iOSVersion.Major >= 17
             ? "com.apple.CoreSimulator.SimDeviceType.iPhone-15"
-            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-X");
+            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-XS");
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -53,7 +53,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         if (target.Platform == TestTarget.Simulator_watchOS)
         {
             companionRuntime = "com.apple.CoreSimulator.SimRuntime.iOS-" + (minVersion ? SdkVersions.MinWatchOSCompanionSimulator : SdkVersions.MaxWatchOSCompanionSimulator).Replace('.', '-');
-            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X");
+            companionDeviceType = "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-SE-3rd-generation");
         }
         else
         {
@@ -79,6 +79,6 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         }
         return iOSVersion.Major >= 17
             ? "com.apple.CoreSimulator.SimDeviceType.iPhone-15"
-            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X");
+            : "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-SE-3rd-generation");
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
@@ -113,7 +113,7 @@ public class SimulatorLoaderTests
         MlaunchArgument outputFormatArg = passedArguments.Where(a => a is XmlOutputFormatArgument).FirstOrDefault();
         Assert.NotNull(outputFormatArg);
 
-        Assert.Equal(75, _simulatorLoader.AvailableDevices.Count());
+        Assert.Equal(76, _simulatorLoader.AvailableDevices.Count());
     }
 
     [Theory]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
@@ -716,6 +716,12 @@
         <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/18F485DC-7F0A-440F-BEF9-5BE5954B0FB1</DataPath>
         <LogPath>/Users/mandel/Library/Logs/CoreSimulator/18F485DC-7F0A-440F-BEF9-5BE5954B0FB1</LogPath>
       </SimDevice>
+      <SimDevice UDID="336E1D83-AB00-4FAE-A70D-C516D269B90A" Name="iPhone Xs (iOS {{MAX-IOS.VERSION}}) - created by xharness">
+        <SimRuntime>com.apple.CoreSimulator.SimRuntime.iOS-{{MAX-IOS-VERSION}}</SimRuntime>
+        <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.iPhone-XS</SimDeviceType>
+        <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/336E1D83-AB00-4FAE-A70D-C516D269B90A</DataPath>
+        <LogPath>/Users/mandel/Library/Logs/CoreSimulator/336E1D83-AB00-4FAE-A70D-C516D269B90A</LogPath>
+      </SimDevice>
       <SimDevice UDID="ABC2A44A-789D-4C8B-88A7-0CD7C6BF316C" Name="iPhone 11">
         <SimRuntime>com.apple.CoreSimulator.SimRuntime.iOS-{{MAX-IOS-VERSION}}</SimRuntime>
         <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.iPhone-11</SimDeviceType>
@@ -910,6 +916,10 @@
       </SimDevicePair>
       <SimDevicePair UDID="39ED2FCC-0A8B-4CC6-B2C9-CFCD5A073762">
         <Companion>18F485DC-7F0A-440F-BEF9-5BE5954B0FB1</Companion>
+        <Gizmo>BB2F9CF0-A928-4909-867A-525A937D7390</Gizmo>
+      </SimDevicePair>
+      <SimDevicePair UDID="324096C4-4773-48E7-8420-CECCC8B060BD">
+        <Companion>336E1D83-AB00-4FAE-A70D-C516D269B90A</Companion>
         <Gizmo>BB2F9CF0-A928-4909-867A-525A937D7390</Gizmo>
       </SimDevicePair>
       <SimDevicePair UDID="59E9A82D-89C7-4456-AE2C-FECB01899CD6">


### PR DESCRIPTION
Based on some investigation I did with Xcode 15.2 and previous, seems the device type that xharness creates is not allowed in more recent versions. 
By looking at what simulators I was able to create and that show up on Xcode 15.2 i think we want to use the SE 3rd generation as a base for old versions. 

<img width="676" alt="Screenshot 2024-01-16 at 12 59 53" src="https://github.com/dotnet/xharness/assets/1235097/d56b6831-ea78-4f44-ad2a-d90ccc199636">
