### PR TITLE
[wasm] Switch between threadless and multi-threaded runner

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/EnvironmentVariables.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/EnvironmentVariables.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
+
+internal static class EnvironmentVariables
+{
+    public static bool IsTrue(string varName) => Environment.GetEnvironmentVariable(varName)?.ToLower().Equals("true") ?? false;
+
+    public static bool IsLogTestStart() => IsTrue("XHARNESS_LOG_TEST_START");
+
+    public static bool IsLogThreadId() => IsTrue("XHARNESS_LOG_THREAD_ID");
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -62,7 +62,7 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
 #pragma warning restore
             var completionSink = new CompletionCallbackExecutionSink(resultsSink, summary => summaryTaskSource.SetResult(summary));
 
-            if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
+            if (EnvironmentVariables.IsLogTestStart())
             {
                 testSink.Execution.TestStartingEvent += args => { Console.WriteLine($"[STRT] {args.Message.Test.DisplayName}"); };
             }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -121,12 +121,7 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
     {
         if (_oneLineResults)
         {
-            using var ms = new MemoryStream();
-            _assembliesElement.Save(ms);
-            ms.TryGetBuffer(out var bytes);
-            var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
-            Console.WriteLine($"STARTRESULTXML {bytes.Count} {base64} ENDRESULTXML");
-            Console.WriteLine($"Finished writing {bytes.Count} bytes of RESULTXML");
+            WasmXmlResultWriter.WriteOnSingleLine(_assembliesElement);
         }
         else
         {

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
@@ -22,9 +22,14 @@ public abstract class WasmApplicationEntryPoint : WasmApplicationEntryPointBase
 
     protected override bool IsXunit => true;
 
+    protected bool IsThreadless { get; set; } = true;
+
     protected override TestRunner GetTestRunner(LogWriter logWriter)
     {
-        var runner = new ThreadlessXunitTestRunner(logWriter, true);
+        XunitTestRunnerBase runner = IsThreadless
+            ? new ThreadlessXunitTestRunner(logWriter, true)
+            : new WasmThreadedTestRunner(logWriter);
+
         ConfigureRunnerFilters(runner, ApplicationOptions.Current);
 
         runner.SkipCategories(ExcludedTraits);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
@@ -16,12 +16,5 @@ internal class WasmThreadedTestRunner : XUnitTestRunner
     }
 
     public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
-    {
-        using var ms = new MemoryStream();
-        AssembliesElement.Save(ms);
-        ms.TryGetBuffer(out var bytes);
-        var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
-        Console.WriteLine($"STARTRESULTXML {bytes.Count} {base64} ENDRESULTXML");
-        Console.WriteLine($"Finished writing {bytes.Count} bytes of RESULTXML");
-    }
+        => WasmXmlResultWriter.WriteOnSingleLine(AssembliesElement);
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
+
+internal class WasmThreadedTestRunner : XUnitTestRunner
+{
+    public WasmThreadedTestRunner(LogWriter logger) : base(logger)
+    {
+    }
+
+    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+    {
+        using var ms = new MemoryStream();
+        AssembliesElement.Save(ms);
+        ms.TryGetBuffer(out var bytes);
+        var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
+        Console.WriteLine($"STARTRESULTXML {bytes.Count} {base64} ENDRESULTXML");
+        Console.WriteLine($"Finished writing {bytes.Count} bytes of RESULTXML");
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.XHarness.TestRunners.Xunit
+{
+    public class WasmXmlResultWriter
+    {
+        public static void WriteOnSingleLine(XElement assembliesElement)
+        {
+            using var ms = new MemoryStream();
+            assembliesElement.Save(ms);
+            ms.TryGetBuffer(out var bytes);
+            var base64 = Convert.ToBase64String(bytes, Base64FormattingOptions.None);
+            Console.WriteLine($"STARTRESULTXML {bytes.Count} {base64} ENDRESULTXML");
+            Console.WriteLine($"Finished writing {bytes.Count} bytes of RESULTXML");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -124,6 +124,14 @@ internal class XUnitTestRunner : XunitTestRunnerBase
         }
     }
 
+    private string GetThreadIdForLog()
+    {
+        if (Environment.GetEnvironmentVariable("XHARNESS_LOG_THREAD_ID") == null)
+            return string.Empty;
+
+        return $"[{Thread.CurrentThread.ManagedThreadId}]";
+    }
+
     private void HandleTestStarting(MessageHandlerArgs<ITestStarting> args)
     {
         if (args == null || args.Message == null)
@@ -133,7 +141,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
         if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
         {
-            OnInfo($"\t[STRT] {args.Message.Test.DisplayName}");
+            OnInfo($"\t[STRT]{GetThreadIdForLog()} {args.Message.Test.DisplayName}");
         }
 
         OnDebug("Test starting");
@@ -159,7 +167,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
         }
 
         PassedTests++;
-        OnInfo($"\t[PASS] {args.Message.TestCase.DisplayName}");
+        OnInfo($"\t[PASS]{GetThreadIdForLog()} {args.Message.TestCase.DisplayName}");
         LogTestDetails(args.Message.Test, log: OnDebug);
         LogTestOutput(args.Message, log: OnDiagnostic);
         ReportTestCases("   Associated", args.Message.TestCases, log: OnDiagnostic);
@@ -244,7 +252,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
         FailedTests++;
         string assemblyInfo = GetAssemblyInfo(args.Message.TestAssembly);
-        var sb = new StringBuilder($"\t[FAIL] {args.Message.TestCase.DisplayName}");
+        var sb = new StringBuilder($"\t[FAIL]{GetThreadIdForLog()} {args.Message.TestCase.DisplayName}");
         LogTestDetails(args.Message.Test, OnError, sb);
         sb.AppendLine();
         if (!string.IsNullOrEmpty(assemblyInfo))
@@ -281,7 +289,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
             TestName = args.Message.Test?.DisplayName,
             Message = sb.ToString()
         });
-        OnInfo($"\t[FAIL] {args.Message.Test.TestCase.DisplayName}");
+        OnInfo($"\t[FAIL]{GetThreadIdForLog()} {args.Message.Test.TestCase.DisplayName}");
         OnInfo(sb.ToString());
         OnTestCompleted((
             TestName: args.Message.Test.DisplayName,

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -129,6 +129,11 @@ internal class XUnitTestRunner : XunitTestRunnerBase
             return;
         }
 
+        if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
+        {
+            OnInfo($"\t[STRT] {args.Message.Test.DisplayName}");
+        }
+
         OnDebug("Test starting");
         LogTestDetails(args.Message.Test, log: OnDebug);
         ReportTestCases("   Associated", args.Message.TestCases, args.Message.TestCase, OnDiagnostic);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -126,10 +126,10 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
     private string GetThreadIdForLog()
     {
-        if (Environment.GetEnvironmentVariable("XHARNESS_LOG_THREAD_ID") == null)
-            return string.Empty;
+        if (EnvironmentVariables.IsLogThreadId())
+            return $"[{Thread.CurrentThread.ManagedThreadId}]";
 
-        return $"[{Thread.CurrentThread.ManagedThreadId}]";
+        return string.Empty;
     }
 
     private void HandleTestStarting(MessageHandlerArgs<ITestStarting> args)
@@ -139,7 +139,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
             return;
         }
 
-        if (Environment.GetEnvironmentVariable("XHARNESS_LOG_TEST_START") != null)
+        if (EnvironmentVariables.IsLogTestStart())
         {
             OnInfo($"\t[STRT]{GetThreadIdForLog()} {args.Message.Test.DisplayName}");
         }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -35,6 +35,8 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
     private XElement _assembliesElement;
 
+    internal XElement AssembliesElement => _assembliesElement;
+
     public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
     protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
 


### PR DESCRIPTION
- Switch between threadless and multi-threaded XUnit runner for WASM based on `IsThreadless` property
- The property will be set in the runtime based on passed flags and based on used runtime flavor
- Mutli-threaded runner extends the runner for other platforms and overrides how results are written (as single line)
- Add current thread id to STRT, PASS and FAIL messages when enabled with `XHARNESS_LOG_THREAD_ID`

Contributes to https://github.com/dotnet/runtime/issues/88763