### PR TITLE
Support Xcode 15.3 simulators

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -395,6 +395,7 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
 
         xcodeVersion = xcodeVersion.Trim();
 
+        // the first two digits of DTXcode are the major version, then minor and revision so e.g. 1520 would translate to 15.2.0
         xcodeVersion = xcodeVersion.Insert(xcodeVersion.Length - 2, ".");
         xcodeVersion = xcodeVersion.Insert(xcodeVersion.Length - 1, ".");
 


### PR DESCRIPTION
DVTPlugInCompatibilityUUID is no longer available in the Info.plist so stop reading it. We only really used it for Xcode < 14 anyway.

Fixes https://github.com/dotnet/xharness/issues/1171