### PR TITLE
firefox fix -private-window

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -137,7 +137,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             options.AddArguments("--headless");
 
         if (!Arguments.NoIncognito)
-            options.AddArguments("--incognito");
+            options.AddArguments("-private-window");
 
         logger.LogInformation($"Starting Firefox with args: {string.Join(' ', options.ToCapabilities())}");
 


### PR DESCRIPTION
change `--incognito` to `-private-window`

because `console.error: "Warning: unrecognized command line flag" "-incognito"` see [Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-100697-merge-1b0bd685a6294b16af/WasmTestOnFirefox-ST-Wasm.Browser.Config.Sample/1/console.93426114.log?helixlogtype=result)