### PR TITLE
[android] Bump Android platform tools version to `32.0.0`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -12,13 +12,13 @@
     <MlaunchDestinationDir Condition="'$(TargetFrameworks)' == '' OR $(TargetFrameworks.EndsWith($(TargetFramework)))">$(BaseIntermediateOutputPath)/mlaunch</MlaunchDestinationDir>
 
     <!-- When updating these URLs, avoid using 'latest' url as these are redirects and can make the same commit build differently on different days -->
-    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-windows.zip</WindowsAndroidSdkUrl>
+    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-windows.zip</WindowsAndroidSdkUrl>
     <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
 
-    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-linux.zip</LinuxAndroidSdkUrl>
+    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-linux.zip</LinuxAndroidSdkUrl>
     <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
 
-    <MacOsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r29.0.6-darwin.zip</MacOsAndroidSdkUrl>
+    <MacOsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-darwin.zip</MacOsAndroidSdkUrl>
     <MacOsAndroidSdkFileName>macos-android-platform-tools.zip</MacOsAndroidSdkFileName>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

This PR bumps the version of Android platform tools that we ship to `32.0.0`. 

The reason for this is that on older versions `adb` for MacOS was shipped only as `x86_64` executable, which is problematic if Rosetta is disabled on arm64 Mac devices on which xharness android commands are invoked.

Version `32.0.0` of Android tools: https://developer.android.com/tools/releases/platform-tools#3200_january_2022 has changed this limitation and `adb` now ships as the universal binary for Apple M1 devices.

---
Fixes https://github.com/dotnet/xharness/issues/1200