### PR TITLE
[ios] Skip downloading simulators which don't have their source specified

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -106,8 +106,16 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
 
             var nameNode = downloadable.SelectSingleNode("key[text()='name']/following-sibling::string") ?? throw new Exception("Name node not found");
             var versionNode = downloadable.SelectSingleNode("key[text()='version']/following-sibling::string") ?? throw new Exception("Version node not found");
-            var sourceNode = downloadable.SelectSingleNode("key[text()='source']/following-sibling::string") ?? throw new Exception("Source node not found");
             var identifierNode = downloadable.SelectSingleNode("key[text()='identifier']/following-sibling::string") ?? throw new Exception("Identifier node not found");
+            var sourceNode = downloadable.SelectSingleNode("key[text()='source']/following-sibling::string");
+            if (sourceNode is null)
+            {
+                // It seems that Apple can list beta simulators in the index file, but they do not provide a source for downloading them (eg: iOS 18.0 beta Simulator Runtime).
+                // In such cases log a warning and skip trying to download such simulator as they are not publicly available.
+                Logger.LogWarning($"Simulator with name: '{nameNode.InnerText}' version: '{versionNode.InnerText}' identifier: '{identifierNode.InnerText}' has no source for download, skipping...");
+                continue;
+            }
+
             var fileSizeNode = downloadable.SelectSingleNode("key[text()='fileSize']/following-sibling::integer|key[text()='fileSize']/following-sibling::real");
             var installPrefixNode = downloadable.SelectSingleNode("key[text()='userInfo']/following-sibling::dict/key[text()='InstallPrefix']/following-sibling::string");
 


### PR DESCRIPTION
## Description 

When we want to install simulators through xharness (via for example: `apple simulators install ios-simulator-64_17.2`) we first fetch simulator index file from Apple server. From that file we parse the available simulators and fetch the sources for their download. 

However, it can happen that for beta simulators Apple does not provide the `source` for download which currently breaks the xharness with:
```
crit: System.Exception: Source node not found
         at Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators.SimulatorsCommand.GetAvailableSimulators() in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs:line 109
         at Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators.InstallCommand.InvokeInternal(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs:line 41
         at Microsoft.DotNet.XHarness.CLI.Commands.XHarnessCommand`1.Invoke(IEnumerable`1 arguments) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessCommand.cs:line 145
```

The example of the problematic index file with no `source` tag:
```
<dict>
	<key>category</key>
	<string>simulator</string>
	<key>contentType</key>
	<string>cryptexDiskImage</string>
	<key>dictionaryVersion</key>
	<integer>2</integer>
	<key>downloadMethod</key>
	<string>mobileAsset</string>
	<key>fileSize</key>
	<integer>8455760175</integer>
	<key>identifier</key>
	<string>com.apple.dmg.iPhoneSimulatorSDK18_0_b1</string>
	<key>name</key>
	<string>iOS 18.0 beta Simulator Runtime</string>
	<key>platform</key>
	<string>com.apple.platform.iphoneos</string>
	<key>simulatorVersion</key>
	<dict>
		<key>buildUpdate</key>
		<string>22A5282m</string>
		<key>version</key>
		<string>18.0</string>
	</dict>
	<key>version</key>
	<string>18.0.0.1</string>
</dict>
```

## Changes

In case a source is not found for a given simulator in the index file, instead of throwing an exception we now skip the problematic simulator and log a warning message about it e.g.,:
```
warn: Simulator with name: 'iOS 18.0 beta Simulator Runtime' version: '18.0.0.1' identifier: 'com.apple.dmg.iPhoneSimulatorSDK18_0_b1' has no source for download, skipping...
```

---

This should fix CI failures on MAUI like: https://dev.azure.com/xamarin/public/_build/results?buildId=117242&view=logs&j=0e3f2fb8-7a3a-523c-6f79-029322d7bc72&t=42aa25c1-d277-5dfe-a58d-159f24950f7f&s=d749bf34-c6fe-53af-7b97-b5d9438515d1