### PR TITLE
[release/6.0] Bump to macos-12 build image

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -75,7 +75,7 @@ stages:
       jobs:
       - job: OSX
         pool:
-          vmImage: macOS-11
+          vmImage: macOS-12
         strategy:
           matrix:
             Release:


### PR DESCRIPTION
AzDO will remove macos-11 later this month.