### PR TITLE
Prevent infinite loop when closing all tabs before quitting.

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -106,10 +106,12 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             // close all tabs before quit is a workaround for broken Selenium - GeckoDriver communication in Firefox
             // https://github.com/dotnet/runtime/issues/101617
             logger.LogInformation($"Closing {driver.WindowHandles.Count} browser tabs before setting the main tab to config page and quitting.");
-            DateTime timeoutThreshold = DateTime.Now.AddSeconds(10);
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(10000);
+
             while (driver.WindowHandles.Count > 1)
             {
-                if (DateTime.Now > timeoutThreshold)
+                if (cts.IsCancellationRequested)
                 {
                     logger.LogInformation($"Timeout while trying to close tabs, {driver.WindowHandles.Count} is left open before quitting.");
                     break;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -106,8 +106,14 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
             // close all tabs before quit is a workaround for broken Selenium - GeckoDriver communication in Firefox
             // https://github.com/dotnet/runtime/issues/101617
             logger.LogInformation($"Closing {driver.WindowHandles.Count} browser tabs before setting the main tab to config page and quitting.");
+            DateTime timeoutThreshold = DateTime.Now.AddSeconds(10);
             while (driver.WindowHandles.Count > 1)
             {
+                if (DateTime.Now > timeoutThreshold)
+                {
+                    logger.LogInformation($"Timeout while trying to close tabs, {driver.WindowHandles.Count} is left open before quitting.");
+                    break;
+                }
                 driver.Navigate().GoToUrl("about:config");
                 driver.Navigate().GoToUrl("about:blank");
                 driver.Close(); //Close Tab


### PR DESCRIPTION
Follow up for https://github.com/dotnet/xharness/pull/1221. In case of unsuccessful closing of tabs, we would end in infinite loop. Adding 10 sec timeout.