### PR TITLE
Fix Environment.SpecialFolder.MyDocuments usage in BaseOrchestrator.cs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.XHarness.Apple;
 /// </summary>
 public abstract class BaseOrchestrator : IDisposable
 {
-    protected static readonly string s_mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), ".mtouch-launch-with-lldb");
+    protected static readonly string s_mlaunchLldbConfigFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".mtouch-launch-with-lldb");
 
     private readonly IAppBundleInformationParser _appBundleInformationParser;
     private readonly IAppInstaller _appInstaller;


### PR DESCRIPTION
The value changed in .NET 8: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix#change-description

This was touched in https://github.com/dotnet/xharness/pull/948 but the change is wrong, mlaunch expects this file to be in $HOME: https://github.com/xamarin/maccore/blob/bd1f42be1995b8501542a90671aa668771f1b3a0/tools/mlaunch/Xamarin.Hosting/Xamarin.Launcher/controller-device.cs#L341