### PR TITLE
Prevent "Sequence contains no elements" in browser tests

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -120,7 +120,13 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                     driver.Navigate().GoToUrl("about:config");
                     driver.Navigate().GoToUrl("about:blank");
                     driver.Close(); //Close Tab
-                    driver.SwitchTo().Window(driver.WindowHandles.Last());
+
+                    // this is not redundant, it prevents "System.InvalidOperationException: Sequence contains no elements"
+                    var windowHandles = driver.WindowHandles.ToList();
+                    if (windowHandles.Any())
+                    {
+                        driver.SwitchTo().Window(windowHandles.Last());
+                    }
                 }
                 if (driverService.IsRunning)
                 {


### PR DESCRIPTION
Follow up for https://github.com/dotnet/xharness/pull/1221.
Contributes to https://github.com/dotnet/runtime/issues/107466.
In https://github.com/dotnet/runtime/pull/107259 we discovered very frequent timeouts on Windows with newer chrome version, with logs:

```
          [wasm test-browser] info: Closing 2 browser tabs before setting the main tab to config page and quitting.
          [wasm test-browser] fail: Error while closing browser: System.InvalidOperationException: Sequence contains no elements
          [wasm test-browser]          at System.Linq.ThrowHelper.ThrowNoElementsException()
          [wasm test-browser]          at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.InvokeInternal(ILogger logger)
          [wasm test-browser] XHarness exit code: 0
```

It suggests that in the try-catch block we're using LINQ function on an empty collection. It might happen if closing of tabs did not happen instantly but with a slight delay. Then the `while` condition was still true but when we call `Last()`, `windowHandles` is already an empty collection.
This should fix it.