### PR TITLE
Simplify checking for last window in WasmTestBrowserCommand.cs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -121,11 +121,10 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                     driver.Navigate().GoToUrl("about:blank");
                     driver.Close(); //Close Tab
 
-                    // this is not redundant, it prevents "System.InvalidOperationException: Sequence contains no elements"
-                    var windowHandles = driver.WindowHandles.ToList();
-                    if (windowHandles.Any())
+                    var lastWindowHandle = driver.WindowHandles.LastOrDefault();
+                    if (lastWindowHandle != null)
                     {
-                        driver.SwitchTo().Window(windowHandles.Last());
+                        driver.SwitchTo().Window(lastWindowHandle);
                     }
                 }
                 if (driverService.IsRunning)


### PR DESCRIPTION
@ilonatommy I think we should backport the fix to release/9.0 too.