### PR TITLE
Browser WBT on Chrome: avoid "no such window: target window already closed"

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -123,11 +123,11 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
 
                     var lastWindowHandle = driver.WindowHandles.LastOrDefault();
                     if (lastWindowHandle != null)
-                    {
+                    {   
                         driver.SwitchTo().Window(lastWindowHandle);
                     }
                 }
-                System.Threading.Thread.Sleep(1000);
+                await Task.Delay(TimeSpan.FromSeconds(1), cts.Token);
                 if (driverService.IsRunning)
                 {
                     if (!cts.IsCancellationRequested && driver.WindowHandles.Count != 0)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -123,7 +123,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
 
                     var lastWindowHandle = driver.WindowHandles.LastOrDefault();
                     if (lastWindowHandle != null)
-                    {   
+                    {
                         driver.SwitchTo().Window(lastWindowHandle);
                     }
                 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -129,7 +129,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                 }
                 if (driverService.IsRunning)
                 {
-                    if (!cts.IsCancellationRequested)
+                    if (!cts.IsCancellationRequested && driver.WindowHandles.Count != 0)
                     {
                         driver.Navigate().GoToUrl("about:config");
                         driver.Navigate().GoToUrl("about:blank");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -127,6 +127,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
                         driver.SwitchTo().Window(lastWindowHandle);
                     }
                 }
+                System.Threading.Thread.Sleep(1000);
                 if (driverService.IsRunning)
                 {
                     if (!cts.IsCancellationRequested && driver.WindowHandles.Count != 0)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/107466 - when running locally with the new chrome we're getting:
```
 [wasm test-browser] fail: Error while closing browser: OpenQA.Selenium.NoSuchWindowException: no such window: target window already closed
          [wasm test-browser] from unknown error: web view not found
          [wasm test-browser]   (Session info: chrome=128.0.6613.120)
          [wasm test-browser]          at OpenQA.Selenium.Remote.RemoteWebDriver.UnpackAndThrowOnError(Response errorResponse)
          [wasm test-browser]          at OpenQA.Selenium.Remote.RemoteWebDriver.Execute(String driverCommandToExecute, Dictionary`2 parameters)
          [wasm test-browser]          at OpenQA.Selenium.Remote.RemoteWebDriver.set_Url(String value)
          [wasm test-browser]          at OpenQA.Selenium.Remote.RemoteNavigator.GoToUrl(String url)
          [wasm test-browser]          at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.InvokeInternal(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs:line 134
```

We have while loop that is closing all the tabs but one. Because there might be delays in closing them, the conditions we're checking might not be deterministic. If because of delays `lastWindowHandle` was null, then we cannot do `driver.Navigate().GoToUrl("about:config");`  in case `driverService` is still running. It throws ` OpenQA.Selenium.NoSuchWindowException: no such window: target window already closed` then. To avoid it, we have to re-check if there's any window to perform this operation on.

We're adding an additional delay before final check for `driverService`.

An alternative would be to add a delay inside of the closing tabs loop, but that would not be deterministic and in case of having many tabs, would prolong the test execution. On the other hand, I haven't seen logs with more than 2 tabs attempting to get closed.