### PR TITLE
Access web driver's properties only in try-catch

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -105,11 +105,11 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
 
             // close all tabs before quit is a workaround for broken Selenium - GeckoDriver communication in Firefox
             // https://github.com/dotnet/runtime/issues/101617
-            logger.LogInformation($"Closing {driver.WindowHandles.Count} browser tabs before setting the main tab to config page and quitting.");
             var cts = new CancellationTokenSource();
             cts.CancelAfter(10000);
             try
             {
+                logger.LogInformation($"Closing {driver.WindowHandles.Count} browser tabs before setting the main tab to config page and quitting.");
                 while (driver.WindowHandles.Count > 1 && driverService.IsRunning)
                 {
                     if (cts.IsCancellationRequested)
@@ -265,7 +265,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
         if (Arguments.NoQuit)
             options.LeaveBrowserRunning = true;
 
-        logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)}");
+                logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)}");
 
         // We want to explicitly specify a timeout here. This is for for the
         // driver commands, like getLog. The default is 60s, which ends up

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -265,7 +265,7 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
         if (Arguments.NoQuit)
             options.LeaveBrowserRunning = true;
 
-                logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)}");
+        logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)}");
 
         // We want to explicitly specify a timeout here. This is for for the
         // driver commands, like getLog. The default is 60s, which ends up


### PR DESCRIPTION
Found on https://github.com/dotnet/runtime/pull/107795.
Accessing `WindowHandles` when the browser is disconnected will always result in exception. We have to move all code that accesses it to try-catch. The code in `try` is the cleanup code, so it's fine if we enter it on disconnected driver.

Error being fixed:
[log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-107795-merge-f7b359a15e1941c3ab/WasmTestOnChrome-MT-System.Net.WebSockets.Client.Tests/1/console.8bfd054e.log?helixlogtype=result)

```
[15:41:09] fail: Application has finished with exit code TIMED_OUT but 0 was expected
[15:41:09] crit: OpenQA.Selenium.WebDriverException: An unknown exception was encountered sending an HTTP request to the remote WebDriver server for URL http://localhost:33861/session/73a9a014d272c52eab96971e91026f34/window/handles. The exception message was: Connection refused (localhost:33861)
                  ---> System.Net.Http.HttpRequestException: Connection refused (localhost:33861)
............
at OpenQA.Selenium.Remote.RemoteWebDriver.get_WindowHandles()
                    at Microsoft.DotNet.XHarness.CLI.Commands.Wasm.WasmTestBrowserCommand.InvokeInternal(ILogger logger) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs:line 108
                    at Microsoft.DotNet.XHarness.CLI.Commands.XHarnessCommand`1.Invoke(IEnumerable`1 arguments) in /_/src/Microsoft.DotNet.XHarness.CLI/Commands/XHarnessCommand.cs:line 145
```
