### PR TITLE
Allow overwriting `PageLoadStrategy` in wasm tests

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Argument.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using OpenQA.Selenium;
 
 namespace Microsoft.DotNet.XHarness.CLI.CommandArguments;
 
@@ -281,6 +282,32 @@ public abstract class SwitchArgument : Argument<bool>
     }
 
     public override string ToString() => Value ? "true" : "false";
+}
+
+public abstract class EnumPageLoadStrategyArgument : Argument<PageLoadStrategy>
+{
+    private readonly PageLoadStrategy _defaultValue;
+
+    public EnumPageLoadStrategyArgument(string prototype, string description, PageLoadStrategy defaultValue)
+        : base(prototype, description, defaultValue)
+    {
+        _defaultValue = defaultValue;
+    }
+
+    public override void Action(string argumentValue)
+    {
+        if (string.IsNullOrEmpty(argumentValue))
+        {
+            Value = _defaultValue;
+        }
+        else
+        {
+            Value = argumentValue.ToLower().Equals("none") ? PageLoadStrategy.None :
+                argumentValue.ToLower().Equals("eager") ? PageLoadStrategy.Eager :
+                argumentValue.ToLower().Equals("normal") ? PageLoadStrategy.Normal :
+                _defaultValue;
+        }
+    }
 }
 
 public abstract class RepeatableArgument : Argument<IEnumerable<string>>

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/PageLoadStrategyArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/PageLoadStrategyArgument.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
+
+using OpenQA.Selenium;
+using System;
+
+internal class PageLoadStrategyArgument : EnumPageLoadStrategyArgument
+{
+    private const string HelpMessage =
+        $@"Decides how long WebDriver will hold off on completing a navigation method.
+        NORMAL (default): Does not block WebDriver at all. Ready state: complete.
+        EAGER: DOM access is ready, but other resources like images may still be loading. Ready state: interactive.
+        NONE: Does not block WebDriver at all. Ready state: any.";
+
+    public PageLoadStrategyArgument(PageLoadStrategy defaultValue)
+        : base("pageLoadStrategy=", HelpMessage, defaultValue)
+    {}
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -26,6 +26,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
     public NoQuitArgument NoQuit { get; } = new();
     public BackgroundThrottlingArgument BackgroundThrottling { get; } = new();
     public LocaleArgument Locale { get; } = new("en-US");
+    public PageLoadStrategyArgument PageLoadStrategy { get; } = new(OpenQA.Selenium.PageLoadStrategy.Normal);
 
     public SymbolMapFileArgument SymbolMapFileArgument { get; } = new();
     public SymbolicatePatternsFileArgument SymbolicatePatternsFileArgument { get; } = new();
@@ -56,6 +57,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
             NoQuit,
             BackgroundThrottling,
             Locale,
+            PageLoadStrategy,
             SymbolMapFileArgument,
             SymbolicatePatternsFileArgument,
             SymbolicatorArgument,

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -18,6 +18,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
     public OutputDirectoryArgument OutputDirectory { get; } = new();
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));
     public LocaleArgument Locale { get; } = new("en-US");
+    public PageLoadStrategyArgument PageLoadStrategy { get; } = new(OpenQA.Selenium.PageLoadStrategy.Normal);
 
     public SymbolMapFileArgument SymbolMapFileArgument { get; } = new();
     public SymbolicatePatternsFileArgument SymbolicatePatternsFileArgument { get; } = new();
@@ -42,6 +43,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
             Timeout,
             ExpectedExitCode,
             Locale,
+            PageLoadStrategy,
             SymbolMapFileArgument,
             SymbolicatePatternsFileArgument,
             SymbolicatorArgument,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -265,7 +265,10 @@ internal class WasmTestBrowserCommand : XHarnessCommand<WasmTestBrowserCommandAr
         if (Arguments.NoQuit)
             options.LeaveBrowserRunning = true;
 
-        logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)}");
+        if (options is ChromeOptions chromeOptions)
+            chromeOptions.PageLoadStrategy = Arguments.PageLoadStrategy.Value;
+
+        logger.LogInformation($"Starting {driverName} with args: {string.Join(' ', options.Arguments)} and load strategy: {Arguments.PageLoadStrategy.Value}");
 
         // We want to explicitly specify a timeout here. This is for for the
         // driver commands, like getLog. The default is 60s, which ends up


### PR DESCRIPTION
Trying to fix the new chrome bump: https://github.com/dotnet/runtime/pull/107504.

Till now we were running tests always with `PageLoadStrategy` with default value `Normal`. It is documented to have caused problems in testing with Selenium with older versions of chrome. This change does not change the default value, only provides an option to overwrite it. Because the failures are observed only on chrome, the change is limited to `ChromeOptions`.

https://www.selenium.dev/documentation/webdriver/drivers/options/#pageloadstrategy