### PR TITLE
Support downloading and installing simulator images with Xcode 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ MigrationBackup/
 
 # some ide stuff
 .idea
+
+.vscode/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Selenium.WebDriver" Version="4.0.0-alpha05" />
-    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.0.96" />
+    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.0.256" />
     <PackageVersion Include="NUnit" Version="3.13.0" />
     <PackageVersion Include="NUnit.Engine" Version="3.13.0" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -148,7 +148,7 @@ stages:
   parameters:
     name: E2E_Apple_Simulator_Commands
     displayName: Apple - Simulator Commands
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
 
 - template: eng/e2e-test.yml
   parameters:

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -148,7 +148,7 @@ stages:
   parameters:
     name: E2E_Apple_Simulator_Commands
     displayName: Apple - Simulator Commands
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
 
 - template: eng/e2e-test.yml
   parameters:

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
@@ -131,13 +131,17 @@ internal class InstallCommand : SimulatorsCommand
             else
             {
                 Logger.LogInformation($"Downloading and installing simulator: {simulator.Name} through xcodebuild with Xcode: {xcodeVersion}");
-                var (succeeded, stdout) = await ExecuteCommand("xcodebuild", TimeSpan.FromMinutes(15), "-downloadPlatform", simulator.Platform);
+                var (succeeded, stdout) = await ExecuteCommand("xcodebuild", TimeSpan.FromMinutes(15), "-downloadPlatform", simulator.Platform, "-verbose");
                 if (!succeeded)
                 {
                     Logger.LogError($"Download and installation failed through xcodebuild for simulator: {simulator.Name} with Xcode: {xcodeVersion}!" + Environment.NewLine + stdout);
                     return false;
                 }
-                return true;
+                else
+                {
+                    Logger.LogDebug(stdout);
+                    return true;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/Simulator.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/Simulator.cs
@@ -9,21 +9,25 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators;
 internal class Simulator
 {
     public string Name { get; }
+    public string Platform { get; }
     public string Identifier { get; }
     public string Version { get; }
-    public string Source { get; }
+    public string? Source { get; }
     public string InstallPrefix { get; }
     public long FileSize { get; }
     public bool IsDmgFormat { get; }
+    public bool IsCryptexDiskImage { get; }
 
-    public Simulator(string name, string identifier, string version, string source, string installPrefix, long fileSize)
+    public Simulator(string name, string platform, string identifier, string version, string? source, string installPrefix, long fileSize, bool isCryptexDiskImage)
     {
         Name = name;
+        Platform = platform;
         Identifier = identifier;
         Version = version;
         Source = source;
         InstallPrefix = installPrefix;
         FileSize = fileSize;
         IsDmgFormat = Identifier.StartsWith("com.apple.dmg.", StringComparison.OrdinalIgnoreCase);
+        IsCryptexDiskImage = isCryptexDiskImage;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -213,6 +213,8 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
             {
                 return null;
             }
+            Logger.LogDebug($"Listing runtime disk images via returned: {json}");
+
             string simulatorRuntime = "";
             string simulatorVersion = "";
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -108,13 +108,6 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
             var versionNode = downloadable.SelectSingleNode("key[text()='version']/following-sibling::string") ?? throw new Exception("Version node not found");
             var identifierNode = downloadable.SelectSingleNode("key[text()='identifier']/following-sibling::string") ?? throw new Exception("Identifier node not found");
             var sourceNode = downloadable.SelectSingleNode("key[text()='source']/following-sibling::string");
-            if (sourceNode is null)
-            {
-                // It seems that Apple can list beta simulators in the index file, but they do not provide a source for downloading them (eg: iOS 18.0 beta Simulator Runtime).
-                // In such cases log a warning and skip trying to download such simulator as they are not publicly available.
-                Logger.LogWarning($"Simulator with name: '{nameNode.InnerText}' version: '{versionNode.InnerText}' identifier: '{identifierNode.InnerText}' has no source for download, skipping...");
-                continue;
-            }
 
             var fileSizeNode = downloadable.SelectSingleNode("key[text()='fileSize']/following-sibling::integer|key[text()='fileSize']/following-sibling::real");
             var installPrefixNode = downloadable.SelectSingleNode("key[text()='userInfo']/following-sibling::dict/key[text()='InstallPrefix']/following-sibling::string");
@@ -144,13 +137,51 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
                 installPrefix = $"/Library/Developer/CoreSimulator/Profiles/Runtimes/{simRuntimeName}";
             }
 
+            var platform = name.Split(' ').FirstOrDefault();
+            if (platform is null)
+            {
+                Logger.LogWarning($"Platform name could not be parsed from simulator name: '{nameNode.InnerText}' version: '{versionNode.InnerText}' identifier: '{identifierNode.InnerText}' skipping...");
+                continue;
+            }
+
+            var source = ReplaceStringUsingKey(sourceNode?.InnerText, dict);
+            var isCryptexDiskImage = false;
+            if (source is null)
+            {
+                // We allow source to be missing for newer simulators (e.g., iOS 18+ available from Xcode 16) that use cryptographically-sealed archives.
+                // Eg.:
+                // <dict>
+                //     <key>category</key>
+                //     <string>simulator</string>
+                //     <key>contentType</key>
+                //     <string>cryptexDiskImage</string>
+                //     ...
+                // These images are downloaded and installed through xcodebuild instead.
+                // https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-from-the-command-line
+                var contentTypeNode = downloadable.SelectSingleNode("key[text()='contentType']/following-sibling::string") ?? throw new Exception("ContentType node not found");
+                var contentType = contentTypeNode.InnerText;
+                if (contentType.Equals("cryptexDiskImage", StringComparison.OrdinalIgnoreCase))
+                {
+                    isCryptexDiskImage = true;
+                    Logger.LogInformation($"Simulator with name: '{nameNode.InnerText}' version: '{versionNode.InnerText}' identifier: '{identifierNode.InnerText}' has no source but it is a cryptex disk image which can be downloaded through xcodebuild.");
+                }
+                else
+                {
+                    Logger.LogWarning($"Simulator with name: '{nameNode.InnerText}' version: '{versionNode.InnerText}' identifier: '{identifierNode.InnerText}' has no source for download nor it is a cryptex disk image, skipping...");
+                    continue;
+                }
+            }
+
             simulators.Add(new Simulator(
                 name: name,
+                platform: platform,
                 identifier: ReplaceStringUsingKey(identifierNode.InnerText, dict),
                 version: versionNode.InnerText,
-                source: ReplaceStringUsingKey(sourceNode.InnerText, dict),
+                source: source,
                 installPrefix: installPrefix,
-                fileSize: (long)parsedFileSize));
+                fileSize: (long)parsedFileSize,
+                isCryptexDiskImage: isCryptexDiskImage
+                ));
         }
 
         return simulators;
@@ -385,7 +416,7 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
         return false;
     }
 
-    private async Task<string> GetXcodeVersion()
+    protected async Task<string> GetXcodeVersion()
     {
         if (_xcodeVersion is not null)
         {

--- a/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
@@ -29,6 +29,8 @@
         <![CDATA[
           set -ex
           deviceId=`xharness apple device $target`
+          xharness apple simulators install $target --verbosity=Debug
+          xharness apple simulators reset-simulator --output-directory="$output_directory" --target=$target --verbosity=Debug
           xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v
           set +e
           result=0

--- a/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.13.amd64.open"/>
+    <iOSSimulatorVersionUnderTest>16.4</iOSSimulatorVersionUnderTest>
   </ItemGroup>
 
   <PropertyGroup>
@@ -21,7 +22,7 @@
 
     <ItemGroup>
       <XHarnessAppBundleToTest Include="$(TestAppDestinationDir)\$(TestAppBundleName).app">
-        <TestTarget>ios-simulator-64</TestTarget>
+        <TestTarget>ios-simulator-64_$(iOSSimulatorVersionUnderTest)</TestTarget>
         <WorkItemTimeout>00:20:00</WorkItemTimeout>
         <TestTimeout>00:07:00</TestTimeout>
         <LaunchTimeout>00:03:30</LaunchTimeout>

--- a/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
@@ -32,9 +32,9 @@
         <CustomCommands>
         <![CDATA[
           set -ex
-          deviceId=`xharness apple device $target`
           xharness apple simulators install $target --verbosity=Debug
           xharness apple simulators reset-simulator --output-directory="$output_directory" --target=$target --verbosity=Debug
+          deviceId=`xharness apple device $target`
           xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v
           set +e
           result=0

--- a/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
@@ -2,8 +2,11 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.13.amd64.open"/>
-    <iOSSimulatorVersionUnderTest>16.4</iOSSimulatorVersionUnderTest>
   </ItemGroup>
+
+  <PropertyGroup>
+    <iOSSimulatorVersionUnderTest>16.4</iOSSimulatorVersionUnderTest>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TestAppBundleName>System.Numerics.Vectors.Tests</TestAppBundleName>

--- a/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk">
+
+  <ItemGroup>
+    <!-- Adjust to the desired souting queue. -->
+    <HelixTargetQueue Include="osx.amd64.iphone.scouting.open"/>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- 
+      Change to specify the exact Xcode version for testing.
+      In the CustomCommands below we can probe installed Xcode versions on Helix with `ls -al /Applications` and then choosing the write path.
+    -->
+    <XcodeVersionUnderTest>Xcode_16_beta_6</XcodeVersionUnderTest>
+    <iOSSimulatorVersionUnderTest>18.0</iOSSimulatorVersionUnderTest>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TestAppBundleName>System.Numerics.Vectors.Tests</TestAppBundleName>
+    <XHarnessTestAppBundleUrl>$(AssetsBaseUri)/ios/test-app/ios-simulator-64/$(TestAppBundleName).app.zip</XHarnessTestAppBundleUrl>
+    <TestAppDestinationDir>$(ArtifactsTmpDir)test-app\ios-simulator-64</TestAppDestinationDir>
+  </PropertyGroup>
+
+  <Target Name="TestApple" BeforeTargets="CoreTest">
+    <DownloadFile SourceUrl="$(XHarnessTestAppBundleUrl)" DestinationFolder="$(TestAppDestinationDir)" SkipUnchangedFiles="True" Retries="5">
+      <Output TaskParameter="DownloadedFile" ItemName="ZippedAppBundle" />
+    </DownloadFile>
+
+    <Message Text="Downloaded $(TestAppBundleName) from @(ZippedAppBundle). Extracting..." Importance="High" />
+    <Exec Command="tar -xzf @(ZippedAppBundle) -C $(TestAppDestinationDir)" />
+    <Message Text="Extracted to $(TestAppDestinationDir)" Importance="High" />
+
+    <ItemGroup>
+      <XHarnessAppBundleToTest Include="$(TestAppDestinationDir)\$(TestAppBundleName).app">
+        <TestTarget>ios-simulator-64_$(iOSSimulatorVersionUnderTest)</TestTarget>
+        <WorkItemTimeout>00:20:00</WorkItemTimeout>
+        <TestTimeout>00:07:00</TestTimeout>
+        <LaunchTimeout>00:03:30</LaunchTimeout>
+        <CustomCommands>
+        <![CDATA[
+          set -ex
+          xharness apple simulators install $target --verbosity=Debug --xcode /Applications/$(XcodeVersionUnderTest).app
+          xharness apple simulators reset-simulator --output-directory="$output_directory" --target=$target --verbosity=Debug --xcode /Applications/$(XcodeVersionUnderTest).app
+          deviceId=`xharness apple device $target`
+          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v --xcode /Applications/$(XcodeVersionUnderTest).app
+          set +e
+          result=0
+          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v --xcode /Applications/$(XcodeVersionUnderTest).app
+          ((result|=$?))
+          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v --xcode /Applications/$(XcodeVersionUnderTest).app
+          ((result|=$?))
+          exit $result
+        ]]>
+        </CustomCommands>
+      </XHarnessAppBundleToTest>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -1,0 +1,20 @@
+# Integration tests
+
+This folder includes integration tests projects for different support platforms (iOS, Android, WASM).
+They are used in end-to-end testing scenarios and are referenced from `azure-pipelines-public.yml` E2E templates.
+
+In the relevant `*.proj` files one can configure various setting for execution on Helix like:
+- configuring the Helix queue (e.g., `osx.13.amd64.iphone.open` via `HelixTargetQueue` item group)
+- app bundle to download, send to Helix and test (e.g., `System.Buffers.Tests.app`)
+- etc.
+
+## Testing on scouting queue
+
+NOTE: This is Apple-specific but can be applied to other platforms as well
+
+There are two test projects which can be used on scouting queues which are not used by default:
+
+- Apple/Simulator.Scouting.Tests.proj
+- Apple/Simulator.Scouting.Commands.Tests.proj
+
+When desired, these can be included in the `azure-pipelines-public.yml` so that the CI runs them on a desired scouting queue (check the `HelixTargetQueue` setting) with a particular version of Xcode.


### PR DESCRIPTION
## Description

### Xcode 16 change

From Xcode 16 Apple stopped providing sources for downloading newer simulator runtime images. 

If we consider `watchOS 10.5 Simulator Runtime` and `iOS 18.0 beta Simulator Runtime` from https://devimages-cdn.apple.com/downloads/xcode/simulators/index2.dvtdownloadableindex we can see that source is not provided for the latter:

```xml
<dict>
	<key>authentication</key>
	<string>virtual</string>
	<key>category</key>
	<string>simulator</string>
	<key>contentType</key>
	<string>diskImage</string>
	<key>dictionaryVersion</key>
	<integer>2</integer>
	<key>fileSize</key>
	<integer>3946536779</integer>
	<key>identifier</key>
	<string>com.apple.dmg.WatchSimulatorSDK10_5</string>
	<key>name</key>
	<string>watchOS 10.5 Simulator Runtime</string>
	<key>platform</key>
	<string>com.apple.platform.watchos</string>
	<key>simulatorVersion</key>
	<dict>
		<key>buildUpdate</key>
		<string>21T575</string>
		<key>version</key>
		<string>10.5</string>
	</dict>
	<key>source</key>
	<string>https://download.developer.apple.com/Developer_Tools/watchOS_10.5_Simulator_Runtime/watchOS_10.5_Simulator_Runtime.dmg</string>
	<key>version</key>
	<string>10.5.0.0</string>
</dict>
<dict>
	<key>category</key>
	<string>simulator</string>
	<key>contentType</key>
	<string>cryptexDiskImage</string>
	<key>dictionaryVersion</key>
	<integer>2</integer>
	<key>downloadMethod</key>
	<string>mobileAsset</string>
	<key>fileSize</key>
	<integer>8455760175</integer>
	<key>identifier</key>
	<string>com.apple.dmg.iPhoneSimulatorSDK18_0_b1</string>
	<key>name</key>
	<string>iOS 18.0 beta Simulator Runtime</string>
	<key>platform</key>
	<string>com.apple.platform.iphoneos</string>
	<key>simulatorVersion</key>
	<dict>
		<key>buildUpdate</key>
		<string>22A5282m</string>
		<key>version</key>
		<string>18.0</string>
	</dict>
	<key>version</key>
	<string>18.0.0.1</string>
</dict>
```

The new images which do not have a source for download (in the above case `iOS 18.0 beta Simulator Runtime`) are classified as cryptographically-sealed disk images a.k.a `cryptexDiskImage` via `contentType` property in the XML which we can use to differentiate between the old and the new ones.

### Recommendation

The recommended way of downloading and installing the new simulator runtimes is to use:
```
xcodebuild -downloadPlatform <platform>
```
as specified in: https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes#Install-and-manage-Simulator-runtimes-from-the-command-line. However, this approach does not seem to allow specifying a particular version of the simulator runtime, but rather installs the latest one available for a specific Xcode version.

Furthermore, Apple states they will stop hosting images publicly:
```
The simulator runtimes are available on [Apple Developer website](https://developer.apple.com/download/all/?q=Simulator%20Runtime), but will no longer be posted through the website in future updates.
```

## How does it affect xharness?

### Short-term solution

As a short term solution, we can use the recommended approach to download and install the simulator runtimes through `xcodebuild` if we are using Xcode 16+. 

### Long-term solution

With the recommended approach, currently there does not seem to be a way of specifying a specific version (or the build number) of the simulator runtime to be installed. To overcome this, for our internal testing and backward compatibility, we might want to consider hosting older simulator images on our own, and adapt xharness with functionality to fallback to internal feeds when a specific version is requested. This would be a "in-house" solution and would not be available for public use.

## Changes

This PR implements the `Short-term solution` solution by:
- Adapting the code to use `xcodebuild -downloadPlatform <platform>` for downloading and installing the new simulator runtimes with Xcode 16+.  
- Bumping `mlaunch` version to be compatible with Xcode 16+
- Adding description and test project for testing in scouting queues (queues used for testing new/beta versions of Xcode) 

## Testing

Xcode 16 is currently only available on scouting queue which was tested in: https://github.com/dotnet/xharness/pull/1277/commits/1fd9292b2e8b0cd489bd88c23a2a528ed8125085 and results are available [here](https://helixre107v0xdeko0k025g8.blob.core.windows.net/dotnet-xharness-refs-pull-1277-merge-1575e564c89b429f8a/System.Numerics.Vectors.Tests/1/console.cd9d9f8c.log?helixlogtype=result).
