### PR TITLE
[release/8.0] Support downloading and installing simulator images with Xcode 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ MigrationBackup/
 
 # some ide stuff
 .idea
+
+.vscode/

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/InstallCommand.cs
@@ -121,6 +121,30 @@ internal class InstallCommand : SimulatorsCommand
 
     private async Task<bool> Install(Simulator simulator)
     {
+        if (simulator.Source is null)
+        {
+            var xcodeVersion = await GetXcodeVersion();
+            if (!simulator.IsCryptexDiskImage || Version.Parse(xcodeVersion).Major < 16)
+            {
+                throw new Exception($"Cannot download simulator: {simulator.Name} from source nor through Xcode: {xcodeVersion}");
+            }
+            else
+            {
+                Logger.LogInformation($"Downloading and installing simulator: {simulator.Name} through xcodebuild with Xcode: {xcodeVersion}");
+                var (succeeded, stdout) = await ExecuteCommand("xcodebuild", TimeSpan.FromMinutes(15), "-downloadPlatform", simulator.Platform, "-verbose");
+                if (!succeeded)
+                {
+                    Logger.LogError($"Download and installation failed through xcodebuild for simulator: {simulator.Name} with Xcode: {xcodeVersion}!" + Environment.NewLine + stdout);
+                    return false;
+                }
+                else
+                {
+                    Logger.LogDebug(stdout);
+                    return true;
+                }
+            }
+        }
+
         var filename = Path.GetFileName(simulator.Source);
         var downloadPath = Path.Combine(TempDirectory, filename);
         var download = true;

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/Simulator.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/Simulator.cs
@@ -9,21 +9,25 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Apple.Simulators;
 internal class Simulator
 {
     public string Name { get; }
+    public string Platform { get; }
     public string Identifier { get; }
     public string Version { get; }
-    public string Source { get; }
+    public string? Source { get; }
     public string InstallPrefix { get; }
     public long FileSize { get; }
     public bool IsDmgFormat { get; }
+    public bool IsCryptexDiskImage { get; }
 
-    public Simulator(string name, string identifier, string version, string source, string installPrefix, long fileSize)
+    public Simulator(string name, string platform, string identifier, string version, string? source, string installPrefix, long fileSize, bool isCryptexDiskImage)
     {
         Name = name;
+        Platform = platform;
         Identifier = identifier;
         Version = version;
         Source = source;
         InstallPrefix = installPrefix;
         FileSize = fileSize;
         IsDmgFormat = Identifier.StartsWith("com.apple.dmg.", StringComparison.OrdinalIgnoreCase);
+        IsCryptexDiskImage = isCryptexDiskImage;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Tools.Mlaunch" Version="1.0.95">
+    <PackageReference Include="Microsoft.Tools.Mlaunch" Version="1.0.256">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Commands.Tests.proj
@@ -1,12 +1,17 @@
-<Project DefaultTargets="Test">
-  <Import Project="../Helix.SDK.configuration.props"/>
+<Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.13.amd64.open"/>
+    <!-- Adjust to the desired souting queue. -->
+    <HelixTargetQueue Include="osx.amd64.iphone.scouting.open"/>
   </ItemGroup>
 
   <PropertyGroup>
-    <iOSSimulatorVersionUnderTest>16.4</iOSSimulatorVersionUnderTest>
+    <!-- 
+      Change to specify the exact Xcode version for testing.
+      In the CustomCommands below we can probe installed Xcode versions on Helix with `ls -al /Applications` and then choosing the write path.
+    -->
+    <XcodeVersionUnderTest>Xcode_16_beta_6</XcodeVersionUnderTest>
+    <iOSSimulatorVersionUnderTest>18.0</iOSSimulatorVersionUnderTest>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -33,15 +38,15 @@
         <CustomCommands>
         <![CDATA[
           set -ex
-          xharness apple simulators install $target --verbosity=Debug
-          xharness apple simulators reset-simulator --output-directory="$output_directory" --target=$target --verbosity=Debug
+          xharness apple simulators install $target --verbosity=Debug --xcode /Applications/$(XcodeVersionUnderTest).app
+          xharness apple simulators reset-simulator --output-directory="$output_directory" --target=$target --verbosity=Debug --xcode /Applications/$(XcodeVersionUnderTest).app
           deviceId=`xharness apple device $target`
-          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v
+          xharness apple install -t=$target --device="$deviceId" -o="$output_directory" --app="$app" --timeout=$launch_timeout -v --xcode /Applications/$(XcodeVersionUnderTest).app
           set +e
           result=0
-          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v
+          xharness apple just-test -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" --launch-timeout=$launch_timeout --timeout=$timeout -v --xcode /Applications/$(XcodeVersionUnderTest).app
           ((result|=$?))
-          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v
+          xharness apple uninstall -t=$target --device="$deviceId" -o="$output_directory" --app="net.dot.$(TestAppBundleName)" -v --xcode /Applications/$(XcodeVersionUnderTest).app
           ((result|=$?))
           exit $result
         ]]>
@@ -50,5 +55,4 @@
     </ItemGroup>
   </Target>
 
-  <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets"/>
 </Project>

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -1,0 +1,20 @@
+# Integration tests
+
+This folder includes integration tests projects for different support platforms (iOS, Android, WASM).
+They are used in end-to-end testing scenarios and are referenced from `azure-pipelines-public.yml` E2E templates.
+
+In the relevant `*.proj` files one can configure various setting for execution on Helix like:
+- configuring the Helix queue (e.g., `osx.13.amd64.iphone.open` via `HelixTargetQueue` item group)
+- app bundle to download, send to Helix and test (e.g., `System.Buffers.Tests.app`)
+- etc.
+
+## Testing on scouting queue
+
+NOTE: This is Apple-specific but can be applied to other platforms as well
+
+There are two test projects which can be used on scouting queues which are not used by default:
+
+- Apple/Simulator.Scouting.Tests.proj
+- Apple/Simulator.Scouting.Commands.Tests.proj
+
+When desired, these can be included in the `azure-pipelines-public.yml` so that the CI runs them on a desired scouting queue (check the `HelixTargetQueue` setting) with a particular version of Xcode.


### PR DESCRIPTION
Backport of: https://github.com/dotnet/xharness/pull/1277 to release/8.0