### PR TITLE
[android] Add warning message when Android devices have package verification enabled

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -19,46 +19,46 @@ pr:
 # Build
 
 stages:
-# - stage: Build_Windows_NT
-#   displayName: Build Windows
-#   jobs:
-#   - template: /eng/common/templates/jobs/jobs.yml
-#     parameters:
-#       enableTelemetry: true
-#       enablePublishBuildArtifacts: true
-#       enableMicrobuild: true
-#       enablePublishUsingPipelines: true
-#       enablePublishBuildAssets: true
-#       helixRepo: dotnet/xharness
+- stage: Build_Windows_NT
+  displayName: Build Windows
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableTelemetry: true
+      enablePublishBuildArtifacts: true
+      enableMicrobuild: true
+      enablePublishUsingPipelines: true
+      enablePublishBuildAssets: true
+      helixRepo: dotnet/xharness
 
-#       jobs:
-#       - job: Windows_NT
-#         pool:
-#             name: $(DncEngPublicBuildPool)
-#             demands: ImageOverride -equals 1es-windows-2022-open
-#         strategy:
-#           matrix:
-#             Release:
-#               _BuildConfig: Release
-#             Debug:
-#               _BuildConfig: Debug
-#         steps:
-#         - script: eng\common\CIBuild.cmd
-#             -configuration $(_BuildConfig)
-#             -prepareMachine
-#           name: Build
-#           displayName: Build and run tests
-#           condition: succeeded()
+      jobs:
+      - job: Windows_NT
+        pool:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals 1es-windows-2022-open
+        strategy:
+          matrix:
+            Release:
+              _BuildConfig: Release
+            Debug:
+              _BuildConfig: Debug
+        steps:
+        - script: eng\common\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+          name: Build
+          displayName: Build and run tests
+          condition: succeeded()
 
-#         - task: PublishTestResults@2
-#           displayName: 'Publish Unit Test Results'
-#           inputs:
-#             testResultsFormat: xUnit
-#             testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
-#             mergeTestResults: true
-#             searchFolder: $(system.defaultworkingdirectory)
-#             testRunTitle: XHarness unit tests - $(Agent.JobName)
-#           condition: succeededOrFailed()
+        - task: PublishTestResults@2
+          displayName: 'Publish Unit Test Results'
+          inputs:
+            testResultsFormat: xUnit
+            testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
+            mergeTestResults: true
+            searchFolder: $(system.defaultworkingdirectory)
+            testRunTitle: XHarness unit tests - $(Agent.JobName)
+          condition: succeededOrFailed()
 
 - stage: Build_OSX
   displayName: Build OSX
@@ -108,11 +108,11 @@ stages:
 
 # E2E tests
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Android_Simulators
-#     displayName: Android - Simulators
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Android_Simulators
+    displayName: Android - Simulators
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj
 
 - template: eng/e2e-test.yml
   parameters:
@@ -120,50 +120,50 @@ stages:
     displayName: Android - Devices
     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Device.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Android_Manual_Commands
-#     displayName: Android - Manual Commands
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Android_Manual_Commands
+    displayName: Android - Manual Commands
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Apple_Simulators
-#     displayName: Apple - Simulators
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Apple_Simulators
+    displayName: Apple - Simulators
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_iOS_Devices
-#     displayName: Apple - iOS devices
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_iOS_Devices
+    displayName: Apple - iOS devices
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_tvOS_Devices
-#     displayName: Apple - tvOS devices
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_tvOS_Devices
+    displayName: Apple - tvOS devices
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Apple_Simulator_Commands
-#     displayName: Apple - Simulator Commands
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Apple_Simulator_Commands
+    displayName: Apple - Simulator Commands
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Apple_Device_Commands
-#     displayName: Apple - Device Commands
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Apple_Device_Commands
+    displayName: Apple - Device Commands
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_Apple_Simulator_Mgmt
-#     displayName: Apple - Simulator management
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_Apple_Simulator_Mgmt
+    displayName: Apple - Simulator management
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
 
-# - template: eng/e2e-test.yml
-#   parameters:
-#     name: E2E_WASM
-#     displayName: WASM
-#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
+- template: eng/e2e-test.yml
+  parameters:
+    name: E2E_WASM
+    displayName: WASM
+    testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -19,46 +19,46 @@ pr:
 # Build
 
 stages:
-- stage: Build_Windows_NT
-  displayName: Build Windows
-  jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableTelemetry: true
-      enablePublishBuildArtifacts: true
-      enableMicrobuild: true
-      enablePublishUsingPipelines: true
-      enablePublishBuildAssets: true
-      helixRepo: dotnet/xharness
+# - stage: Build_Windows_NT
+#   displayName: Build Windows
+#   jobs:
+#   - template: /eng/common/templates/jobs/jobs.yml
+#     parameters:
+#       enableTelemetry: true
+#       enablePublishBuildArtifacts: true
+#       enableMicrobuild: true
+#       enablePublishUsingPipelines: true
+#       enablePublishBuildAssets: true
+#       helixRepo: dotnet/xharness
 
-      jobs:
-      - job: Windows_NT
-        pool:
-            name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals 1es-windows-2022-open
-        strategy:
-          matrix:
-            Release:
-              _BuildConfig: Release
-            Debug:
-              _BuildConfig: Debug
-        steps:
-        - script: eng\common\CIBuild.cmd
-            -configuration $(_BuildConfig)
-            -prepareMachine
-          name: Build
-          displayName: Build and run tests
-          condition: succeeded()
+#       jobs:
+#       - job: Windows_NT
+#         pool:
+#             name: $(DncEngPublicBuildPool)
+#             demands: ImageOverride -equals 1es-windows-2022-open
+#         strategy:
+#           matrix:
+#             Release:
+#               _BuildConfig: Release
+#             Debug:
+#               _BuildConfig: Debug
+#         steps:
+#         - script: eng\common\CIBuild.cmd
+#             -configuration $(_BuildConfig)
+#             -prepareMachine
+#           name: Build
+#           displayName: Build and run tests
+#           condition: succeeded()
 
-        - task: PublishTestResults@2
-          displayName: 'Publish Unit Test Results'
-          inputs:
-            testResultsFormat: xUnit
-            testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
-            mergeTestResults: true
-            searchFolder: $(system.defaultworkingdirectory)
-            testRunTitle: XHarness unit tests - $(Agent.JobName)
-          condition: succeededOrFailed()
+#         - task: PublishTestResults@2
+#           displayName: 'Publish Unit Test Results'
+#           inputs:
+#             testResultsFormat: xUnit
+#             testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/**/*.xml'
+#             mergeTestResults: true
+#             searchFolder: $(system.defaultworkingdirectory)
+#             testRunTitle: XHarness unit tests - $(Agent.JobName)
+#           condition: succeededOrFailed()
 
 - stage: Build_OSX
   displayName: Build OSX
@@ -108,11 +108,11 @@ stages:
 
 # E2E tests
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Android_Simulators
-    displayName: Android - Simulators
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Android_Simulators
+#     displayName: Android - Simulators
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Simulator.Tests.proj
 
 - template: eng/e2e-test.yml
   parameters:
@@ -120,50 +120,50 @@ stages:
     displayName: Android - Devices
     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Device.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Android_Manual_Commands
-    displayName: Android - Manual Commands
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Android_Manual_Commands
+#     displayName: Android - Manual Commands
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Android/Commands.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Apple_Simulators
-    displayName: Apple - Simulators
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Apple_Simulators
+#     displayName: Apple - Simulators
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_iOS_Devices
-    displayName: Apple - iOS devices
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_iOS_Devices
+#     displayName: Apple - iOS devices
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.iOS.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_tvOS_Devices
-    displayName: Apple - tvOS devices
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_tvOS_Devices
+#     displayName: Apple - tvOS devices
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.tvOS.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Apple_Simulator_Commands
-    displayName: Apple - Simulator Commands
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Apple_Simulator_Commands
+#     displayName: Apple - Simulator Commands
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Apple_Device_Commands
-    displayName: Apple - Device Commands
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Apple_Device_Commands
+#     displayName: Apple - Device Commands
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/Device.Commands.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_Apple_Simulator_Mgmt
-    displayName: Apple - Simulator management
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_Apple_Simulator_Mgmt
+#     displayName: Apple - Simulator management
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
 
-- template: eng/e2e-test.yml
-  parameters:
-    name: E2E_WASM
-    displayName: WASM
-    testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj
+# - template: eng/e2e-test.yml
+#   parameters:
+#     name: E2E_WASM
+#     displayName: WASM
+#     testProject: $(Build.SourcesDirectory)/tests/integration-tests/WASM/WASM.Helix.SDK.Tests.proj

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -115,8 +115,7 @@ Arguments:
 
             logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 
-            if (!runner.AdjustPackageVerificationSettings())
-                return ExitCode.PACKAGE_INSTALLATION_FAILURE;
+            runner.CheckPackageVerificationSettings();
 
             // If anything changed about the app, Install will fail; uninstall it first.
             // (we'll ignore if it's not present)

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -115,6 +115,9 @@ Arguments:
 
             logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
 
+            if (!runner.AdjustPackageVerificationSettings())
+                return ExitCode.PACKAGE_INSTALLATION_FAILURE;
+
             // If anything changed about the app, Install will fail; uninstall it first.
             // (we'll ignore if it's not present)
             // This is where mismatched architecture APKs fail.
@@ -128,7 +131,6 @@ Arguments:
 
             runner.KillApk(apkPackageName);
         }
-        
         return ExitCode.SUCCESS;
     }
 }


### PR DESCRIPTION
## Description

This PR adds functionality to check if a physical Android device is configured to correctly to allow debug APK installs.
Additionally, it prints out warning messages in cases the package verifier is not properly disabled which can lead to `INSTALL_FAILED_VERIFICATION_FAILURE` errors.

## Follow-up work

- [ ] https://github.com/dotnet/dnceng/issues/4253
- If tests start failing again the warning message can be tracked with Build Analysis to record which Helix/tethered devices are affected