### PR TITLE
Improve exception handling

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -270,9 +270,9 @@ public class AdbRunner
                     {
                         KillAdbServer();
                     }
-                    catch
+                    catch (Exception e)
                     {
-                        _log.LogDebug($"Error killing ADB server after a failed start");
+                        _log.LogError($"Error killing ADB server after a failed start: {e.Message}");
                     }
                 }
                 else

--- a/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/Execution/AdbProcessManager.cs
@@ -86,7 +86,13 @@ public class AdbProcessManager : IAdbProcessManager
             exitCode = (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT;
 
             // try to terminate the process
-            try { p.Kill(); } catch { }
+            try
+            {
+                p.Kill();
+            } catch (Exception e) {
+                _log.LogError($"Failed to kill process: {e.Message}");
+            }
+
         }
         else
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/ExitCodeDetector.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/ExitCodeDetector.cs
@@ -41,7 +41,7 @@ public abstract class ExitCodeDetector : IExitCodeDetector
         }
         catch (FileNotFoundException e)
         {
-            throw new Exception("Failed to detect application's exit code. The log file was empty / not found at " + e.FileName);
+            throw new Exception("Failed to detect application's exit code. The log file was empty / not found at " + e.FileName, e);
         }
 
         using (reader)
@@ -86,7 +86,7 @@ public class iOSExitCodeDetector : ExitCodeDetector, IiOSExitCodeDetector
     // Example line coming from the mlaunch log
     // [07:02:21.6637600] Application 'net.dot.iOS.Simulator.PInvoke.Test' terminated (with exit code '42' and/or crashing signal ').
     private Regex DeviceExitCodeRegex { get; } = new Regex(@"terminated \(with exit code '(?<exitCode>-?[0-9]+)' and/or crashing signal", RegexOptions.Compiled);
-    
+
     protected override Match? IsSignalLine(AppBundleInformation appBundleInfo, string logLine)
     {
         if (base.IsSignalLine(appBundleInfo, logLine) is Match match && match.Success)

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceArchitectureArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/DeviceArchitectureArgument.cs
@@ -22,11 +22,11 @@ internal class DeviceArchitectureArgument : RepeatableArgument
             {
                 AndroidArchitectureHelper.ParseAsAndroidArchitecture(archName);
             }
-            catch (ArgumentOutOfRangeException)
+            catch (ArgumentOutOfRangeException e)
             {
                 throw new ArgumentException(
                     $"Failed to parse architecture '{archName}'. Available architectures are:" +
-                    GetAllowedValues<AndroidArchitecture>(t => t.AsString()));
+                    GetAllowedValues<AndroidArchitecture>(t => t.AsString()), e);
             }
         }
     }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/TargetArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Apple/Arguments/TargetArgument.cs
@@ -23,13 +23,13 @@ internal class TargetArgument : Argument<TestTargetOs>
         {
             Value = argumentValue.ParseAsAppRunnerTargetOs();
         }
-        catch (ArgumentOutOfRangeException)
+        catch (ArgumentOutOfRangeException e)
         {
             throw new ArgumentException(
                 $"Failed to parse test target '{argumentValue}'. Available targets are:" +
                 GetAllowedValues(t => t.AsString(), invalidValues: TestTarget.None) +
                 Environment.NewLine + Environment.NewLine +
-                "You can also specify desired OS version, e.g. ios-simulator-64_13.4");
+                "You can also specify desired OS version, e.g. ios-simulator-64_13.4", e);
         }
     }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Apple/Simulators/SimulatorsCommand.cs
@@ -251,7 +251,7 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
             foreach(JsonProperty sim in simulators.RootElement.EnumerateObject())
             {
                 if (sim.Value.GetProperty("runtimeIdentifier").GetString() == runtimeIdentifier)
-                { 
+                {
                     var version = sim.Value.GetProperty("version").GetString();
                     if (version == null)
                         return null;
@@ -305,12 +305,12 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
             {
                 target = argument.ParseAsAppRunnerTargetOs();
             }
-            catch (ArgumentOutOfRangeException)
+            catch (ArgumentOutOfRangeException e)
             {
                 throw new ArgumentException(
                     $"Failed to parse simulator '{argument}'. Available values are ios-simulator, tvos-simulator, watchos-simulator and xros-simulator." +
                     Environment.NewLine + Environment.NewLine +
-                    "You need to also specify the version. Example: ios-simulator_13.4");
+                    "You need to also specify the version. Example: ios-simulator_13.4", e);
             }
 
             if (string.IsNullOrEmpty(target.OSVersion))
@@ -349,14 +349,14 @@ internal abstract class SimulatorsCommand : XHarnessCommand<SimulatorsCommandArg
         {
             /*
             * The following url was found while debugging Xcode, the "index2" part is actually hardcoded:
-            * 
+            *
             *	DVTFoundation`-[DVTDownloadableIndexSource identifier]:
             *		0x103db478d <+0>:  pushq  %rbp
             *		0x103db478e <+1>:  movq   %rsp, %rbp
             *		0x103db4791 <+4>:  leaq   0x53f008(%rip), %rax      ; @"index2"
             *		0x103db4798 <+11>: popq   %rbp
             *		0x103db4799 <+12>: retq
-            * 
+            *
             */
             indexName = $"index-{xcodeVersion}.dvtdownloadableindex";
             indexUrl = "https://devimages-cdn.apple.com/downloads/xcode/simulators/index2.dvtdownloadableindex";

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -242,7 +242,9 @@ internal class WasmBrowserTestRunner
             }
         }
         catch (WebDriverException wde) when (wde.Message.Contains("timed out after"))
-        { }
+        {
+            _logger.LogDebug(wde.Message);
+        }
         catch (Exception ex)
         {
             _logger.LogDebug($"Failed trying to read log messages via selenium: {ex}");

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -170,8 +170,9 @@ public class WasmTestMessagesProcessor
                     line = message;
                 }
             }
-            catch (JsonException)
+            catch (JsonException e)
             {
+                _logger.LogError(e.Message);
                 line = message;
             }
         }

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/MacOSProcessManager.cs
@@ -47,11 +47,11 @@ public class MacOSProcessManager : UnixProcessManager, IMacOSProcessManager
                     doc.Load(plistPath);
                     _xcode_version = Version.Parse(doc.SelectSingleNode("//key[text() = 'CFBundleShortVersionString']/following-sibling::string")?.InnerText ?? throw new Exception("Failed to find the CFBundleShortVersionString property"));
                 }
-                catch (IOException)
+                catch (IOException e)
                 {
                     throw new Exception(
                         $"Failed to find Xcode! Version.plist missing at {plistPath}. " +
-                        "Please make sure xcode-select is set up, or the path to Xcode is supplied as an argument.");
+                        "Please make sure xcode-select is set up, or the path to Xcode is supplied as an argument.", e);
                 }
             }
             return _xcode_version;

--- a/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/Execution/ProcessManager.cs
@@ -136,9 +136,9 @@ public abstract class ProcessManager : IProcessManager
                     {
                         File.Delete(template);
                     }
-                    catch
+                    catch (Exception e)
                     {
-                        // Don't care
+                        log.WriteLine(e.Message);
                     }
                 }
             }
@@ -298,12 +298,17 @@ public abstract class ProcessManager : IProcessManager
             {
                 hasExited = process.HasExited;
             }
-            catch
+            catch (InvalidOperationException e)
             {
                 // Process.HasExited can sometimes throw exceptions, so
                 // just ignore those and to be safe treat it as the
                 // process didn't exit (the safe option being to not leave
                 // processes behind).
+                stderr.WriteLine($"Process {pid} already exited or busy: {e.Message}");
+            }
+            catch (Exception e)
+            {
+                stderr.WriteLine($"Unexpected error while checking process {pid}: {e.Message}");
             }
 
             if (!hasExited)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppBundleInformationParser.cs
@@ -129,10 +129,10 @@ public class AppBundleInformationParser : IAppBundleInformationParser
         {
             supports32 = await GetPlistProperty(plistPath, PListExtensions.RequiredDeviceCapabilities, log, cancellationToken);
         }
-        catch
+        catch (Exception e)
         {
             // The property might not be present
-            log.WriteLine("Property UIRequiredDeviceCapabilities not present in Info.plist, assuming 32-bit is not supported");
+            log.WriteLine("Property UIRequiredDeviceCapabilities not present in Info.plist, assuming 32-bit is not supported. Error: " + e.Message);
         }
 
         string? bundleExecutable = null;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -522,7 +522,7 @@ public class SimulatorLoader : ISimulatorLoader
 
                 if (attempt == retryCount)
                 {
-                    throw new NoDeviceFoundException("Failed to find/create suitable simulator");
+                    throw new NoDeviceFoundException("Failed to find/create suitable simulator", e);
                 }
             }
             finally

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleListener.cs
@@ -134,9 +134,10 @@ public abstract class SimpleListener : ISimpleListener
                 Stop();
             }
         }
-        catch
+        catch (Exception e)
         {
             // We might have stopped already, so just ignore any exceptions.
+            Log.WriteLine($"An exception occurred in processing thread: {e.Message}");
         }
     }
 


### PR DESCRIPTION
## Description

This PR improves exception handling by following these rules:
 - Don't use catch-all without logging or handling
 - If a catch block re-throw, include inner exception
 - If a catch block handles an exception, include logging

Fixes https://github.com/dotnet/xharness/issues/1247