### PR TITLE
[sdl] Include cgmanifest.json generation for Android platform tools to be included in SBOM generation

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -12,13 +12,15 @@
     <MlaunchDestinationDir Condition="'$(TargetFrameworks)' == '' OR $(TargetFrameworks.EndsWith($(TargetFramework)))">$(BaseIntermediateOutputPath)/mlaunch</MlaunchDestinationDir>
 
     <!-- When updating these URLs, avoid using 'latest' url as these are redirects and can make the same commit build differently on different days -->
-    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-windows.zip</WindowsAndroidSdkUrl>
+    <AndroidSdkVersion>32.0.0</AndroidSdkVersion>
+
+    <WindowsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r$(AndroidSdkVersion)-windows.zip</WindowsAndroidSdkUrl>
     <WindowsAndroidSdkFileName>windows-android-platform-tools.zip</WindowsAndroidSdkFileName>
 
-    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-linux.zip</LinuxAndroidSdkUrl>
+    <LinuxAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r$(AndroidSdkVersion)-linux.zip</LinuxAndroidSdkUrl>
     <LinuxAndroidSdkFileName>linux-android-platform-tools.zip</LinuxAndroidSdkFileName>
 
-    <MacOsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r32.0.0-darwin.zip</MacOsAndroidSdkUrl>
+    <MacOsAndroidSdkUrl>https://dl.google.com/android/repository/platform-tools_r$(AndroidSdkVersion)-darwin.zip</MacOsAndroidSdkUrl>
     <MacOsAndroidSdkFileName>macos-android-platform-tools.zip</MacOsAndroidSdkFileName>
   </PropertyGroup>
 
@@ -52,7 +54,7 @@
     <RemoveDir Directories="$(BaseIntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/systrace;$(BaseIntermediateOutputPath)/android-tools-unzipped/linux/platform-tools/systrace;$(BaseIntermediateOutputPath)/android-tools-unzipped/macos/platform-tools/systrace" />
   </Target>
 
-  <Target Name="IncludeAdb" BeforeTargets="DispatchToInnerBuilds" DependsOnTargets="DownloadAdb">
+  <Target Name="IncludeAdb" BeforeTargets="DispatchToInnerBuilds" DependsOnTargets="DownloadAdb;GenerateCGManifest">
     <ItemGroup>
       <WindowsAdbFiles Include="$(BaseIntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/adb.exe" />
       <WindowsAdbFiles Include="$(BaseIntermediateOutputPath)/android-tools-unzipped/windows/platform-tools/AdbWinApi.dll" />
@@ -87,6 +89,55 @@
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateCGManifest">
+    <PropertyGroup>
+        <CGManifestTemplate>
+        <![CDATA[
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "version": 1,
+  "registrations": [
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Android platform tools for Windows",
+          "version": "$(AndroidSdkVersion)",
+          "downloadUrl": "$(WindowsAndroidSdkUrl)"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Android platform tools for Linux",
+          "version": "$(AndroidSdkVersion)",
+          "downloadUrl": "$(LinuxAndroidSdkUrl)"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Android platform tools for MacOS",
+          "version": "$(AndroidSdkVersion)",
+          "downloadUrl": "$(MacOsAndroidSdkUrl)"
+        }
+      }
+    }
+  ]
+}
+        ]]>
+        </CGManifestTemplate>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(BaseIntermediateOutputPath)/cgmanifest.json"
+      Lines="$(CGManifestTemplate)"
+      Overwrite="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Since we are distributing OSS it is required to list all OSS dependencies in the generated SBOM manifest.
This can be accomplished by providing `cgmanifest.json` with custom entries which are not detectable by Component Governance (ref: https://docs.opensource.microsoft.com/tools/cg/component-detection/cgmanifest )

This PR adds a custom MSBuild task which list Android platform tools that we are distributing with xharness which is later properly included in the SBOM manifest (test in the official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2568115&view=results) 

SBOM manifest `manifest.spdx.json` from the linked official build:
```json
...
{
      "name": "Android platform tools for Windows",
      "SPDXID": "SPDXRef-Package-F3150E9103F8373C20F4E2F276D045725D67FD48DDD945AEB2033BB6F0CD99F6",
      "downloadLocation": "https://dl.google.com/android/repository/platform-tools_r32.0.0-windows.zip",
      "filesAnalyzed": false,
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "NOASSERTION",
      "copyrightText": "NOASSERTION",
      "versionInfo": "32.0.0",
      "supplier": "NOASSERTION"
 }
 ...
```