### PR TITLE
Bump macOS build image version

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -76,7 +76,7 @@ stages:
       jobs:
       - job: OSX
         pool:
-          vmImage: macOS-12
+          vmImage: macOS-13
         strategy:
           matrix:
             Release:


### PR DESCRIPTION
### Description

macOS-12 image has been deprecated and we started getting:
```
##[error]The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721
,##[error]The remote provider was unable to process the request.
```
in CI builds e.g.: https://dev.azure.com/dnceng-public/public/_build/results?buildId=859872&view=logs&j=15cba83b-cf63-5728-c708-eb441e2bd9e9

This PR bumps the build image version.