### PR TITLE
[release/6.0] Backport bypass OS security model + prevent failures on multiple exit messages

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmTestBrowserCommand.cs
@@ -189,6 +189,12 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
                 "--metrics-recording-only"
             });
 
+            if (File.Exists("/.dockerenv"))
+            {
+                // Use --no-sandbox for containers, and codespaces
+                options.AddArguments("--no-sandbox");
+            }
+
             if (Arguments.NoQuit)
                 options.LeaveBrowserRunning = true;
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             if (line.StartsWith("WASM EXIT"))
             { 
                 _logger.LogDebug("Reached wasm exit");
-                if (!WasmExitReceivedTcs.TrySetResult())
+                if (!WasmExitReceivedTcs.TrySetResult(true))
                     _logger.LogDebug("Got a duplicate exit message.");
             }
         }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/WasmTestMessagesProcessor.cs
@@ -127,8 +127,10 @@ namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm
             // after the tests have run, and the xml results file
             // has been written to the console
             if (line.StartsWith("WASM EXIT"))
-            {
-                WasmExitReceivedTcs.SetResult(true);
+            { 
+                _logger.LogDebug("Reached wasm exit");
+                if (!WasmExitReceivedTcs.TrySetResult())
+                    _logger.LogDebug("Got a duplicate exit message.");
             }
         }
 


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/issues/108859.

In the tests running on newer .net we have `no-sandbox` passed to the browser. There are chrome user reports confirming that this fixes the issue. This flag was introduced in https://github.com/dotnet/xharness/pull/951, so while backporting I added both changes from the original PR: no sandbox + avoiding failures on multiple exit messages.

Backport of https://github.com/dotnet/xharness/pull/951 to release/6.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

## Testing

CI

## Risk

This is infa-only.
