### PR TITLE
[release/9.0] Bump macOS image version (#1317)

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -76,7 +76,7 @@ stages:
       jobs:
       - job: OSX
         pool:
-          vmImage: macOS-12
+          vmImage: macOS-13
         strategy:
           matrix:
             Release:


### PR DESCRIPTION
Backport of https://github.com/dotnet/xharness/pull/1317 to release/9.0