### PR TITLE
[release/9.0] Bump queues to MacOS 13

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1300.amd64.open"/>
-    <HelixTargetQueue Include="osx.1300.arm64.open"/>
+    <HelixTargetQueue Include="osx.13.amd64.open"/>
+    <HelixTargetQueue Include="osx.13.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.open"/>
-    <HelixTargetQueue Include="osx.1200.arm64.open"/>
+    <HelixTargetQueue Include="osx.1300.amd64.open"/>
+    <HelixTargetQueue Include="osx.1300.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">


### PR DESCRIPTION
Backport of: https://github.com/dotnet/xharness/pull/1359