### PR TITLE
[infra][apple] Update Apple simulator queues to OSX 14/15

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -15,7 +15,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.15.amd64.open"/>
-    <HelixTargetQueue Include="osx.15.arm64.open"/>
+    <HelixTargetQueue Include="osx.14.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -19,6 +19,11 @@
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
+    <!-- apple test / maccatalyst -->
+    <XHarnessAppleProject Include="TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
+    </XHarnessAppleProject>
+
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.open"/>
-    <HelixTargetQueue Include="osx.1200.arm64.open"/>
+    <HelixTargetQueue Include="osx.15.amd64.open"/>
+    <HelixTargetQueue Include="osx.15.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -16,11 +16,6 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
-    </XHarnessAppleProject>
-
-    <!-- apple test / maccatalyst -->
-    <XHarnessAppleProject Include="TestAppBundle.proj">
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 


### PR DESCRIPTION
Update Apple simulator queues from `osx.1200.[amd64/arm64].open` to new macOS queues.

Contributes to https://github.com/dotnet/xharness/issues/1365.

# Changes:
## New MacCatalyst testing app
On newer macOS version, MacCatalyst apps must be signed to be able tu run, see https://github.com/dotnet/xharness/issues/1376.

In this PR, we add a new signed test app, System.Collections.NonGeneric.Tests.app taken from dotnet/runtime CI and compressed using tar -czf to create a gzip archive. The compressed archive is uploaded as System.Collections.NonGeneric.Tests.app.zip to the remote storage.

Removing the old app maccatalyst-System.AppContext.Tests.app as there isn't 1:1 signed replacement which we could use after we migrate to newer osx queues.

## Queue migration
Moving to `osx.15.amd64.open` and `osx.14.arm64.open` queues. Use `osx.14.arm64.open` queue until `osx.15` has enough capacity for dotnet/runtime CI. We want to match the used queues in xharness to make sure we are testing the same thing.

---

FYI: This needs to be backported to servicing branches.

TODO:
- [x] Update other simulator e2e test queues
- [x] Remove `System.AppContext.Tests.app` MacCatalyst test app
- [x] upload new `iOS.Simulator.PInvoke.Test.app` MacCatalyst test app
- [x] Install iOS simulators on `osx.14.arm64.open`

