### PR TITLE
Stop building Microsoft.DotNet.XHarness.CLI for NetCurrent

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
+++ b/src/Microsoft.DotNet.XHarness.CLI/Microsoft.DotNet.XHarness.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(NetPrevious);$(NetMinimum)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>xharness</ToolCommandName>


### PR DESCRIPTION
We don't need to be on the latest TFM (we already set RollForward=major) and it prevents issues when xharness uses a newer SDK than runtime like in https://github.com/dotnet/runtime/pull/113381#issuecomment-2722131488