### PR TITLE
[maccatalyst] New signed test app for MacCatalyst (`System.Collections.NonGeneric.Tests`)

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -15,7 +15,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -19,6 +19,11 @@
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
+    <!-- apple test / maccatalyst -->
+    <XHarnessAppleProject Include="TestAppBundle.proj">
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
+    </XHarnessAppleProject>
+
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -16,11 +16,6 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
-    </XHarnessAppleProject>
-
-    <!-- apple test / maccatalyst -->
-    <XHarnessAppleProject Include="TestAppBundle.proj">
       <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 


### PR DESCRIPTION
On newer macOS version, MacCatalyst apps must be signed to be able tu run. 

In this PR, we add a new signed test app, `System.Collections.NonGeneric.Tests.app` taken from dotnet/runtime CI and compressed using `tar -czf` to create a gzip archive. The compressed archive is uploaded as `System.Collections.NonGeneric.Tests.app.zip` to the remote storage.

Removing the old app `maccatalyst-System.AppContext.Tests.app` as there isn't 1:1 signed replacement which we could use after we migrate to newer osx queues.


---

https://github.com/dotnet/xharness/issues/1376