### PR TITLE
Use dotnet-install script directly from CDN instead of dot.net

### DIFF
--- a/tools/Install-XHarness.ps1
+++ b/tools/Install-XHarness.ps1
@@ -16,7 +16,7 @@ $xharness_version = "10.0.0-prerelease.$Version"
 
 # Install .NET
 Write-Host "Getting dotnet-install.ps1.." -ForegroundColor Cyan
-Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
+Invoke-WebRequest -Uri "https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
 
 Write-Host "Installing .NET SDK locally to " -NoNewline -ForegroundColor Cyan
 Write-Host ".dotnet" -ForegroundColor Yellow

--- a/tools/install-xharness.sh
+++ b/tools/install-xharness.sh
@@ -31,7 +31,7 @@ here=$(pwd)
 dotnet_install="$here/dotnet-install.sh"
 
 echo "Getting dotnet-install.sh.."
-curl -L https://dot.net/v1/dotnet-install.sh -o "$dotnet_install"
+curl -L https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.sh -o "$dotnet_install"
 chmod u+x "$dotnet_install"
 dotnet_dir="$here/.dotnet"
 


### PR DESCRIPTION
The dot.net redirector is currently having issues, we should be using the script directly from the CDN anyway.