### PR TITLE
[browser] HTTP POST test results when possible

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUploadResults.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Arguments/WebServerUploadResults.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments;
+
+internal class WebServerUploadResults : SwitchArgument
+{
+    public WebServerUploadResults()
+        : base("web-server-upload-results", "Enable uploading XML test results", true)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASI/WasiTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASI/WasiTestCommandArguments.cs
@@ -25,6 +25,7 @@ internal class WasiTestCommandArguments : XHarnessCommandArguments, IWebServerAr
     public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
     public WebServerUseDefaultFilesArguments WebServerUseDefaultFiles { get; } = new();
     public bool IsWebServerEnabled => WebServerMiddlewarePathsAndTypes.Value.Count > 0;
+    public WebServerUploadResults WebServerUploadResults { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/IWebServerArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/IWebServerArguments.cs
@@ -14,4 +14,6 @@ internal interface IWebServerArguments
     WebServerUseCorsArguments WebServerUseCors { get; }
     WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; }
     WebServerUseDefaultFilesArguments WebServerUseDefaultFiles { get; }
+    WebServerUploadResults WebServerUploadResults { get; }
+    OutputDirectoryArgument OutputDirectory { get; }
 }

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -38,6 +38,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
     public WebServerUseCorsArguments WebServerUseCors { get; } = new();
     public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
     public WebServerUseDefaultFilesArguments WebServerUseDefaultFiles { get; } = new();
+    public WebServerUploadResults WebServerUploadResults { get; } = new();
     public bool IsWebServerEnabled => WebServerMiddlewarePathsAndTypes.Value.Count > 0;
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestCommandArguments.cs
@@ -30,6 +30,7 @@ internal class WasmTestCommandArguments : XHarnessCommandArguments, IWebServerAr
     public WebServerUseCorsArguments WebServerUseCors { get; } = new();
     public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
     public WebServerUseDefaultFilesArguments WebServerUseDefaultFiles { get; } = new();
+    public WebServerUploadResults WebServerUploadResults { get; } = new();
     public bool IsWebServerEnabled => WebServerMiddlewarePathsAndTypes.Value.Count > 0;
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WebServerCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WebServerCommandArguments.cs
@@ -18,6 +18,9 @@ internal class WebServerCommandArguments : XHarnessCommandArguments, IWebServerA
     public WebServerUseCorsArguments WebServerUseCors { get; } = new();
     public WebServerUseCrossOriginPolicyArguments WebServerUseCrossOriginPolicy { get; } = new();
     public WebServerUseDefaultFilesArguments WebServerUseDefaultFiles { get; } = new();
+    public WebServerUploadResults WebServerUploadResults { get; } = new();
+    public OutputDirectoryArgument OutputDirectory { get; } = new();
+
     public bool IsWebServerEnabled => WebServerMiddlewarePathsAndTypes.Value.Count > 0;
 
     public TimeoutArgument Timeout { get; } = new(TimeSpan.FromMinutes(15));

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -184,7 +184,7 @@ public class WebServer
                     {
                         var xmlResultsFilePath = Path.Combine(options.OutputDirectory ?? Directory.CreateTempSubdirectory().FullName, "testResults.xml");
                         await using var fileStream = File.Create(xmlResultsFilePath);
-                        await request.BodyReader.CopyToAsync(fileStream);
+                        await context.Request.BodyReader.CopyToAsync(fileStream);
                         _logger.LogInformation($"Stored {xmlResultsFilePath} results {fileStream.Position} bytes");
                     });
                 });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -182,7 +182,7 @@ public class WebServer
                 {
                     router.MapPost("/test-results", async context =>
                     {
-                        var xmlResultsFilePath = Path.Combine(options.OutputDirectory, "testResults.xml");
+                        var xmlResultsFilePath = Path.Combine(options.OutputDirectory!, "testResults.xml");
 
                         await using var fileStream = File.Create(xmlResultsFilePath);
                         await context.Request.BodyReader.CopyToAsync(fileStream);

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -183,9 +183,8 @@ public class WebServer
                     router.MapPost("/test-results", async context =>
                     {
                         var xmlResultsFilePath = Path.Combine(options.OutputDirectory ?? Directory.CreateTempSubdirectory().FullName, "testResults.xml");
-                        using var fileStream = new FileStream(xmlResultsFilePath, FileMode.Create);
-                        await context.Request.Body.CopyToAsync(fileStream);
-                        await fileStream.FlushAsync();
+                        await using var fileStream = File.Create(xmlResultsFilePath);
+                        await request.BodyReader.CopyToAsync(fileStream);
                         _logger.LogInformation($"Stored {xmlResultsFilePath} results {fileStream.Position} bytes");
                     });
                 });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -184,7 +184,7 @@ public class WebServer
                     {
                         var xmlResultsFilePath = Path.Combine(options.OutputDirectory ?? Directory.CreateTempSubdirectory().FullName, "testResults.xml");
                         using var fileStream = new FileStream(xmlResultsFilePath, FileMode.Create);
-                        await context.Request.Body.CopyToAsync(fileStream);
+                        await context.Response.Body.CopyToAsync(fileStream);
                         _logger.LogInformation($"Stored {xmlResultsFilePath} results");
                     });
                 });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -186,7 +186,7 @@ public class WebServer
                         using var fileStream = new FileStream(xmlResultsFilePath, FileMode.Create);
                         await context.Request.Body.CopyToAsync(fileStream);
                         await fileStream.FlushAsync();
-                        _logger.LogInformation($"Stored {xmlResultsFilePath} results");
+                        _logger.LogInformation($"Stored {xmlResultsFilePath} results {fileStream.Position} bytes");
                     });
                 });
             }

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -184,7 +184,8 @@ public class WebServer
                     {
                         var xmlResultsFilePath = Path.Combine(options.OutputDirectory ?? Directory.CreateTempSubdirectory().FullName, "testResults.xml");
                         using var fileStream = new FileStream(xmlResultsFilePath, FileMode.Create);
-                        await context.Response.Body.CopyToAsync(fileStream);
+                        await context.Request.Body.CopyToAsync(fileStream);
+                        await fileStream.FlushAsync();
                         _logger.LogInformation($"Stored {xmlResultsFilePath} results");
                     });
                 });

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WebServer.cs
@@ -182,7 +182,8 @@ public class WebServer
                 {
                     router.MapPost("/test-results", async context =>
                     {
-                        var xmlResultsFilePath = Path.Combine(options.OutputDirectory ?? Directory.CreateTempSubdirectory().FullName, "testResults.xml");
+                        var xmlResultsFilePath = Path.Combine(options.OutputDirectory, "testResults.xml");
+
                         await using var fileStream = File.Create(xmlResultsFilePath);
                         await context.Request.BodyReader.CopyToAsync(fileStream);
                         _logger.LogInformation($"Stored {xmlResultsFilePath} results {fileStream.Position} bytes");

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/ApplicationEntryPoint.cs
@@ -173,7 +173,7 @@ public abstract class ApplicationEntryPoint
         }
     }
 
-    private static void WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer)
+    private static async Task WriteResults(TestRunner runner, ApplicationOptions options, LogWriter logger, TextWriter writer)
     {
         if (options.EnableXml && writer == null)
         {
@@ -182,12 +182,12 @@ public abstract class ApplicationEntryPoint
 
         if (options.EnableXml)
         {
-            runner.WriteResultsToFile(writer, options.XmlVersion);
+            await runner.WriteResultsToFile(writer, options.XmlVersion);
             logger.Info("Xml file was written to the provided writer.");
         }
         else
         {
-            string resultsFilePath = runner.WriteResultsToFile(options.XmlVersion);
+            string resultsFilePath = await runner.WriteResultsToFile(options.XmlVersion);
             logger.Info($"XML results can be found in '{resultsFilePath}'");
         }
     }
@@ -227,7 +227,7 @@ public abstract class ApplicationEntryPoint
         logger.MinimumLogLevel = MinimumLogLevel.Info;
         var runner = await InternalRunAsync(logger);
 
-        WriteResults(runner, options, logger, resultsFile ?? Console.Out);
+        await WriteResults(runner, options, logger, resultsFile ?? Console.Out);
 
         logger.Info($"{Environment.NewLine}=== TEST EXECUTION SUMMARY ==={Environment.NewLine}Tests run: {runner.TotalTests} Passed: {runner.PassedTests} Inconclusive: {runner.InconclusiveTests} Failed: {runner.FailedTests} Ignored: {runner.FilteredTests} Skipped: {runner.SkippedTests}{Environment.NewLine}");
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Common/TestRunner.cs
@@ -112,8 +112,8 @@ public abstract class TestRunner
     }
 
     public abstract Task Run(IEnumerable<TestAssemblyInfo> testAssemblies);
-    public abstract string WriteResultsToFile(XmlResultJargon xmlResultJargon);
-    public abstract void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon);
+    public abstract Task<string> WriteResultsToFile(XmlResultJargon xmlResultJargon);
+    public abstract Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon);
     public abstract void SkipTests(IEnumerable<string> tests);
     public abstract void SkipCategories(IEnumerable<string> categories);
     public abstract void SkipMethod(string method, bool isExcluded);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.NUnit/NUnitTestRunner.cs
@@ -158,32 +158,34 @@ internal class NUnitTestRunner : TestRunner, INUnitTestRunner
         return include;
     }
 
-    public override string WriteResultsToFile(XmlResultJargon jargon)
+    public override Task<string> WriteResultsToFile(XmlResultJargon jargon)
     {
         if (_results == null)
         {
-            return string.Empty;
+            return Task.FromResult(string.Empty);
         }
 
         string ret = GetResultsFilePath();
         if (string.IsNullOrEmpty(ret))
         {
-            return string.Empty;
+            return Task.FromResult(string.Empty);
         }
 
         jargon.GetWriter().WriteResultFile(_results, ret);
 
-        return ret;
+        return Task.FromResult(ret);
     }
 
-    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+    public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
     {
         if (_results == null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         jargon.GetWriter().WriteResultFile(_results, writer);
+
+        return Task.CompletedTask;
     }
 
     public override void SkipTests(IEnumerable<string> tests)

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/ThreadlessXunitTestRunner.cs
@@ -19,16 +19,14 @@ namespace Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
 internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
 {
-    public ThreadlessXunitTestRunner(LogWriter logger, bool oneLineResults = false) : base(logger)
+    public ThreadlessXunitTestRunner(LogWriter logger) : base(logger)
     {
-        _oneLineResults = oneLineResults;
         ShowFailureInfos = false;
     }
 
     protected override string ResultsFileName { get => string.Empty; set => throw new InvalidOperationException("This runner outputs its results to stdout."); }
 
     private readonly XElement _assembliesElement = new XElement("assemblies");
-    private readonly bool _oneLineResults;
 
     public override async Task Run(IEnumerable<TestAssemblyInfo> testAssemblies)
     {
@@ -110,26 +108,16 @@ internal class ThreadlessXunitTestRunner : XunitTestRunnerBase
         };
     }
 
-    public override string WriteResultsToFile(XmlResultJargon xmlResultJargon)
+    public override async Task<string> WriteResultsToFile(XmlResultJargon xmlResultJargon)
     {
         Debug.Assert(xmlResultJargon == XmlResultJargon.xUnit);
-        WriteResultsToFile(Console.Out, xmlResultJargon);
+        await WriteResultsToFile(Console.Out, xmlResultJargon);
         return "";
     }
 
-    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+    public override async Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
     {
-        if (_oneLineResults)
-        {
-            WasmXmlResultWriter.WriteOnSingleLine(_assembliesElement);
-        }
-        else
-        {
-            writer.WriteLine($"STARTRESULTXML");
-            _assembliesElement.Save(writer);
-            writer.WriteLine();
-            writer.WriteLine($"ENDRESULTXML");
-        }
+        await WasmXmlResultWriter.WriteResultsToFile(_assembliesElement);
     }
 }
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmApplicationEntryPoint.cs
@@ -28,7 +28,7 @@ public abstract class WasmApplicationEntryPoint : WasmApplicationEntryPointBase
     protected override TestRunner GetTestRunner(LogWriter logWriter)
     {
         XunitTestRunnerBase runner = IsThreadless
-            ? new ThreadlessXunitTestRunner(logWriter, true)
+            ? new ThreadlessXunitTestRunner(logWriter)
             : new WasmThreadedTestRunner(logWriter) { MaxParallelThreads = MaxParallelThreads };
 
         ConfigureRunnerFilters(runner, ApplicationOptions.Current);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
@@ -31,6 +31,6 @@ internal class WasmThreadedTestRunner : XUnitTestRunner
         return base.Run(testAssemblies);
     }
 
-    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
-        => WasmXmlResultWriter.WriteOnSingleLine(AssembliesElement);
+    public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+        => WasmXmlResultWriter.WriteResultsToFile(AssembliesElement);
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -23,6 +23,8 @@ internal class WasmXmlResultWriter
 
         if (OperatingSystem.IsBrowser() && JSHost.GlobalThis.HasProperty("fetch"))
         {
+            ms.Position = 0;
+
             // globalThis.location.origin
             var originURL = JSHost.GlobalThis.GetPropertyAsJSObject("location")!.GetPropertyAsString("origin");
             using var req = new HttpRequestMessage(HttpMethod.Post, originURL + "/test-results");

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -39,6 +39,7 @@ internal class WasmXmlResultWriter
                 Console.WriteLine($"Finished uploading {ms.Length} bytes of RESULTXML");
                 return;
             }
+            // otherwise fall back to the console output
         }
 
         ms.TryGetBuffer(out var bytes);

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -21,7 +21,10 @@ internal class WasmXmlResultWriter
         using var ms = new MemoryStream();
         assembliesElement.Save(ms);
 
-        if (OperatingSystem.IsBrowser() && JSHost.GlobalThis.HasProperty("fetch"))
+        if (OperatingSystem.IsBrowser()
+            && JSHost.GlobalThis.HasProperty("fetch")
+            && JSHost.GlobalThis.HasProperty("location")
+            && JSHost.GlobalThis.HasProperty("document"))
         {
             ms.Position = 0;
 

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -26,12 +26,12 @@ internal class WasmXmlResultWriter
             try
             {
                 using JSObject globalThis = JSHost.GlobalThis;
-                if (globalThis.HasProperty("fetch") && JSHost.GlobalThis.HasProperty("location") && JSHost.GlobalThis.HasProperty("document"))
+                if (globalThis.HasProperty("fetch") && globalThis.HasProperty("location") && globalThis.HasProperty("document"))
                 {
                     ms.Position = 0;
 
                     // globalThis.location.origin
-                    using JSObject location = JSHost.GlobalThis.GetPropertyAsJSObject("location")!;
+                    using JSObject location = globalThis.GetPropertyAsJSObject("location")!;
                     var originURL = location.GetPropertyAsString("origin");
 
                     using var req = new HttpRequestMessage(HttpMethod.Post, originURL + "/test-results");

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -901,11 +901,11 @@ internal class XUnitTestRunner : XunitTestRunnerBase
         TotalTests += FilteredTests; // ensure that we do have in the total run the excluded ones.
     }
 
-    public override string WriteResultsToFile(XmlResultJargon jargon)
+    public override Task<string> WriteResultsToFile(XmlResultJargon jargon)
     {
         if (_assembliesElement == null)
         {
-            return string.Empty;
+            return Task.FromResult(string.Empty);
         }
         // remove all the empty nodes
         _assembliesElement.Descendants().Where(e => e.Name == "collection" && !e.Descendants().Any()).Remove();
@@ -928,13 +928,13 @@ internal class XUnitTestRunner : XunitTestRunnerBase
             }
         }
 
-        return outputFilePath;
+        return Task.FromResult(outputFilePath);
     }
-    public override void WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
+    public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
     {
         if (_assembliesElement == null)
         {
-            return;
+            return Task.CompletedTask;
         }
         // remove all the empty nodes
         _assembliesElement.Descendants().Where(e => e.Name == "collection" && !e.Descendants().Any()).Remove();
@@ -969,6 +969,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
                     break;
             }
         }
+        return Task.CompletedTask;
     }
 
     private void Transform_Results(string xsltResourceName, XElement element, XmlWriter writer)


### PR DESCRIPTION
- use HTTP POST when in available
- always single line otherwise
- `WebServerUploadResults` option, default true
- async `WriteResults`

Contributes to https://github.com/dotnet/runtime/issues/113474