### PR TITLE
[release/9.0][infra][apple] Update Apple simulator queues to OSX 14/15 (#1368)

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -15,7 +15,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.open"/>
-    <HelixTargetQueue Include="osx.1200.arm64.open"/>
+    <HelixTargetQueue Include="osx.15.amd64.open"/>
+    <HelixTargetQueue Include="osx.14.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
@@ -16,7 +16,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->


### PR DESCRIPTION
* use osx.15.amd64.open queue
* use osx.14.arm64.open queue Use osx.14.x86_64.open queue until osx.15 has enough capacity for dotnet/runtime CI. We want to match the used queues in xharness to make sure we are testing the same thing.
* Replacing the MacCatalyst app to use `System.Collections.NonGeneric.Tests.app`


backport of https://github.com/dotnet/xharness/pull/1368