### PR TITLE
[release/8.0][infra][apple] Update Apple simulator queues to OSX 14/15 (#1368)

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -40,7 +40,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         {
             TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
             TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
-            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6" : "iPhone-X"),
+            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-XS"),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
             TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm"),
             TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorLoaderTests.cs
@@ -113,7 +113,7 @@ public class SimulatorLoaderTests
         MlaunchArgument outputFormatArg = passedArguments.Where(a => a is XmlOutputFormatArgument).FirstOrDefault();
         Assert.NotNull(outputFormatArg);
 
-        Assert.Equal(75, _simulatorLoader.AvailableDevices.Count());
+        Assert.Equal(76, _simulatorLoader.AvailableDevices.Count());
     }
 
     [Theory]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
@@ -716,6 +716,12 @@
         <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/18F485DC-7F0A-440F-BEF9-5BE5954B0FB1</DataPath>
         <LogPath>/Users/mandel/Library/Logs/CoreSimulator/18F485DC-7F0A-440F-BEF9-5BE5954B0FB1</LogPath>
       </SimDevice>
+      <SimDevice UDID="336E1D83-AB00-4FAE-A70D-C516D269B90A" Name="iPhone Xs (iOS {{MAX-IOS.VERSION}}) - created by xharness">
+        <SimRuntime>com.apple.CoreSimulator.SimRuntime.iOS-{{MAX-IOS-VERSION}}</SimRuntime>
+        <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.iPhone-XS</SimDeviceType>
+        <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/336E1D83-AB00-4FAE-A70D-C516D269B90A</DataPath>
+        <LogPath>/Users/mandel/Library/Logs/CoreSimulator/336E1D83-AB00-4FAE-A70D-C516D269B90A</LogPath>
+      </SimDevice>
       <SimDevice UDID="ABC2A44A-789D-4C8B-88A7-0CD7C6BF316C" Name="iPhone 11">
         <SimRuntime>com.apple.CoreSimulator.SimRuntime.iOS-{{MAX-IOS-VERSION}}</SimRuntime>
         <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.iPhone-11</SimDeviceType>

--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -16,7 +16,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -2,8 +2,8 @@
   <Import Project="../Helix.SDK.configuration.props"/>
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.1200.amd64.open"/>
-    <HelixTargetQueue Include="osx.1200.arm64.open"/>
+    <HelixTargetQueue Include="osx.15.amd64.open"/>
+    <HelixTargetQueue Include="osx.14.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
@@ -17,7 +17,7 @@
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.AppContext.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->


### PR DESCRIPTION
backport of https://github.com/dotnet/xharness/pull/1368:

* use osx.15.amd64.open queue
* use osx.14.arm64.open queue Use osx.14.x86_64.open queue until osx.15 has enough capacity for dotnet/runtime CI. We want to match the used queues in xharness to make sure we are testing the same thing.
* Replacing the MacCatalyst app to use `System.Collections.NonGeneric.Tests.app`


Another change:

* Fix simulator selector to look for iPhone XS instead of iPhone X.
