### PR TITLE
[codeql] Don't include RawUrl in the response

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -125,7 +125,8 @@ public class SimpleHttpListener : SimpleListener
                 break;
             default:
                 Log.WriteLine("Unknown upload url: {0}", request.RawUrl);
-                response = $"Unknown upload url: {request.RawUrl}"; // CodeQL [SM02175] False Positive: This is a plain-text API response
+                response = "Unknown upload url";
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 break;
         }
 


### PR DESCRIPTION
## Description

Since we want to avoid CodeQL warnings like: `SM02175` and `SM00430` and as the `request.RawUrl` is already logged in the error case, this PR removes sending `request.RawUrl` back as the response.