### PR TITLE
[release/9.0] Backports for compliance improvements 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,6 @@ extends:
         enabled: true
       binskim:
         enabled: true
-        scanOutputDirectoryOnly: true
     pool:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022
@@ -53,6 +52,13 @@ extends:
               - script: eng\common\CIBuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs) /p:Test=false
                 name: Build
                 displayName: Build
+                condition: succeeded()
+            templateContext:
+              outputs:
+              - output: pipelineArtifact
+                artifact: Artifacts_Windows_NT
+                path: '$(Build.SourcesDirectory)\artifacts\bin\Microsoft.DotNet.XHarness.CLI'
+                displayName: 'Publish Windows_NT Artifacts'
                 condition: succeeded()
 
     - template: /eng/common/templates-official/post-build/post-build.yml@self

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Listeners/SimpleHttpListener.cs
@@ -125,7 +125,8 @@ public class SimpleHttpListener : SimpleListener
                 break;
             default:
                 Log.WriteLine("Unknown upload url: {0}", request.RawUrl);
-                response = $"Unknown upload url: {request.RawUrl}"; // CodeQL [SM02175] False Positive: This is a plain-text API response
+                response = "Unknown upload url";
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 break;
         }
 


### PR DESCRIPTION
This PR includes backports for improving compliance into release/9.0 branch of the following PRs:
- https://github.com/dotnet/xharness/pull/1394 for properly enabling and triggering binskim runs on xharness artifacts
- https://github.com/dotnet/xharness/pull/1397 CodeQL warning fixes