### PR TITLE
[xunit] GC before XML serialization of results

### DIFF
--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmThreadedTestRunner.cs
@@ -32,5 +32,5 @@ internal class WasmThreadedTestRunner : XUnitTestRunner
     }
 
     public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
-        => WasmXmlResultWriter.WriteResultsToFile(AssembliesElement);
+        => WasmXmlResultWriter.WriteResultsToFile(ConsumeAssembliesElement());
 }

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -18,11 +18,24 @@ internal class WasmXmlResultWriter
 {
     public async static Task WriteResultsToFile(XElement assembliesElement)
     {
+        if (OperatingSystem.IsBrowser())
+        {
+            await Task.Yield();
+            GC.Collect();
+            await Task.Yield();
+            GC.Collect();
+        }
+
         using var ms = new MemoryStream();
         assembliesElement.Save(ms);
+        assembliesElement = null;
+
 
         if (OperatingSystem.IsBrowser())
         {
+            await Task.Yield();
+            GC.Collect();
+
             try
             {
                 using JSObject globalThis = JSHost.GlobalThis;

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/WasmXmlResultWriter.cs
@@ -28,7 +28,7 @@ internal class WasmXmlResultWriter
 
         using var ms = new MemoryStream();
         assembliesElement.Save(ms);
-        assembliesElement = null;
+        assembliesElement = null!;
 
 
         if (OperatingSystem.IsBrowser())

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -34,7 +34,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
     public int? MaxParallelThreads { get; set; }
 
-    protected XElement _assembliesElement;
+    private XElement _assembliesElement;
 
     internal XElement ConsumeAssembliesElement()
     {

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -938,7 +938,6 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
         return Task.FromResult(outputFilePath);
     }
-
     public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
     {
         if (_assembliesElement == null)

--- a/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.TestRunners.Xunit/XUnitTestRunner.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -33,9 +34,16 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
     public int? MaxParallelThreads { get; set; }
 
-    private XElement _assembliesElement;
+    protected XElement _assembliesElement;
 
-    internal XElement AssembliesElement => _assembliesElement;
+    internal XElement ConsumeAssembliesElement()
+    {
+        Debug.Assert(_assembliesElement != null, "ConsumeAssembliesElement called before Run() or after ConsumeAssembliesElement() was already called.");
+        var res = _assembliesElement;
+        _assembliesElement = null;
+        FailureInfos.Clear();
+        return res;
+    }
 
     public AppDomainSupport AppDomainSupport { get; set; } = AppDomainSupport.Denied;
     protected override string ResultsFileName { get; set; } = "TestResults.xUnit.xml";
@@ -930,6 +938,7 @@ internal class XUnitTestRunner : XunitTestRunnerBase
 
         return Task.FromResult(outputFilePath);
     }
+
     public override Task WriteResultsToFile(TextWriter writer, XmlResultJargon jargon)
     {
         if (_assembliesElement == null)


### PR DESCRIPTION
Because [System.Private.Xml.Tests](https://helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-115000-merge-f3e9e25dad9b4e958b/WasmTestOnChrome-ST-System.Private.Xml.Tests/1/console.8628b1e9.log?helixlogtype=result)
```
[19:06:40] fail: MONO_WASM: Out of memory
   at System.IO.MemoryStream.set_Capacity(Int32 value)
   at System.Xml.Linq.XElement.Save(Stream stream)
   at Microsoft.DotNet.XHarness.TestRunners.Xunit.WasmXmlResultWriter.WriteResultsToFile(XElement assembliesElement)
```