### PR TITLE
Remove firewall setting from copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Do an initial build to ensure all dependencies are restored
+      - name: Do an initial restore to ensure all dependencies are restored
         run: |
-          ./build.sh
+          ./eng/common/build.sh --restore
       - name: Put repo-local dotnet install on PATH
         run: |
           echo "PATH=$PWD/.dotnet:$PATH" >> $GITHUB_ENV

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,10 +12,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Allow Copilot to access Visual Studio assets URLs needed for NuGet restore
-  COPILOT_AGENT_FIREWALL_ALLOW_LIST_ADDITIONS: "vsblob.vsassets.io"
-
 jobs:
 
   copilot-setup-steps:


### PR DESCRIPTION
This doesn't actually work as an env var, it needs to be set as a GitHub Actions variable in the repository settings: https://github.com/orgs/community/discussions/163374

I added the variable and it seems to have helped Copilot access the feeds.

Also only do a restore in copilot-setup-steps.yml to make sure a build error doesn't break Copilot