### PR TITLE
[release/9.0] Backport mobile log unification

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -154,6 +154,9 @@ public class AdbRunner
             Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath) ?? throw new ArgumentNullException(nameof(outputFilePath)));
             File.WriteAllText(outputFilePath, result.StandardOutput);
             _log.LogInformation($"Wrote current ADB log to {outputFilePath}");
+            // The adb log is not directly accessible.
+            // Hence, we duplicate the log to the main console log to simplify the UX of failure investigation.
+            _log.LogInformation($"ADB log output:{Environment.NewLine}{result.StandardOutput}");
             return true;
         }
     }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -327,11 +327,8 @@ public abstract class AppRunnerBase
         }
         else
         {
-            // For MacCatalyst, the test output log does not propagate to the main log.
-            // Hence, we duplicate the log to the main console log to simplify the UX of failure investigation.
-            IFileBackedLog aggregatedAppOutputLog = Log.CreateReadableAggregatedLog(_mainLog, log);
             _processManager
-                .ExecuteCommandAsync("log", logArgs, _mainLog, aggregatedAppOutputLog, aggregatedAppOutputLog, TimeSpan.FromDays(1), cancellationToken: streamCancellation)
+                .ExecuteCommandAsync("log", logArgs, _mainLog, log, log, TimeSpan.FromDays(1), cancellationToken: streamCancellation)
                 .DoNotAwait();
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -327,8 +327,11 @@ public abstract class AppRunnerBase
         }
         else
         {
+            // For MacCatalyst, the test output log does not propagate to the main log.
+            // Hence, we duplicate the log to the main console log to simplify the UX of failure investigation.
+            IFileBackedLog aggregatedAppOutputLog = Log.CreateReadableAggregatedLog(_mainLog, log);
             _processManager
-                .ExecuteCommandAsync("log", logArgs, _mainLog, log, log, TimeSpan.FromDays(1), cancellationToken: streamCancellation)
+                .ExecuteCommandAsync("log", logArgs, _mainLog, aggregatedAppOutputLog, aggregatedAppOutputLog, TimeSpan.FromDays(1), cancellationToken: streamCancellation)
                 .DoNotAwait();
         }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -362,15 +362,12 @@ public class AppTester : AppRunnerBase, IAppTester
             // We need to check for MT1111 (which means that mlaunch won't wait for the app to exit)
             IFileBackedLog aggregatedLog = Log.CreateReadableAggregatedLog(_mainLog, testReporter.CallbackLog);
 
-            // The app output log is not directly accessible. 
-            // Hence, we duplicate the log to the main console log to simplify the UX of failure investigation.
-            IFileBackedLog aggregatedAppOutputLog = Log.CreateReadableAggregatedLog(_mainLog, appOutputLog);
 
             var result = await RunAndWatchForAppSignal(() => _processManager.ExecuteCommandAsync(
                 mlaunchArguments,
                 aggregatedLog,
-                aggregatedAppOutputLog,
-                aggregatedAppOutputLog,
+                appOutputLog,
+                appOutputLog,
                 timeout,
                 envVars,
                 cancellationToken: cancellationToken));


### PR DESCRIPTION
Combined backport of https://github.com/dotnet/xharness/pull/1348 and https://github.com/dotnet/xharness/pull/1383 to ensure we're able to track mobile test failures on release/9.0 branch as well.