### PR TITLE
Remove cancellation token from `CopyResultsAsync`

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -25,13 +25,13 @@ public class InstrumentationRunner
 
     private readonly ILogger _logger;
     private readonly AdbRunner _runner;
-    
+
     public InstrumentationRunner(ILogger logger, AdbRunner runner)
     {
         _logger = logger;
         _runner = runner;
     }
-    
+
     public ExitCode RunApkInstrumentation(
         string apkPackageName,
         string? instrumentationName,

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -347,8 +347,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 simulator.OSVersion,
                 simulator.UDID,
                 appInformation.BundleIdentifier,
-                deviceListener.TestLog.FullPath,
-                cancellationToken))
+                deviceListener.TestLog.FullPath))
         {
             throw new InvalidOperationException("Failed to copy test results from simulator to host.");
         }
@@ -435,8 +434,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 device.OSVersion,
                 device.UDID,
                 appInformation.BundleIdentifier,
-                deviceListener.TestLog.FullPath,
-                cancellationToken))
+                deviceListener.TestLog.FullPath))
         {
             throw new InvalidOperationException("Failed to copy test results from device to host.");
         }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
@@ -24,6 +24,5 @@ public interface IResultFileHandler
         string osVersion,
         string udid,
         string bundleIdentifier,
-        string hostDestinationPath,
-        CancellationToken token);
+        string hostDestinationPath);
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
@@ -93,7 +93,6 @@ public class ResultFileHandler : IResultFileHandler
                 _mainLog,
                 _mainLog,
                 TimeSpan.FromMinutes(1),
-                null,
                 null);
 
             if (!File.Exists(hostDestinationPath))

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
@@ -67,8 +67,7 @@ public class ResultFileHandler : IResultFileHandler
         string osVersion,
         string udid,
         string bundleIdentifier,
-        string hostDestinationPath,
-        CancellationToken token)
+        string hostDestinationPath)
     {
         // This file path is set in iOSApplicationEntryPointBase
         string sourcePath = runMode == RunMode.iOS
@@ -95,7 +94,7 @@ public class ResultFileHandler : IResultFileHandler
                 _mainLog,
                 TimeSpan.FromMinutes(1),
                 null,
-                cancellationToken: token);
+                null);
 
             if (!File.Exists(hostDestinationPath))
             {

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
@@ -47,7 +47,7 @@ public class ResultFileHandlerTests : IDisposable
 
         var exception = await Assert.ThrowsAsync<FormatException>(async () =>
             await handler.CopyResultsAsync(
-                RunMode.iOS, true, "Simulator", "udid", "bundle", _tempFile, CancellationToken.None));
+                RunMode.iOS, true, "Simulator", "udid", "bundle", _tempFile));
 
         Assert.Equal("Simulator OS version is not in the expected format.", exception.Message);
     }
@@ -61,7 +61,7 @@ public class ResultFileHandlerTests : IDisposable
 
         var exception = await Assert.ThrowsAsync<FormatException>(async () =>
             await handler.CopyResultsAsync(
-                RunMode.iOS, true, "Simulator notanumber", "udid", "bundle", _tempFile, CancellationToken.None));
+                RunMode.iOS, true, "Simulator notanumber", "udid", "bundle", _tempFile));
 
         Assert.Equal("Simulator OS version is not in the expected format.", exception.Message);
     }
@@ -74,7 +74,7 @@ public class ResultFileHandlerTests : IDisposable
         ResultFileHandler handler = CreateHandler(pm, log);
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, true, "Simulator 17.4", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, true, "Simulator 17.4", "udid", "bundle", _tempFile);
 
         Assert.True(result);
     }
@@ -89,7 +89,7 @@ public class ResultFileHandlerTests : IDisposable
         File.WriteAllText(_tempFile, "dummy");
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, true, "Simulator 18.0", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, true, "Simulator 18.0", "udid", "bundle", _tempFile);
 
         Assert.True(result);
     }
@@ -105,7 +105,7 @@ public class ResultFileHandlerTests : IDisposable
             File.Delete(_tempFile);
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, true, "Simulator 18.0", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, true, "Simulator 18.0", "udid", "bundle", _tempFile);
 
         Assert.False(result);
         log.Verify(l => l.WriteLine($"Failed to copy results file from simulator. Expected at: {_tempFile}"), Times.Once);
@@ -120,7 +120,7 @@ public class ResultFileHandlerTests : IDisposable
 
         var exception = await Assert.ThrowsAsync<FormatException>(async () =>
             await handler.CopyResultsAsync(
-                RunMode.iOS, false, "notanumber", "udid", "bundle", _tempFile, CancellationToken.None));
+                RunMode.iOS, false, "notanumber", "udid", "bundle", _tempFile));
 
         Assert.Equal("Device OS version is not in the expected format.", exception.Message);
     }
@@ -133,7 +133,7 @@ public class ResultFileHandlerTests : IDisposable
         ResultFileHandler handler = CreateHandler(pm, log);
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, false, "17.4", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, false, "17.4", "udid", "bundle", _tempFile);
 
         Assert.True(result);
     }
@@ -148,7 +148,7 @@ public class ResultFileHandlerTests : IDisposable
         File.WriteAllText(_tempFile, "dummy");
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, false, "18.0", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, false, "18.0", "udid", "bundle", _tempFile);
 
         Assert.True(result);
     }
@@ -164,7 +164,7 @@ public class ResultFileHandlerTests : IDisposable
             File.Delete(_tempFile);
 
         bool result = await handler.CopyResultsAsync(
-            RunMode.iOS, false, "18.0", "udid", "bundle", _tempFile, CancellationToken.None);
+            RunMode.iOS, false, "18.0", "udid", "bundle", _tempFile);
 
         Assert.False(result);
         log.Verify(l => l.WriteLine($"Failed to copy results file from device. Expected at: {_tempFile}"), Times.Once);


### PR DESCRIPTION
## Description

This PR removes the cancellation token from `CopyResultsAsync`. When `--signal-app-end` is used, the same cancellation token was shared, which caused the copy command to terminate as soon as the app was terminated.

The copy command is considered deterministic and does not require a cancellation token.