### PR TITLE
Add env variables support to Android test command

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/AndroidTestCommandArguments.cs
@@ -23,6 +23,7 @@ internal class AndroidTestCommandArguments : XHarnessCommandArguments, IAndroidA
     public ExpectedExitCodeArgument ExpectedExitCode { get; } = new((int)Common.CLI.ExitCode.SUCCESS);
     public DeviceOutputFolderArgument DeviceOutputFolder { get; } = new();
     public WifiArgument Wifi { get; } = new();
+    public EnvironmentalVariablesArgument EnvironmentalVariables { get; } = new();
 
     protected override IEnumerable<Argument> GetArguments() => new Argument[]
     {
@@ -39,6 +40,7 @@ internal class AndroidTestCommandArguments : XHarnessCommandArguments, IAndroidA
         ExpectedExitCode,
         DeviceOutputFolder,
         Wifi,
+        EnvironmentalVariables,
     };
 
     public override void Validate()

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/EnvironmentalVariablesArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/Android/Arguments/EnvironmentalVariablesArgument.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
+
+/// <summary>
+/// Environmental variables set when executing the application.
+/// </summary>
+internal class EnvironmentalVariablesArgument : Argument
+{
+    public IReadOnlyCollection<(string, string)> Value => _environmentalVariables;
+
+    private readonly List<(string, string)> _environmentalVariables = new();
+
+    public EnvironmentalVariablesArgument() : base("set-env=", "Environmental variable to set for the application in format key=value. Can be used multiple times")
+    {
+    }
+
+    public override void Action(string argumentValue)
+    {
+        var position = argumentValue.IndexOf('=');
+        if (position == -1)
+        {
+            throw new ArgumentException($"The set-env argument {argumentValue} must be in the key=value format");
+        }
+
+        var key = argumentValue.Substring(0, position);
+        var value = argumentValue.Substring(position + 1);
+        _environmentalVariables.Add((key, value));
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.XHarness.Android;
 using Microsoft.DotNet.XHarness.CLI.Android;
@@ -62,10 +64,17 @@ Arguments:
                 runner.ClearAdbLog();
 
                 var instrumentationRunner = new InstrumentationRunner(logger, runner);
+                var instrumentationArguments = new Dictionary<string, string>(Arguments.InstrumentationArguments.Value, StringComparer.Ordinal);
+
+                foreach (var (name, value) in Arguments.EnvironmentalVariables.Value)
+                {
+                    instrumentationArguments[$"env:{name}"] = value;
+                }
+
                 exitCode = instrumentationRunner.RunApkInstrumentation(
                     Arguments.PackageName,
                     Arguments.InstrumentationName,
-                    Arguments.InstrumentationArguments,
+                    instrumentationArguments,
                     Arguments.OutputDirectory,
                     Arguments.DeviceOutputFolder,
                     Arguments.Timeout,

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/CommandArguments/ArgumentTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/CommandArguments/ArgumentTests.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Microsoft.DotNet.XHarness.CLI.CommandArguments;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments.Android;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Xunit;
 
@@ -194,5 +196,43 @@ public class ArgumentTests
         Assert.Equal("time is 00:00:05", $"time is {timespanArg}");
         Assert.Equal("switch is true", $"switch is {switchArg}");
         Assert.Equal("string is string-value", $"string is {stringArg}");
+    }
+
+    [Fact]
+    public void EnvironmentalVariablesArgumentCollectsValues()
+    {
+        var argument = new EnvironmentalVariablesArgument();
+        var command = UnitTestCommand.FromArgument(argument);
+
+        var exitCode = command.Invoke(new[]
+        {
+            "--set-env=env1=val1",
+            "--set-env",
+            "env2=val2",
+        });
+
+        Assert.Equal(0, exitCode);
+        Assert.True(command.CommandRun);
+
+        var values = argument.Value.ToArray();
+        Assert.Equal(2, values.Length);
+        Assert.Equal(("env1", "val1"), values[0]);
+        Assert.Equal(("env2", "val2"), values[1]);
+    }
+
+    [Fact]
+    public void EnvironmentalVariablesArgumentRequiresKeyValueFormat()
+    {
+        var argument = new EnvironmentalVariablesArgument();
+        var command = UnitTestCommand.FromArgument(argument);
+
+        var exitCode = command.Invoke(new[]
+        {
+            "--set-env",
+            "invalid",
+        });
+
+        Assert.Equal((int)ExitCode.INVALID_ARGUMENTS, exitCode);
+        Assert.False(command.CommandRun);
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for passing environment variables to Android instrumentation runs:
```
--set-env key=value
```
Values are emitted as instrumentation arguments with the `env:` prefix and applied inside the test app before test execution.