### PR TITLE
Enable CodeQL on release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,9 @@ extends:
         enabled: true
       binskim:
         enabled: true
+      codeql:
+        ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+          enabledOnNonDefaultBranches: true
     pool:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022


### PR DESCRIPTION
By default, CodeQL is enabled only on the default branch.

This PR enables CodeQL on release branches by checking if the branch name starts with `release/`.

Enabling CodeQL this way has been verified to work on a test branch:

https://dev.azure.com/dnceng/internal/_build/results?buildId=2848917&view=logs&j=bb592630-4b9d-53ad-3960-d954a70a95cf&t=140baf9e-5028-5c0c-1412-41cdda4839f3
