### PR TITLE
Update simulator tests to use osx.15.amd64.open queue

### DIFF
--- a/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Commands.Tests.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.13.amd64.open"/>
+    <HelixTargetQueue Include="osx.15.amd64.open"/>
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
+++ b/tests/integration-tests/Apple/SimulatorInstaller.Tests.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
   <ItemGroup>
-    <HelixTargetQueue Include="osx.13.amd64.open"/>
+    <HelixTargetQueue Include="osx.15.amd64.open"/>
 
     <HelixWorkItem Include="SimulatorInstaller.Tests">
       <PayloadDirectory>$(RepoRoot)\tests\integration-tests\Apple\helix-payloads</PayloadDirectory>


### PR DESCRIPTION
## Description

This PR updates simulator tests to use osx.15.amd64.open queue. This might fix https://github.com/dotnet/xharness/issues/1509 as osx.13 queue is obsolete.