### PR TITLE
[browser] use IDevTools for console logs

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -18,9 +18,7 @@ using Microsoft.Extensions.Logging;
 using OpenQA.Selenium;
 using OpenQA.Selenium.DevTools;
 using OpenQA.Selenium.Support.UI;
-using OpenQA.Selenium.Firefox;
 
-using SeleniumLogLevel = OpenQA.Selenium.LogLevel;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Microsoft.DotNet.XHarness.CLI.Commands.Wasm;


### PR DESCRIPTION
- drop `RunSeleniumLogMessagePump` and replace it with `session.Console.MessageAdded` event
   - this is better than `logs.GetLog(logType)` that is HTTP call to webdriver until browser can respond. This is blocked by synchronous unit test code running.
   - this requires selenium `IDevTools` that only chromedriver implements
   - the new method is based on chrome dev tools protocol, that is pushing/streaming console events regardless of busy JS thread.
   - `logs.AvailableLogTypes` returns empty on Firefox and we use websockets to push console logs anyway.