### PR TITLE
Fix artifact upload collision between Debug and Release matrix legs

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -40,12 +40,15 @@ stages:
           matrix:
             Release:
               _BuildConfig: Release
+              _PublishArgs: ''
             Debug:
               _BuildConfig: Debug
+              _PublishArgs: /p:Publish=false
         steps:
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
+            $(_PublishArgs)
           name: Build
           displayName: Build and run tests
           condition: succeeded()
@@ -81,12 +84,15 @@ stages:
           matrix:
             Release:
               _BuildConfig: Release
+              _PublishArgs: ''
             Debug:
               _BuildConfig: Debug
+              _PublishArgs: /p:Publish=false
         steps:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
+            $(_PublishArgs)
           name: Build
           displayName: Build and run tests
           condition: succeeded()


### PR DESCRIPTION
## Problem

Both Debug and Release matrix legs in the public CI pipeline call `CIBuild.cmd`/`cibuild.sh`, which includes `-publish`. This causes both legs to simultaneously upload `PackageArtifacts/Microsoft.DotNet.XHarness.CLI.11.0.0-ci.nupkg` to the same AzDO artifact container, resulting in intermittent "Blob is incomplete (missing block)" errors when the blob uploads interleave.

This was observed in the most recent CI runs on #1563 and is a well-known pattern across dotnet repos (see dotnet/dnceng#1916).

## Root Cause

The arcade SDK's `PushToBuildStorage` MSBuild task (invoked by `Publish.proj` when `Publish=true`) emits `##vso[artifact.upload containerfolder=PackageArtifacts;artifactname=PackageArtifacts]` commands. When both matrix legs run this simultaneously for the same `.nupkg` file, AzDO's blob storage encounters write conflicts.

## Fix

Pass `/p:Publish=false` to the Debug matrix leg so only the Release leg publishes packages to artifact storage. The Debug leg still builds, tests, signs, and packs — it just skips the artifact upload step. MSBuild's "last property wins" rule ensures this overrides the `-publish` flag passed by `CIBuild.cmd`.

Applied to both Windows and macOS stages.