### PR TITLE
New structured log output for Apple and Android platforms

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -50,6 +50,11 @@ public class AdbRunner
 
     private AndroidDevice? _activeDevice = null;
 
+    /// <summary>
+    /// Returns the currently active device, if one has been selected.
+    /// </summary>
+    public AndroidDevice? GetActiveDevice() => _activeDevice;
+
     public AdbRunner(ILogger log, string adbExePath = "") : this(log, new AdbProcessManager(log), adbExePath) { }
 
     public AdbRunner(ILogger log, IAdbProcessManager processManager, string adbExePath = "")
@@ -154,12 +159,60 @@ public class AdbRunner
         {
             Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath) ?? throw new ArgumentNullException(nameof(outputFilePath)));
             File.WriteAllText(outputFilePath, result.StandardOutput);
-            _log.LogInformation($"Wrote current ADB log to {outputFilePath}");
-            // The adb log is not directly accessible.
-            // Hence, we duplicate the log to the main console log to simplify the UX of failure investigation.
-            _log.LogInformation($"ADB log output:{Environment.NewLine}{result.StandardOutput}");
+            _log.LogInformation($"Wrote full ADB log ({CountLines(result.StandardOutput)} lines) to {outputFilePath}");
+
+            // Filter to only DOTNET-tagged lines for console output (full log is in the file above)
+            var filteredLog = FilterToDotnetLines(result.StandardOutput);
+            if (!string.IsNullOrEmpty(filteredLog))
+            {
+                _log.LogInformation($"ADB log (DOTNET entries):{Environment.NewLine}{filteredLog}");
+            }
+            else
+            {
+                _log.LogInformation("ADB log contained no DOTNET-tagged entries (see full log file for details)");
+            }
+
             return true;
         }
+    }
+
+    public static string FilterToDotnetLines(string logcatOutput)
+    {
+        if (string.IsNullOrEmpty(logcatOutput))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var line in logcatOutput.Split('\n'))
+        {
+            // Match lines from the DOTNET log tag used by the Mono Android test runner
+            if (line.Contains(" DOTNET  ") || line.Contains(" DOTNET: "))
+            {
+                sb.AppendLine(line.TrimEnd('\r'));
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static int CountLines(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return 0;
+        }
+
+        int count = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (text[i] == '\n')
+            {
+                count++;
+            }
+        }
+
+        return count + 1;
     }
 
     public string DumpBugReport(string outputFilePathWithoutFormat)

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -6,9 +6,6 @@ using Microsoft.DotNet.XHarness.Android.Execution;
 using System.Collections.Generic;
 using System.IO;
 using System;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
@@ -267,109 +264,17 @@ public class InstrumentationRunner
 
     private void EmitRunSummary(ExitCode exitCode, int? instrumentationExitCode, List<DiagnosticsFile> producedFiles)
     {
-        // Human-readable summary
-        var summary = new StringBuilder();
-        summary.AppendLine("=== XHARNESS RUN SUMMARY ===");
-        summary.AppendLine($"Exit code: {(int)exitCode} ({exitCode})");
-
-        if (instrumentationExitCode.HasValue)
-        {
-            summary.AppendLine($"Instrumentation exit code: {instrumentationExitCode}");
-        }
-
         var device = _runner.GetActiveDevice();
-        if (device != null)
-        {
-            summary.Append($"Device: {device.DeviceSerial}");
-            if (device.ApiVersion.HasValue)
-            {
-                summary.Append($" (API {device.ApiVersion}");
-                if (!string.IsNullOrEmpty(device.Architecture))
-                {
-                    summary.Append($", {device.Architecture}");
-                }
-                summary.Append(')');
-            }
-            summary.AppendLine();
-        }
+        string? deviceOsVersion = device?.ApiVersion.HasValue == true ? $"API {device.ApiVersion}" : null;
 
-        if (producedFiles.Count > 0)
-        {
-            summary.AppendLine("Files produced:");
-            foreach (var file in producedFiles)
-            {
-                summary.AppendLine($"  [{file.Type.ToUpperInvariant()}] {file.Name}");
-            }
-        }
-
-        summary.Append("=============================");
-        _logger.LogInformation(summary.ToString());
-
-        // Machine-readable JSON block for AI agents
-        EmitJsonResultBlock(exitCode, instrumentationExitCode, device, producedFiles);
-    }
-
-    public void EmitJsonResultBlock(ExitCode exitCode, int? instrumentationExitCode, AndroidDevice? device, List<DiagnosticsFile> producedFiles)
-    {
-        // Construct Helix API URLs if running inside Helix
-        string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
-        string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
-
-        var fileEntries = new List<object>();
-        foreach (var file in producedFiles)
-        {
-            var entry = new Dictionary<string, string>
-            {
-                ["name"] = file.Name,
-                ["type"] = file.Type,
-            };
-
-            if (!string.IsNullOrEmpty(helixJobId) && !string.IsNullOrEmpty(helixWorkItem))
-            {
-                entry["helixApiUrl"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{Uri.EscapeDataString(helixWorkItem)}/files/{Uri.EscapeDataString(file.Name)}";
-            }
-
-            fileEntries.Add(entry);
-        }
-
-        var resultData = new Dictionary<string, object?>
-        {
-            ["version"] = 1,
-            ["exitCode"] = (int)exitCode,
-            ["exitCodeName"] = exitCode.ToString(),
-        };
-
-        if (instrumentationExitCode.HasValue)
-        {
-            resultData["instrumentationExitCode"] = instrumentationExitCode.Value;
-        }
-
-        if (device != null)
-        {
-            resultData["device"] = device.DeviceSerial;
-            if (device.ApiVersion.HasValue)
-            {
-                resultData["apiVersion"] = device.ApiVersion.Value;
-            }
-            if (!string.IsNullOrEmpty(device.Architecture))
-            {
-                resultData["architecture"] = device.Architecture;
-            }
-        }
-
-        if (fileEntries.Count > 0)
-        {
-            resultData["files"] = fileEntries;
-        }
-
-        var options = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-
-        string json = JsonSerializer.Serialize(resultData, options);
-        _logger.LogInformation($"<<XHARNESS_RESULT_START>>{Environment.NewLine}{json}{Environment.NewLine}<<XHARNESS_RESULT_END>>");
+        RunSummaryEmitter.EmitRunSummary(
+            _logger,
+            exitCode,
+            platform: "android",
+            deviceName: device?.DeviceSerial,
+            deviceOsVersion: deviceOsVersion,
+            architecture: device?.Architecture,
+            instrumentationExitCode: instrumentationExitCode,
+            producedFiles: producedFiles);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -84,19 +84,21 @@ public class InstrumentationRunner
             }
 
             var logcatFileName = $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log";
-            producedFiles.Add(new DiagnosticsFile { Name = logcatFileName, Type = "logcat" });
-
-            if (processCrashed)
-            {
-                producedFiles.Add(new DiagnosticsFile { Name = $"adb-bugreport-{apkPackageName}", Type = "bugreport" });
-            }
-
             var logcatFilePath = Path.Combine(outputDirectory, logcatFileName);
             logCatSucceeded = _runner.TryDumpAdbLog(logcatFilePath);
 
+            if (logCatSucceeded)
+            {
+                producedFiles.Add(new DiagnosticsFile { Name = logcatFileName, Type = "logcat" });
+            }
+
             if (processCrashed)
             {
-                _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
+                var bugreportPath = _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
+                if (!string.IsNullOrEmpty(bugreportPath))
+                {
+                    producedFiles.Add(new DiagnosticsFile { Name = Path.GetFileName(bugreportPath), Type = "bugreport" });
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -6,7 +6,11 @@ using Microsoft.DotNet.XHarness.Android.Execution;
 using System.Collections.Generic;
 using System.IO;
 using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using System.Linq;
 
@@ -42,6 +46,7 @@ public class InstrumentationRunner
         int expectedExitCode)
     {
         int? instrumentationExitCode = null;
+        var producedFiles = new List<DiagnosticsFile>();
 
         // No class name = default Instrumentation
         ProcessExecutionResults result = _runner.RunApkInstrumentation(apkPackageName, instrumentationName, instrumentationArguments, timeout);
@@ -54,7 +59,7 @@ public class InstrumentationRunner
         {
             if (result.ExitCode == (int)ExitCode.SUCCESS)
             {
-                (instrumentationExitCode, processCrashed, failurePullingFiles) = ParseInstrumentationResult(apkPackageName, outputDirectory, result.StandardOutput);
+                (instrumentationExitCode, processCrashed, failurePullingFiles) = ParseInstrumentationResult(apkPackageName, outputDirectory, result.StandardOutput, producedFiles);
             }
 
             // Optionally copy off an entire folder
@@ -66,6 +71,12 @@ public class InstrumentationRunner
                     foreach (string log in logs)
                     {
                         _logger.LogDebug($"Found output file: {log}");
+                        producedFiles.Add(new DiagnosticsFile
+                        {
+                            Name = Path.GetFileName(log),
+                            Type = "device-output",
+                            Path = log,
+                        });
                     }
                 }
                 catch (Exception toLog)
@@ -75,58 +86,83 @@ public class InstrumentationRunner
                 }
             }
 
-            logCatSucceeded = _runner.TryDumpAdbLog(Path.Combine(outputDirectory, $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log"));
+            var logcatFileName = $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log";
+            var logcatFilePath = Path.Combine(outputDirectory, logcatFileName);
+            logCatSucceeded = _runner.TryDumpAdbLog(logcatFilePath);
+
+            if (logCatSucceeded)
+            {
+                producedFiles.Add(new DiagnosticsFile
+                {
+                    Name = logcatFileName,
+                    Type = "logcat",
+                    Path = logcatFilePath,
+                });
+            }
 
             if (processCrashed)
             {
-                _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
+                var bugreportPath = _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
+                if (!string.IsNullOrEmpty(bugreportPath))
+                {
+                    producedFiles.Add(new DiagnosticsFile
+                    {
+                        Name = Path.GetFileName(bugreportPath),
+                        Type = "bugreport",
+                        Path = bugreportPath,
+                    });
+                }
             }
         }
+
+        // Determine exit code
+        ExitCode exitCode;
 
         // In case emulator crashes halfway through, we can tell by failing to pull ADB logs from it
         if (!logCatSucceeded)
         {
-            return ExitCode.SIMULATOR_FAILURE;
+            exitCode = ExitCode.SIMULATOR_FAILURE;
         }
-
-        if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
+        else if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
         {
-            return ExitCode.TIMED_OUT;
+            exitCode = ExitCode.TIMED_OUT;
         }
-
-        if (processCrashed)
+        else if (processCrashed)
         {
-            return ExitCode.APP_CRASH;
+            exitCode = ExitCode.APP_CRASH;
         }
-
-        if (failurePullingFiles)
+        else if (failurePullingFiles)
         {
             _logger.LogError($"Received expected instrumentation exit code ({instrumentationExitCode}), " +
                              "but we hit errors pulling files from the device (see log for details.)");
-            return ExitCode.DEVICE_FILE_COPY_FAILURE;
+            exitCode = ExitCode.DEVICE_FILE_COPY_FAILURE;
         }
-
-        if (!instrumentationExitCode.HasValue)
+        else if (!instrumentationExitCode.HasValue)
         {
-            return ExitCode.RETURN_CODE_NOT_SET;
+            exitCode = ExitCode.RETURN_CODE_NOT_SET;
         }
-
-        if (instrumentationExitCode != expectedExitCode)
+        else if (instrumentationExitCode != expectedExitCode)
         {
             _logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {expectedExitCode}");
-            return ExitCode.TESTS_FAILED;
+            exitCode = ExitCode.TESTS_FAILED;
+        }
+        else
+        {
+            exitCode = ExitCode.SUCCESS;
         }
 
-        return ExitCode.SUCCESS;
+        EmitRunSummary(exitCode, instrumentationExitCode, producedFiles);
+
+        return exitCode;
     }
 
-    private (int? ExitCode, bool Crashed, bool FilePullFailed) ParseInstrumentationResult(string apkPackageName, string outputDirectory, string result)
+    private (int? ExitCode, bool Crashed, bool FilePullFailed) ParseInstrumentationResult(string apkPackageName, string outputDirectory, string result, List<DiagnosticsFile> producedFiles)
     {
         // This is where test instrumentation can communicate outwardly that test execution failed
         IReadOnlyDictionary<string, string> resultValues = ParseInstrumentationOutputs(result);
 
         // Pull XUnit result XMLs off the device
-        bool failurePullingFiles = PullResultXMLs(apkPackageName, outputDirectory, resultValues)!;
+        bool failurePullingFiles = PullResultXMLs(apkPackageName, outputDirectory, resultValues, producedFiles)!;
         bool processCrashed = false;
 
         if (resultValues.TryGetValue(TestRunSummaryVariableName, out string? testRunSummary))
@@ -163,7 +199,7 @@ public class InstrumentationRunner
         return (ExitCode: instrumentationExitCode, Crashed: processCrashed, FilePullFailed: failurePullingFiles);
     }
 
-    private bool PullResultXMLs(string apkPackageName, string outputDirectory, IReadOnlyDictionary<string, string> resultValues)
+    private bool PullResultXMLs(string apkPackageName, string outputDirectory, IReadOnlyDictionary<string, string> resultValues, List<DiagnosticsFile> producedFiles)
     {
         bool success = false;
 
@@ -179,6 +215,12 @@ public class InstrumentationRunner
             try
             {
                 _runner.PullFiles(apkPackageName, resultFile, outputDirectory);
+                producedFiles.Add(new DiagnosticsFile
+                {
+                    Name = Path.GetFileName(resultFile),
+                    Type = "test-results",
+                    Path = Path.Combine(outputDirectory, Path.GetFileName(resultFile)),
+                });
             }
             catch (Exception toLog)
             {
@@ -221,5 +263,113 @@ public class InstrumentationRunner
         }
 
         return outputs;
+    }
+
+    private void EmitRunSummary(ExitCode exitCode, int? instrumentationExitCode, List<DiagnosticsFile> producedFiles)
+    {
+        // Human-readable summary
+        var summary = new StringBuilder();
+        summary.AppendLine("=== XHARNESS RUN SUMMARY ===");
+        summary.AppendLine($"Exit code: {(int)exitCode} ({exitCode})");
+
+        if (instrumentationExitCode.HasValue)
+        {
+            summary.AppendLine($"Instrumentation exit code: {instrumentationExitCode}");
+        }
+
+        var device = _runner.GetActiveDevice();
+        if (device != null)
+        {
+            summary.Append($"Device: {device.DeviceSerial}");
+            if (device.ApiVersion.HasValue)
+            {
+                summary.Append($" (API {device.ApiVersion}");
+                if (!string.IsNullOrEmpty(device.Architecture))
+                {
+                    summary.Append($", {device.Architecture}");
+                }
+                summary.Append(')');
+            }
+            summary.AppendLine();
+        }
+
+        if (producedFiles.Count > 0)
+        {
+            summary.AppendLine("Files produced:");
+            foreach (var file in producedFiles)
+            {
+                summary.AppendLine($"  [{file.Type.ToUpperInvariant()}] {file.Name}");
+            }
+        }
+
+        summary.Append("=============================");
+        _logger.LogInformation(summary.ToString());
+
+        // Machine-readable JSON block for AI agents
+        EmitJsonResultBlock(exitCode, instrumentationExitCode, device, producedFiles);
+    }
+
+    public void EmitJsonResultBlock(ExitCode exitCode, int? instrumentationExitCode, AndroidDevice? device, List<DiagnosticsFile> producedFiles)
+    {
+        // Construct Helix API URLs if running inside Helix
+        string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
+        string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
+
+        var fileEntries = new List<object>();
+        foreach (var file in producedFiles)
+        {
+            var entry = new Dictionary<string, string>
+            {
+                ["name"] = file.Name,
+                ["type"] = file.Type,
+            };
+
+            if (!string.IsNullOrEmpty(helixJobId) && !string.IsNullOrEmpty(helixWorkItem))
+            {
+                entry["helixApiUrl"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{Uri.EscapeDataString(helixWorkItem)}/files/{Uri.EscapeDataString(file.Name)}";
+            }
+
+            fileEntries.Add(entry);
+        }
+
+        var resultData = new Dictionary<string, object?>
+        {
+            ["version"] = 1,
+            ["exitCode"] = (int)exitCode,
+            ["exitCodeName"] = exitCode.ToString(),
+        };
+
+        if (instrumentationExitCode.HasValue)
+        {
+            resultData["instrumentationExitCode"] = instrumentationExitCode.Value;
+        }
+
+        if (device != null)
+        {
+            resultData["device"] = device.DeviceSerial;
+            if (device.ApiVersion.HasValue)
+            {
+                resultData["apiVersion"] = device.ApiVersion.Value;
+            }
+            if (!string.IsNullOrEmpty(device.Architecture))
+            {
+                resultData["architecture"] = device.Architecture;
+            }
+        }
+
+        if (fileEntries.Count > 0)
+        {
+            resultData["files"] = fileEntries;
+        }
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        string json = JsonSerializer.Serialize(resultData, options);
+        _logger.LogInformation($"<<XHARNESS_RESULT_START>>{Environment.NewLine}{json}{Environment.NewLine}<<XHARNESS_RESULT_END>>");
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -83,74 +83,72 @@ public class InstrumentationRunner
                 }
             }
 
-            var logcatFileName = $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log";
-            var logcatFilePath = Path.Combine(outputDirectory, logcatFileName);
-            logCatSucceeded = _runner.TryDumpAdbLog(logcatFilePath);
+            // Determine exit code before logcat dump so the summary appears first
+            ExitCode exitCode = DetermineExitCode(result, logCatSucceeded: true, processCrashed, failurePullingFiles, instrumentationExitCode, expectedExitCode);
 
-            if (logCatSucceeded)
-            {
-                producedFiles.Add(new DiagnosticsFile
-                {
-                    Name = logcatFileName,
-                    Type = "logcat",
-                    Path = logcatFilePath,
-                });
-            }
+            // Emit summary before the logcat dump for better visibility
+            var logcatFileName = $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log";
+            producedFiles.Add(new DiagnosticsFile { Name = logcatFileName, Type = "logcat" });
 
             if (processCrashed)
             {
-                var bugreportPath = _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
-                if (!string.IsNullOrEmpty(bugreportPath))
-                {
-                    producedFiles.Add(new DiagnosticsFile
-                    {
-                        Name = Path.GetFileName(bugreportPath),
-                        Type = "bugreport",
-                        Path = bugreportPath,
-                    });
-                }
+                producedFiles.Add(new DiagnosticsFile { Name = $"adb-bugreport-{apkPackageName}", Type = "bugreport" });
+            }
+
+            EmitRunSummary(exitCode, instrumentationExitCode, producedFiles, outputDirectory);
+
+            // Now dump the logcat (which produces console output)
+            var logcatFilePath = Path.Combine(outputDirectory, logcatFileName);
+            logCatSucceeded = _runner.TryDumpAdbLog(logcatFilePath);
+
+            if (processCrashed)
+            {
+                _runner.DumpBugReport(Path.Combine(outputDirectory, $"adb-bugreport-{apkPackageName}"));
             }
         }
 
-        // Determine exit code
-        ExitCode exitCode;
+        // Re-determine exit code with actual logcat success
+        ExitCode finalExitCode = DetermineExitCode(result, logCatSucceeded, processCrashed, failurePullingFiles, instrumentationExitCode, expectedExitCode);
 
-        // In case emulator crashes halfway through, we can tell by failing to pull ADB logs from it
+        return finalExitCode;
+    }
+
+    private ExitCode DetermineExitCode(ProcessExecutionResults result, bool logCatSucceeded, bool processCrashed, bool failurePullingFiles, int? instrumentationExitCode, int expectedExitCode)
+    {
         if (!logCatSucceeded)
         {
-            exitCode = ExitCode.SIMULATOR_FAILURE;
+            return ExitCode.SIMULATOR_FAILURE;
         }
-        else if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
+
+        if (result.ExitCode == (int)AdbExitCodes.INSTRUMENTATION_TIMEOUT)
         {
-            exitCode = ExitCode.TIMED_OUT;
+            return ExitCode.TIMED_OUT;
         }
-        else if (processCrashed)
+
+        if (processCrashed)
         {
-            exitCode = ExitCode.APP_CRASH;
+            return ExitCode.APP_CRASH;
         }
-        else if (failurePullingFiles)
+
+        if (failurePullingFiles)
         {
             _logger.LogError($"Received expected instrumentation exit code ({instrumentationExitCode}), " +
                              "but we hit errors pulling files from the device (see log for details.)");
-            exitCode = ExitCode.DEVICE_FILE_COPY_FAILURE;
+            return ExitCode.DEVICE_FILE_COPY_FAILURE;
         }
-        else if (!instrumentationExitCode.HasValue)
+
+        if (!instrumentationExitCode.HasValue)
         {
-            exitCode = ExitCode.RETURN_CODE_NOT_SET;
+            return ExitCode.RETURN_CODE_NOT_SET;
         }
-        else if (instrumentationExitCode != expectedExitCode)
+
+        if (instrumentationExitCode != expectedExitCode)
         {
             _logger.LogError($"Non-success instrumentation exit code: {instrumentationExitCode}, expected: {expectedExitCode}");
-            exitCode = ExitCode.TESTS_FAILED;
-        }
-        else
-        {
-            exitCode = ExitCode.SUCCESS;
+            return ExitCode.TESTS_FAILED;
         }
 
-        EmitRunSummary(exitCode, instrumentationExitCode, producedFiles);
-
-        return exitCode;
+        return ExitCode.SUCCESS;
     }
 
     private (int? ExitCode, bool Crashed, bool FilePullFailed) ParseInstrumentationResult(string apkPackageName, string outputDirectory, string result, List<DiagnosticsFile> producedFiles)
@@ -262,13 +260,23 @@ public class InstrumentationRunner
         return outputs;
     }
 
-    private void EmitRunSummary(ExitCode exitCode, int? instrumentationExitCode, List<DiagnosticsFile> producedFiles)
+    private void EmitRunSummary(ExitCode exitCode, int? instrumentationExitCode, List<DiagnosticsFile> producedFiles, string outputDirectory)
     {
         var device = _runner.GetActiveDevice();
         string? deviceOsVersion = device?.ApiVersion.HasValue == true ? $"API {device.ApiVersion}" : null;
 
         RunSummaryEmitter.EmitRunSummary(
             _logger,
+            exitCode,
+            platform: "android",
+            deviceName: device?.DeviceSerial,
+            deviceOsVersion: deviceOsVersion,
+            architecture: device?.Architecture,
+            instrumentationExitCode: instrumentationExitCode,
+            producedFiles: producedFiles);
+
+        RunSummaryEmitter.WriteResultJsonFile(
+            outputDirectory,
             exitCode,
             platform: "android",
             deviceName: device?.DeviceSerial,

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -83,10 +83,6 @@ public class InstrumentationRunner
                 }
             }
 
-            // Determine exit code before logcat dump so the summary appears first
-            ExitCode exitCode = DetermineExitCode(result, logCatSucceeded: true, processCrashed, failurePullingFiles, instrumentationExitCode, expectedExitCode);
-
-            // Emit summary before the logcat dump for better visibility
             var logcatFileName = $"adb-logcat-{apkPackageName}-{(instrumentationName ?? "default")}.log";
             producedFiles.Add(new DiagnosticsFile { Name = logcatFileName, Type = "logcat" });
 
@@ -95,9 +91,6 @@ public class InstrumentationRunner
                 producedFiles.Add(new DiagnosticsFile { Name = $"adb-bugreport-{apkPackageName}", Type = "bugreport" });
             }
 
-            EmitRunSummary(exitCode, instrumentationExitCode, producedFiles, outputDirectory);
-
-            // Now dump the logcat (which produces console output)
             var logcatFilePath = Path.Combine(outputDirectory, logcatFileName);
             logCatSucceeded = _runner.TryDumpAdbLog(logcatFilePath);
 
@@ -107,10 +100,11 @@ public class InstrumentationRunner
             }
         }
 
-        // Re-determine exit code with actual logcat success
-        ExitCode finalExitCode = DetermineExitCode(result, logCatSucceeded, processCrashed, failurePullingFiles, instrumentationExitCode, expectedExitCode);
+        // Determine exit code and emit summary after all operations complete
+        ExitCode exitCode = DetermineExitCode(result, logCatSucceeded, processCrashed, failurePullingFiles, instrumentationExitCode, expectedExitCode);
+        EmitRunSummary(exitCode, instrumentationExitCode, producedFiles, outputDirectory);
 
-        return finalExitCode;
+        return exitCode;
     }
 
     private ExitCode DetermineExitCode(ProcessExecutionResults result, bool logCatSucceeded, bool processCrashed, bool failurePullingFiles, int? instrumentationExitCode, int expectedExitCode)

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -44,6 +44,7 @@ public abstract class BaseOrchestrator : IDisposable
     private readonly IHelpers _helpers;
 
     private bool _lldbFileCreated;
+    private bool _summaryEmitted;
 
     // This is needed because
     // - For simulators, we query the simulator for Info.plist location and parse it
@@ -158,6 +159,11 @@ public abstract class BaseOrchestrator : IDisposable
 
         if (target.Platform == TestTarget.MacCatalyst)
         {
+            // MacCatalyst runs on the local Mac — set device info accordingly
+            _diagnosticsData.Device = Environment.MachineName;
+            _diagnosticsData.TargetOS = $"macOS {Environment.OSVersion.Version}";
+            _diagnosticsData.IsDevice = false;
+
             try
             {
                 appBundleInfo = await getAppBundle(target, null!, cancellationToken);
@@ -360,8 +366,15 @@ public abstract class BaseOrchestrator : IDisposable
         return exitCode;
     }
 
-    private void EmitAppleRunSummary(ExitCode exitCode)
+    protected void EmitAppleRunSummary(ExitCode exitCode)
     {
+        if (_summaryEmitted)
+        {
+            return;
+        }
+
+        _summaryEmitted = true;
+
         var producedFiles = new List<DiagnosticsFile>();
 
         // Collect files from the logs collection
@@ -398,6 +411,16 @@ public abstract class BaseOrchestrator : IDisposable
 
         RunSummaryEmitter.EmitRunSummary(
             message => _logger.LogInformation(message),
+            exitCode,
+            platform: "apple",
+            deviceName: _diagnosticsData.Device,
+            deviceOsVersion: _diagnosticsData.TargetOS,
+            architecture: null,
+            instrumentationExitCode: null,
+            producedFiles: producedFiles);
+
+        RunSummaryEmitter.WriteResultJsonFile(
+            _logs.Directory,
             exitCode,
             platform: "apple",
             deviceName: _diagnosticsData.Device,

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -44,7 +44,6 @@ public abstract class BaseOrchestrator : IDisposable
     private readonly IHelpers _helpers;
 
     private bool _lldbFileCreated;
-    private bool _summaryEmitted;
 
     // This is needed because
     // - For simulators, we query the simulator for Info.plist location and parse it
@@ -93,9 +92,10 @@ public abstract class BaseOrchestrator : IDisposable
         ExecuteAppFunc executeApp,
         CancellationToken cancellationToken)
     {
+        ExitCode exitCode = ExitCode.GENERAL_FAILURE;
         try
         {
-            return await OrchestrateOperationInternal(
+            exitCode = await OrchestrateOperationInternal(
                 target,
                 deviceName,
                 includeWirelessDevices,
@@ -109,8 +109,14 @@ public abstract class BaseOrchestrator : IDisposable
         catch (OperationCanceledException e)
         {
             _logger.LogDebug(e.ToString());
-            return ExitCode.APP_LAUNCH_TIMEOUT;
+            exitCode = ExitCode.APP_LAUNCH_TIMEOUT;
         }
+        finally
+        {
+            EmitAppleRunSummary(exitCode);
+        }
+
+        return exitCode;
     }
 
     private async Task<ExitCode> OrchestrateOperationInternal(
@@ -205,7 +211,6 @@ public abstract class BaseOrchestrator : IDisposable
                 _logger.LogError(message.ToString());
             }
 
-            EmitAppleRunSummary(exitCode);
             return exitCode;
         }
 
@@ -361,20 +366,11 @@ public abstract class BaseOrchestrator : IDisposable
             }
         }
 
-        EmitAppleRunSummary(exitCode);
-
         return exitCode;
     }
 
     protected void EmitAppleRunSummary(ExitCode exitCode)
     {
-        if (_summaryEmitted)
-        {
-            return;
-        }
-
-        _summaryEmitted = true;
-
         var producedFiles = new List<DiagnosticsFile>();
 
         // Collect files from the logs collection

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -170,7 +171,7 @@ public abstract class BaseOrchestrator : IDisposable
 
             try
             {
-                return await executeMacCatalystApp(appBundleInfo);
+                exitCode = await executeMacCatalystApp(appBundleInfo);
             }
             catch (Exception e)
             {
@@ -196,9 +197,10 @@ public abstract class BaseOrchestrator : IDisposable
                 }
 
                 _logger.LogError(message.ToString());
-
-                return exitCode;
             }
+
+            EmitAppleRunSummary(exitCode);
+            return exitCode;
         }
 
         try
@@ -353,7 +355,56 @@ public abstract class BaseOrchestrator : IDisposable
             }
         }
 
+        EmitAppleRunSummary(exitCode);
+
         return exitCode;
+    }
+
+    private void EmitAppleRunSummary(ExitCode exitCode)
+    {
+        var producedFiles = new List<DiagnosticsFile>();
+
+        // Collect files from the logs collection
+        foreach (var log in _logs.OfType<IFileBackedLog>())
+        {
+            if (string.IsNullOrEmpty(log.FullPath) || !File.Exists(log.FullPath))
+            {
+                continue;
+            }
+
+            // Skip empty log files
+            var fileInfo = new FileInfo(log.FullPath);
+            if (fileInfo.Length == 0)
+            {
+                continue;
+            }
+
+            var fileName = Path.GetFileName(log.FullPath);
+            var fileType = log.Description ?? "log";
+
+            producedFiles.Add(new DiagnosticsFile
+            {
+                Name = fileName,
+                Type = fileType.ToLowerInvariant().Replace(" ", "-"),
+                Path = log.FullPath,
+            });
+        }
+
+        // Also populate diagnostics data files
+        foreach (var file in producedFiles)
+        {
+            _diagnosticsData.Files.Add(file);
+        }
+
+        RunSummaryEmitter.EmitRunSummary(
+            message => _logger.LogInformation(message),
+            exitCode,
+            platform: "apple",
+            deviceName: _diagnosticsData.Device,
+            deviceOsVersion: _diagnosticsData.TargetOS,
+            architecture: null,
+            instrumentationExitCode: null,
+            producedFiles: producedFiles);
     }
 
     public void Dispose()

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -49,6 +49,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
     private readonly ILogs _logs;
     private readonly IFileBackedLog _mainLog;
     private readonly IErrorKnowledgeBase _errorKnowledgeBase;
+    private readonly IDiagnosticsData _diagnosticsData;
 
     public TestOrchestrator(
         IAppBundleInformationParser appBundleInformationParser,
@@ -69,6 +70,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
         _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
         _errorKnowledgeBase = errorKnowledgeBase ?? throw new ArgumentNullException(nameof(errorKnowledgeBase));
+        _diagnosticsData = diagnosticsData ?? throw new ArgumentNullException(nameof(diagnosticsData));
     }
 
     public Task<ExitCode> OrchestrateTest(
@@ -251,6 +253,8 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
 
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
 
+        EmitAppleRunSummary(exitCode);
+
         if (!target.Platform.IsSimulator()) // Simulator app logs are already included in the main log
         {
             // Copy system and application logs to the main log for better failure investigation.
@@ -288,6 +292,8 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             cancellationToken: cancellationToken);
 
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
+
+        EmitAppleRunSummary(exitCode);
 
         // Copy system and application logs to the main log for better failure investigation.
         CopyLogsToMainLog();

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -49,7 +49,6 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
     private readonly ILogs _logs;
     private readonly IFileBackedLog _mainLog;
     private readonly IErrorKnowledgeBase _errorKnowledgeBase;
-    private readonly IDiagnosticsData _diagnosticsData;
 
     public TestOrchestrator(
         IAppBundleInformationParser appBundleInformationParser,
@@ -70,7 +69,6 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
         _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
         _errorKnowledgeBase = errorKnowledgeBase ?? throw new ArgumentNullException(nameof(errorKnowledgeBase));
-        _diagnosticsData = diagnosticsData ?? throw new ArgumentNullException(nameof(diagnosticsData));
     }
 
     public Task<ExitCode> OrchestrateTest(
@@ -253,13 +251,8 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
 
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
 
-        EmitAppleRunSummary(exitCode);
-
-        if (!target.Platform.IsSimulator()) // Simulator app logs are already included in the main log
-        {
-            // Copy system and application logs to the main log for better failure investigation.
-            CopyLogsToMainLog();
-        }
+        // Copy application logs to the main log for better failure investigation.
+        CopyLogsToMainLog();
 
         return exitCode;
     }
@@ -293,10 +286,8 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
 
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
 
-        EmitAppleRunSummary(exitCode);
-
-        // Copy system and application logs to the main log for better failure investigation.
-        CopyLogsToMainLog();
+        // Copy system log to the main log — MacCatalyst output goes to SystemLog, not ApplicationLog
+        CopyLogsToMainLog(isMacCatalyst: true);
 
         return exitCode;
     }
@@ -388,9 +379,14 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
     /// <summary>
     /// Copy system and application logs to the main log for better failure investigation.
     /// </summary>
-    private void CopyLogsToMainLog()
+    private void CopyLogsToMainLog(bool isMacCatalyst = false)
     {
-        var logs = _logs.Where(log => log.Description == LogType.ApplicationLog.ToString()).ToList();
+        // ApplicationLog: app console output captured via simctl (iOS/tvOS simulators, devices)
+        // SystemLog: macOS system log where MacCatalyst app output goes (runs as native process)
+        var targetLogType = isMacCatalyst ? LogType.SystemLog : LogType.ApplicationLog;
+        var logs = _logs.Where(log => log.Description == targetLogType.ToString()).ToList();
+
+        _logger.LogInformation($"Copying {targetLogType} logs to the main log for better failure investigation. Logs count: {logs.Count}.");
 
         foreach (var log in logs)
         {

--- a/src/Microsoft.DotNet.XHarness.Common/CommandDiagnostics.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CommandDiagnostics.cs
@@ -35,6 +35,11 @@ public interface IDiagnosticsData
     /// True when the target is a real HW device, false for simulators, maccatalyst..
     /// </summary>
     bool? IsDevice { get; set; }
+
+    /// <summary>
+    /// Files produced during the command execution.
+    /// </summary>
+    IList<DiagnosticsFile> Files { get; }
 }
 
 /// <summary>
@@ -63,6 +68,9 @@ public class CommandDiagnostics : IDiagnosticsData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? IsDevice { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public IList<DiagnosticsFile> Files { get; } = new List<DiagnosticsFile>();
 
     public int Duration => (int)Math.Round(_timer.Elapsed.TotalSeconds);
 
@@ -147,4 +155,16 @@ public class CommandDiagnostics : IDiagnosticsData
             _logger.LogError("Failed to save diagnostics data to '{pathToFile}': {error}", targetFile, e);
         }
     }
+}
+
+/// <summary>
+/// Represents a file produced during a command execution.
+/// </summary>
+public class DiagnosticsFile
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Path { get; set; }
 }

--- a/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.DotNet.XHarness.Common.CLI;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.DotNet.XHarness.Common;
+
+/// <summary>
+/// Emits a structured run summary and machine-readable JSON block to the console log.
+/// Used by both Android and Apple platforms to provide consistent output for humans and AI agents.
+/// </summary>
+public static class RunSummaryEmitter
+{
+    public const string JsonStartMarker = "<<XHARNESS_RESULT_START>>";
+    public const string JsonEndMarker = "<<XHARNESS_RESULT_END>>";
+
+    /// <summary>
+    /// Emits a human-readable summary block followed by a machine-readable JSON block.
+    /// </summary>
+    public static void EmitRunSummary(
+        ILogger logger,
+        ExitCode exitCode,
+        string platform,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
+        EmitRunSummary(
+            message => logger.LogInformation(message),
+            exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+    }
+
+    /// <summary>
+    /// Emits a human-readable summary block followed by a machine-readable JSON block.
+    /// Uses an Action&lt;string&gt; for logging to support different logger abstractions.
+    /// </summary>
+    public static void EmitRunSummary(
+        Action<string> logInfo,
+        ExitCode exitCode,
+        string platform,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
+        EmitHumanSummary(logInfo, exitCode, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+        EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+    }
+
+    private static void EmitHumanSummary(
+        Action<string> logInfo,
+        ExitCode exitCode,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
+        var summary = new StringBuilder();
+        summary.AppendLine("=== XHARNESS RUN SUMMARY ===");
+        summary.AppendLine($"Exit code: {(int)exitCode} ({exitCode})");
+
+        if (instrumentationExitCode.HasValue)
+        {
+            summary.AppendLine($"Instrumentation exit code: {instrumentationExitCode}");
+        }
+
+        if (!string.IsNullOrEmpty(deviceName))
+        {
+            summary.Append($"Device: {deviceName}");
+            var details = new List<string>();
+            if (!string.IsNullOrEmpty(deviceOsVersion))
+            {
+                details.Add(deviceOsVersion);
+            }
+            if (!string.IsNullOrEmpty(architecture))
+            {
+                details.Add(architecture);
+            }
+            if (details.Count > 0)
+            {
+                summary.Append($" ({string.Join(", ", details)})");
+            }
+            summary.AppendLine();
+        }
+
+        if (producedFiles.Count > 0)
+        {
+            summary.AppendLine("Files produced:");
+            foreach (var file in producedFiles)
+            {
+                summary.AppendLine($"  [{file.Type.ToUpperInvariant()}] {file.Name}");
+            }
+        }
+
+        summary.Append("=============================");
+        logInfo(summary.ToString());
+    }
+
+    /// <summary>
+    /// Emits a machine-readable JSON block between well-known delimiters for AI agents.
+    /// When running in Helix, includes API URLs for direct file download.
+    /// </summary>
+    public static void EmitJsonResultBlock(
+        Action<string> logInfo,
+        ExitCode exitCode,
+        string platform,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
+        string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
+        string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
+
+        var fileEntries = new List<object>();
+        foreach (var file in producedFiles)
+        {
+            var entry = new Dictionary<string, string>
+            {
+                ["name"] = file.Name,
+                ["type"] = file.Type,
+            };
+
+            if (!string.IsNullOrEmpty(helixJobId) && !string.IsNullOrEmpty(helixWorkItem))
+            {
+                entry["helixApiUrl"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{Uri.EscapeDataString(helixWorkItem)}/files/{Uri.EscapeDataString(file.Name)}";
+            }
+
+            fileEntries.Add(entry);
+        }
+
+        var resultData = new Dictionary<string, object?>
+        {
+            ["version"] = 1,
+            ["exitCode"] = (int)exitCode,
+            ["exitCodeName"] = exitCode.ToString(),
+            ["platform"] = platform,
+        };
+
+        if (instrumentationExitCode.HasValue)
+        {
+            resultData["instrumentationExitCode"] = instrumentationExitCode.Value;
+        }
+
+        if (!string.IsNullOrEmpty(deviceName))
+        {
+            resultData["device"] = deviceName;
+        }
+
+        if (!string.IsNullOrEmpty(deviceOsVersion))
+        {
+            resultData["deviceOsVersion"] = deviceOsVersion;
+        }
+
+        if (!string.IsNullOrEmpty(architecture))
+        {
+            resultData["architecture"] = architecture;
+        }
+
+        if (fileEntries.Count > 0)
+        {
+            resultData["files"] = fileEntries;
+        }
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        string json = JsonSerializer.Serialize(resultData, options);
+        logInfo($"{JsonStartMarker}{Environment.NewLine}{json}{Environment.NewLine}{JsonEndMarker}");
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -67,6 +68,7 @@ public static class RunSummaryEmitter
     {
         var summary = new StringBuilder();
         summary.AppendLine("=== XHARNESS RUN SUMMARY ===");
+        summary.AppendLine($"Machine: {Environment.MachineName}");
         summary.AppendLine($"Exit code: {(int)exitCode} ({exitCode})");
 
         if (instrumentationExitCode.HasValue)
@@ -120,6 +122,63 @@ public static class RunSummaryEmitter
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles)
     {
+        var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        string json = JsonSerializer.Serialize(resultData, options);
+        logInfo($"{JsonStartMarker}{Environment.NewLine}{json}{Environment.NewLine}{JsonEndMarker}");
+    }
+
+    /// <summary>
+    /// Writes the JSON result block as a file (xharness-result.json) in the specified directory.
+    /// This file gets uploaded to Helix automatically when written to the output/uploads directory.
+    /// </summary>
+    public static void WriteResultJsonFile(
+        string outputDirectory,
+        ExitCode exitCode,
+        string platform,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
+        try
+        {
+            var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            };
+
+            string json = JsonSerializer.Serialize(resultData, options);
+            Directory.CreateDirectory(outputDirectory);
+            File.WriteAllText(Path.Combine(outputDirectory, "xharness-result.json"), json);
+        }
+        catch
+        {
+            // Best effort — don't fail the run if file writing fails
+        }
+    }
+
+    private static Dictionary<string, object?> BuildResultData(
+        ExitCode exitCode,
+        string platform,
+        string? deviceName,
+        string? deviceOsVersion,
+        string? architecture,
+        int? instrumentationExitCode,
+        IReadOnlyList<DiagnosticsFile> producedFiles)
+    {
         string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
         string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
 
@@ -132,21 +191,26 @@ public static class RunSummaryEmitter
                 ["type"] = file.Type,
             };
 
-            if (!string.IsNullOrEmpty(helixJobId) && !string.IsNullOrEmpty(helixWorkItem))
-            {
-                entry["helixApiUrl"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{Uri.EscapeDataString(helixWorkItem)}/files/{Uri.EscapeDataString(file.Name)}";
-            }
-
             fileEntries.Add(entry);
         }
 
         var resultData = new Dictionary<string, object?>
         {
             ["version"] = 1,
+            ["machineName"] = Environment.MachineName,
             ["exitCode"] = (int)exitCode,
             ["exitCodeName"] = exitCode.ToString(),
             ["platform"] = platform,
         };
+
+        if (!string.IsNullOrEmpty(helixJobId) && !string.IsNullOrEmpty(helixWorkItem))
+        {
+            var encodedWorkItem = Uri.EscapeDataString(helixWorkItem);
+            resultData["helixWorkItemId"] = helixWorkItem;
+            resultData["helixJobId"] = helixJobId;
+            resultData["helixConsoleUri"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{encodedWorkItem}/console";
+            resultData["helixFilesUri"] = $"https://helix.dot.net/api/2019-06-17/jobs/{helixJobId}/workitems/{encodedWorkItem}/files";
+        }
 
         if (instrumentationExitCode.HasValue)
         {
@@ -173,14 +237,6 @@ public static class RunSummaryEmitter
             resultData["files"] = fileEntries;
         }
 
-        var options = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-
-        string json = JsonSerializer.Serialize(resultData, options);
-        logInfo($"{JsonStartMarker}{Environment.NewLine}{json}{Environment.NewLine}{JsonEndMarker}");
+        return resultData;
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.DotNet.XHarness.Common.CLI;
@@ -13,8 +12,8 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.DotNet.XHarness.Common;
 
 /// <summary>
-/// Emits a structured run summary and machine-readable JSON block to the console log.
-/// Used by both Android and Apple platforms to provide consistent output for humans and AI agents.
+/// Emits a structured JSON result block to the console log.
+/// Used by both Android and Apple platforms to provide consistent output for humans and automated tooling.
 /// </summary>
 public static class RunSummaryEmitter
 {
@@ -22,7 +21,7 @@ public static class RunSummaryEmitter
     public const string JsonEndMarker = "<<XHARNESS_RESULT_END>>";
 
     /// <summary>
-    /// Emits a human-readable summary block followed by a machine-readable JSON block.
+    /// Emits a structured JSON result block to the log.
     /// </summary>
     public static void EmitRunSummary(
         ILogger logger,
@@ -40,7 +39,7 @@ public static class RunSummaryEmitter
     }
 
     /// <summary>
-    /// Emits a human-readable summary block followed by a machine-readable JSON block.
+    /// Emits a structured JSON result block to the log.
     /// Uses an Action&lt;string&gt; for logging to support different logger abstractions.
     /// </summary>
     public static void EmitRunSummary(
@@ -53,59 +52,7 @@ public static class RunSummaryEmitter
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles)
     {
-        EmitHumanSummary(logInfo, exitCode, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
         EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
-    }
-
-    private static void EmitHumanSummary(
-        Action<string> logInfo,
-        ExitCode exitCode,
-        string? deviceName,
-        string? deviceOsVersion,
-        string? architecture,
-        int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
-    {
-        var summary = new StringBuilder();
-        summary.AppendLine("=== XHARNESS RUN SUMMARY ===");
-        summary.AppendLine($"Machine: {Environment.MachineName}");
-        summary.AppendLine($"Exit code: {(int)exitCode} ({exitCode})");
-
-        if (instrumentationExitCode.HasValue)
-        {
-            summary.AppendLine($"Instrumentation exit code: {instrumentationExitCode}");
-        }
-
-        if (!string.IsNullOrEmpty(deviceName))
-        {
-            summary.Append($"Device: {deviceName}");
-            var details = new List<string>();
-            if (!string.IsNullOrEmpty(deviceOsVersion))
-            {
-                details.Add(deviceOsVersion);
-            }
-            if (!string.IsNullOrEmpty(architecture))
-            {
-                details.Add(architecture);
-            }
-            if (details.Count > 0)
-            {
-                summary.Append($" ({string.Join(", ", details)})");
-            }
-            summary.AppendLine();
-        }
-
-        if (producedFiles.Count > 0)
-        {
-            summary.AppendLine("Files produced:");
-            foreach (var file in producedFiles)
-            {
-                summary.AppendLine($"  [{file.Type.ToUpperInvariant()}] {file.Name}");
-            }
-        }
-
-        summary.Append("=============================");
-        logInfo(summary.ToString());
     }
 
     /// <summary>

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerLogFilterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerLogFilterTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Android.Tests;
+
+public class AdbRunnerLogFilterTests
+{
+    [Fact]
+    public void FilterToDotnetLines_FiltersCorrectly()
+    {
+        var logcat = string.Join('\n', new[]
+        {
+            "03-24 21:14:29.731 15103 17813 I EuiccGoogle: some noise",
+            "03-24 21:14:30.240 17856 17873 I DOTNET  : Extracting asset to /data/user/0/net.dot.Tests/files/System.Linq.dll",
+            "03-24 21:14:30.247 16176 17499 E SpeechMicro: Hotword model is single-channel neuralnet.",
+            "03-24 21:15:34.276 17856 25041 I DOTNET  : === TEST EXECUTION SUMMARY ===",
+            "03-24 21:15:34.276 17856 25041 I DOTNET  : Tests run: 2686 Passed: 2247 Failed: 26",
+            "03-24 21:15:34.281 17856 17873 D DOTNET  : Exit code: 1.",
+        });
+
+        var result = AdbRunner.FilterToDotnetLines(logcat);
+
+        Assert.Contains("Extracting asset", result);
+        Assert.Contains("TEST EXECUTION SUMMARY", result);
+        Assert.Contains("Tests run: 2686", result);
+        Assert.Contains("Exit code: 1", result);
+        Assert.DoesNotContain("EuiccGoogle", result);
+        Assert.DoesNotContain("SpeechMicro", result);
+    }
+
+    [Fact]
+    public void FilterToDotnetLines_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, AdbRunner.FilterToDotnetLines(""));
+        Assert.Equal(string.Empty, AdbRunner.FilterToDotnetLines(null!));
+    }
+
+    [Fact]
+    public void FilterToDotnetLines_NoDotnetLines_ReturnsEmpty()
+    {
+        var logcat = "03-24 21:14:29.731 15103 17813 I EuiccGoogle: noise\n03-24 21:14:29.731 15103 17813 I Finsky: more noise";
+
+        var result = AdbRunner.FilterToDotnetLines(logcat);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void FilterToDotnetLines_HandlesWindowsLineEndings()
+    {
+        var logcat = "noise line\r\n03-24 21:15:34.276 17856 25041 I DOTNET  : test output\r\nmore noise\r\n";
+
+        var result = AdbRunner.FilterToDotnetLines(logcat);
+
+        Assert.Contains("DOTNET  : test output", result);
+        Assert.DoesNotContain("noise line", result);
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -15,12 +15,12 @@ using Xunit;
 
 namespace Microsoft.DotNet.XHarness.Android.Tests;
 
-public class RunSummaryEmitterTests
+public class InstrumentationRunnerSummaryTests
 {
     private readonly Mock<ILogger> _mockLogger;
     private readonly List<string> _loggedMessages;
 
-    public RunSummaryEmitterTests()
+    public InstrumentationRunnerSummaryTests()
     {
         _mockLogger = new Mock<ILogger>();
         _loggedMessages = new List<string>();

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -127,9 +127,9 @@ public class RunSummaryEmitterTests
             RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, files);
 
             var json = ExtractJsonFromLogs();
-            var url = json.GetProperty("files")[0].GetProperty("helixApiUrl").GetString();
-            Assert.Contains("test-job-id", url);
-            Assert.Contains("testResults.xml", url);
+            Assert.Equal("test-job-id", json.GetProperty("helixJobId").GetString());
+            Assert.Contains("test-job-id", json.GetProperty("helixConsoleUri").GetString());
+            Assert.Contains("test-job-id", json.GetProperty("helixFilesUri").GetString());
         }
         finally
         {
@@ -152,7 +152,8 @@ public class RunSummaryEmitterTests
         RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, files);
 
         var json = ExtractJsonFromLogs();
-        Assert.False(json.GetProperty("files")[0].TryGetProperty("helixApiUrl", out _));
+        Assert.False(json.TryGetProperty("helixJobId", out _));
+        Assert.False(json.TryGetProperty("helixFilesUri", out _));
     }
 
     [Fact]

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -108,6 +108,9 @@ public class InstrumentationRunnerSummaryTests
             new() { Name = "testResults.xml", Type = "test-results" },
         };
 
+        var originalCorrelationId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
+        var originalFriendlyName = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
+
         Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "test-job-id");
         Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "My.Test");
 
@@ -122,8 +125,8 @@ public class InstrumentationRunnerSummaryTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", null);
-            Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", null);
+            Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", originalCorrelationId);
+            Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", originalFriendlyName);
         }
     }
 

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -6,9 +6,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Text.Json;
-using Microsoft.DotNet.XHarness.Android.Execution;
 using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.Extensions.Logging;
@@ -17,23 +15,15 @@ using Xunit;
 
 namespace Microsoft.DotNet.XHarness.Android.Tests;
 
-public class InstrumentationRunnerSummaryTests : IDisposable
+public class RunSummaryEmitterTests
 {
     private readonly Mock<ILogger> _mockLogger;
-    private readonly Mock<IAdbProcessManager> _processManager;
     private readonly List<string> _loggedMessages;
-    private readonly string _fakeAdbPath;
-    private readonly string _tempDir;
 
-    public InstrumentationRunnerSummaryTests()
+    public RunSummaryEmitterTests()
     {
         _mockLogger = new Mock<ILogger>();
-        _processManager = new Mock<IAdbProcessManager>();
         _loggedMessages = new List<string>();
-        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(_tempDir);
-        _fakeAdbPath = Path.Combine(_tempDir, "adb");
-        File.WriteAllText(_fakeAdbPath, string.Empty);
 
         _mockLogger
             .Setup(l => l.Log(
@@ -48,22 +38,15 @@ public class InstrumentationRunnerSummaryTests : IDisposable
             });
     }
 
-    public void Dispose()
-    {
-        Directory.Delete(_tempDir, true);
-        GC.SuppressFinalize(this);
-    }
-
     [Fact]
-    public void EmitJsonResultBlock_ContainsDelimiters()
+    public void EmitRunSummary_ContainsDelimiters()
     {
-        var runner = CreateRunner();
         var files = new List<DiagnosticsFile>
         {
             new() { Name = "testResults.xml", Type = "test-results" }
         };
 
-        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", "device1", "API 33", "arm64", 0, files);
 
         var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));
         Assert.NotNull(jsonMessage);
@@ -71,11 +54,20 @@ public class InstrumentationRunnerSummaryTests : IDisposable
     }
 
     [Fact]
+    public void EmitRunSummary_ContainsHumanSummary()
+    {
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.TESTS_FAILED, "android", "device1", "API 33", "arm64", 1, new List<DiagnosticsFile>());
+
+        var summary = _loggedMessages.Find(m => m.Contains("XHARNESS RUN SUMMARY"));
+        Assert.NotNull(summary);
+        Assert.Contains("TESTS_FAILED", summary);
+        Assert.Contains("device1", summary);
+    }
+
+    [Fact]
     public void EmitJsonResultBlock_ContainsExitCode()
     {
-        var runner = CreateRunner();
-
-        runner.EmitJsonResultBlock(ExitCode.TESTS_FAILED, 1, null, new List<DiagnosticsFile>());
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.TESTS_FAILED, "android", null, null, null, 1, new List<DiagnosticsFile>());
 
         var json = ExtractJsonFromLogs();
         Assert.Equal(1, json.GetProperty("exitCode").GetInt32());
@@ -83,59 +75,60 @@ public class InstrumentationRunnerSummaryTests : IDisposable
     }
 
     [Fact]
+    public void EmitJsonResultBlock_ContainsPlatform()
+    {
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "apple", "iPhone", "iOS 18", null, null, new List<DiagnosticsFile>());
+
+        var json = ExtractJsonFromLogs();
+        Assert.Equal("apple", json.GetProperty("platform").GetString());
+    }
+
+    [Fact]
     public void EmitJsonResultBlock_ContainsDeviceInfo()
     {
-        var runner = CreateRunner();
-        var device = new AndroidDevice("SERIAL123") { ApiVersion = 33, Architecture = "arm64-v8a" };
-
-        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, device, new List<DiagnosticsFile>());
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", "SERIAL123", "API 33", "arm64-v8a", 0, new List<DiagnosticsFile>());
 
         var json = ExtractJsonFromLogs();
         Assert.Equal("SERIAL123", json.GetProperty("device").GetString());
-        Assert.Equal(33, json.GetProperty("apiVersion").GetInt32());
+        Assert.Equal("API 33", json.GetProperty("deviceOsVersion").GetString());
         Assert.Equal("arm64-v8a", json.GetProperty("architecture").GetString());
     }
 
     [Fact]
     public void EmitJsonResultBlock_ContainsFileInfo()
     {
-        var runner = CreateRunner();
         var files = new List<DiagnosticsFile>
         {
             new() { Name = "testResults.xml", Type = "test-results" },
             new() { Name = "logcat.log", Type = "logcat" },
         };
 
-        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, files);
 
         var json = ExtractJsonFromLogs();
         var filesArray = json.GetProperty("files");
         Assert.Equal(2, filesArray.GetArrayLength());
         Assert.Equal("testResults.xml", filesArray[0].GetProperty("name").GetString());
-        Assert.Equal("test-results", filesArray[0].GetProperty("type").GetString());
     }
 
     [Fact]
     public void EmitJsonResultBlock_IncludesHelixUrls_WhenEnvVarsSet()
     {
-        var runner = CreateRunner();
         var files = new List<DiagnosticsFile>
         {
             new() { Name = "testResults.xml", Type = "test-results" },
         };
 
         Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "test-job-id");
-        Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "My.Test.Work.Item");
+        Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "My.Test");
 
         try
         {
-            runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+            RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, files);
 
             var json = ExtractJsonFromLogs();
-            var fileEntry = json.GetProperty("files")[0];
-            var url = fileEntry.GetProperty("helixApiUrl").GetString();
+            var url = json.GetProperty("files")[0].GetProperty("helixApiUrl").GetString();
             Assert.Contains("test-job-id", url);
-            Assert.Contains("My.Test.Work.Item", url);
             Assert.Contains("testResults.xml", url);
         }
         finally
@@ -148,7 +141,6 @@ public class InstrumentationRunnerSummaryTests : IDisposable
     [Fact]
     public void EmitJsonResultBlock_OmitsHelixUrls_WhenEnvVarsNotSet()
     {
-        var runner = CreateRunner();
         var files = new List<DiagnosticsFile>
         {
             new() { Name = "testResults.xml", Type = "test-results" },
@@ -157,42 +149,28 @@ public class InstrumentationRunnerSummaryTests : IDisposable
         Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", null);
         Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", null);
 
-        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, files);
 
         var json = ExtractJsonFromLogs();
-        var fileEntry = json.GetProperty("files")[0];
-        Assert.False(fileEntry.TryGetProperty("helixApiUrl", out _));
+        Assert.False(json.GetProperty("files")[0].TryGetProperty("helixApiUrl", out _));
     }
 
     [Fact]
     public void EmitJsonResultBlock_HasVersionField()
     {
-        var runner = CreateRunner();
-
-        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, new List<DiagnosticsFile>());
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, new List<DiagnosticsFile>());
 
         var json = ExtractJsonFromLogs();
         Assert.Equal(1, json.GetProperty("version").GetInt32());
-    }
-
-    private InstrumentationRunner CreateRunner()
-    {
-        var adbRunner = new AdbRunner(_mockLogger.Object, _processManager.Object, _fakeAdbPath);
-        return new InstrumentationRunner(_mockLogger.Object, adbRunner);
     }
 
     private JsonElement ExtractJsonFromLogs()
     {
         var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));
         Assert.NotNull(jsonMessage);
-        return ExtractJson(jsonMessage);
-    }
-
-    private static JsonElement ExtractJson(string message)
-    {
-        var start = message.IndexOf("<<XHARNESS_RESULT_START>>") + "<<XHARNESS_RESULT_START>>".Length;
-        var end = message.IndexOf("<<XHARNESS_RESULT_END>>");
-        var jsonStr = message[start..end].Trim();
+        var start = jsonMessage.IndexOf("<<XHARNESS_RESULT_START>>") + "<<XHARNESS_RESULT_START>>".Length;
+        var end = jsonMessage.IndexOf("<<XHARNESS_RESULT_END>>");
+        var jsonStr = jsonMessage[start..end].Trim();
         return JsonDocument.Parse(jsonStr).RootElement;
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -54,17 +54,6 @@ public class RunSummaryEmitterTests
     }
 
     [Fact]
-    public void EmitRunSummary_ContainsHumanSummary()
-    {
-        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.TESTS_FAILED, "android", "device1", "API 33", "arm64", 1, new List<DiagnosticsFile>());
-
-        var summary = _loggedMessages.Find(m => m.Contains("XHARNESS RUN SUMMARY"));
-        Assert.NotNull(summary);
-        Assert.Contains("TESTS_FAILED", summary);
-        Assert.Contains("device1", summary);
-    }
-
-    [Fact]
     public void EmitJsonResultBlock_ContainsExitCode()
     {
         RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.TESTS_FAILED, "android", null, null, null, 1, new List<DiagnosticsFile>());

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -1,0 +1,198 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.DotNet.XHarness.Android.Execution;
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.Common.CLI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Android.Tests;
+
+public class InstrumentationRunnerSummaryTests : IDisposable
+{
+    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<IAdbProcessManager> _processManager;
+    private readonly List<string> _loggedMessages;
+    private readonly string _fakeAdbPath;
+    private readonly string _tempDir;
+
+    public InstrumentationRunnerSummaryTests()
+    {
+        _mockLogger = new Mock<ILogger>();
+        _processManager = new Mock<IAdbProcessManager>();
+        _loggedMessages = new List<string>();
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+        _fakeAdbPath = Path.Combine(_tempDir, "adb");
+        File.WriteAllText(_fakeAdbPath, string.Empty);
+
+        _mockLogger
+            .Setup(l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Callback((LogLevel level, EventId eventId, object state, Exception? ex, Delegate formatter) =>
+            {
+                _loggedMessages.Add(state?.ToString() ?? "");
+            });
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempDir, true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_ContainsDelimiters()
+    {
+        var runner = CreateRunner();
+        var files = new List<DiagnosticsFile>
+        {
+            new() { Name = "testResults.xml", Type = "test-results" }
+        };
+
+        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+
+        var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));
+        Assert.NotNull(jsonMessage);
+        Assert.Contains("<<XHARNESS_RESULT_END>>", jsonMessage);
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_ContainsExitCode()
+    {
+        var runner = CreateRunner();
+
+        runner.EmitJsonResultBlock(ExitCode.TESTS_FAILED, 1, null, new List<DiagnosticsFile>());
+
+        var json = ExtractJsonFromLogs();
+        Assert.Equal(1, json.GetProperty("exitCode").GetInt32());
+        Assert.Equal("TESTS_FAILED", json.GetProperty("exitCodeName").GetString());
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_ContainsDeviceInfo()
+    {
+        var runner = CreateRunner();
+        var device = new AndroidDevice("SERIAL123") { ApiVersion = 33, Architecture = "arm64-v8a" };
+
+        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, device, new List<DiagnosticsFile>());
+
+        var json = ExtractJsonFromLogs();
+        Assert.Equal("SERIAL123", json.GetProperty("device").GetString());
+        Assert.Equal(33, json.GetProperty("apiVersion").GetInt32());
+        Assert.Equal("arm64-v8a", json.GetProperty("architecture").GetString());
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_ContainsFileInfo()
+    {
+        var runner = CreateRunner();
+        var files = new List<DiagnosticsFile>
+        {
+            new() { Name = "testResults.xml", Type = "test-results" },
+            new() { Name = "logcat.log", Type = "logcat" },
+        };
+
+        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+
+        var json = ExtractJsonFromLogs();
+        var filesArray = json.GetProperty("files");
+        Assert.Equal(2, filesArray.GetArrayLength());
+        Assert.Equal("testResults.xml", filesArray[0].GetProperty("name").GetString());
+        Assert.Equal("test-results", filesArray[0].GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_IncludesHelixUrls_WhenEnvVarsSet()
+    {
+        var runner = CreateRunner();
+        var files = new List<DiagnosticsFile>
+        {
+            new() { Name = "testResults.xml", Type = "test-results" },
+        };
+
+        Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", "test-job-id");
+        Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", "My.Test.Work.Item");
+
+        try
+        {
+            runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+
+            var json = ExtractJsonFromLogs();
+            var fileEntry = json.GetProperty("files")[0];
+            var url = fileEntry.GetProperty("helixApiUrl").GetString();
+            Assert.Contains("test-job-id", url);
+            Assert.Contains("My.Test.Work.Item", url);
+            Assert.Contains("testResults.xml", url);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", null);
+            Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", null);
+        }
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_OmitsHelixUrls_WhenEnvVarsNotSet()
+    {
+        var runner = CreateRunner();
+        var files = new List<DiagnosticsFile>
+        {
+            new() { Name = "testResults.xml", Type = "test-results" },
+        };
+
+        Environment.SetEnvironmentVariable("HELIX_CORRELATION_ID", null);
+        Environment.SetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME", null);
+
+        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, files);
+
+        var json = ExtractJsonFromLogs();
+        var fileEntry = json.GetProperty("files")[0];
+        Assert.False(fileEntry.TryGetProperty("helixApiUrl", out _));
+    }
+
+    [Fact]
+    public void EmitJsonResultBlock_HasVersionField()
+    {
+        var runner = CreateRunner();
+
+        runner.EmitJsonResultBlock(ExitCode.SUCCESS, 0, null, new List<DiagnosticsFile>());
+
+        var json = ExtractJsonFromLogs();
+        Assert.Equal(1, json.GetProperty("version").GetInt32());
+    }
+
+    private InstrumentationRunner CreateRunner()
+    {
+        var adbRunner = new AdbRunner(_mockLogger.Object, _processManager.Object, _fakeAdbPath);
+        return new InstrumentationRunner(_mockLogger.Object, adbRunner);
+    }
+
+    private JsonElement ExtractJsonFromLogs()
+    {
+        var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));
+        Assert.NotNull(jsonMessage);
+        return ExtractJson(jsonMessage);
+    }
+
+    private static JsonElement ExtractJson(string message)
+    {
+        var start = message.IndexOf("<<XHARNESS_RESULT_START>>") + "<<XHARNESS_RESULT_START>>".Length;
+        var end = message.IndexOf("<<XHARNESS_RESULT_END>>");
+        var jsonStr = message[start..end].Trim();
+        return JsonDocument.Parse(jsonStr).RootElement;
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/CopyLogsToMainLogTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/CopyLogsToMainLogTests.cs
@@ -1,0 +1,209 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.Common.CLI;
+using Microsoft.DotNet.XHarness.Common.Execution;
+using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Apple.Tests.Orchestration;
+
+public class CopyLogsToMainLogTests : OrchestratorTestBase
+{
+    private readonly TestOrchestrator _testOrchestrator;
+    private readonly Mock<IAppTester> _appTester;
+    private readonly Mock<IAppTesterFactory> _appTesterFactory;
+    private readonly List<string> _mainLogLines;
+
+    private const string SuccessResultLine = "Tests run: 10 Passed: 10 Inconclusive: 0 Failed: 0 Ignored: 0";
+
+    public CopyLogsToMainLogTests()
+    {
+        _appTester = new();
+        _appTesterFactory = new();
+        _appTesterFactory.SetReturnsDefault(_appTester.Object);
+
+        _appInstaller.SetReturnsDefault(Task.FromResult(new ProcessExecutionResult
+        {
+            ExitCode = 0,
+            TimedOut = false,
+        }));
+
+        _appUninstaller.SetReturnsDefault(Task.FromResult(new ProcessExecutionResult
+        {
+            ExitCode = 0,
+            TimedOut = false,
+        }));
+
+        _mainLogLines = new List<string>();
+        _mainLog
+            .Setup(x => x.WriteLine(It.IsAny<string>()))
+            .Callback<string>(line => _mainLogLines.Add(line));
+
+        _testOrchestrator = new(
+            _appBundleInformationParser.Object,
+            _appInstaller.Object,
+            _appUninstaller.Object,
+            _appTesterFactory.Object,
+            _deviceFinder.Object,
+            _logger.Object,
+            _logs,
+            _mainLog.Object,
+            _errorKnowledgeBase.Object,
+            _diagnosticsData,
+            _helpers.Object);
+    }
+
+    [Fact]
+    public async Task SimulatorTest_CopiesApplicationLogToMainLog()
+    {
+        // Setup: add an ApplicationLog with test output
+        var appLogContent = "[PASS] MyTest.TestMethod1\n[PASS] MyTest.TestMethod2\n[FAIL] MyTest.TestMethod3\n";
+        AddLogWithContent(LogType.ApplicationLog, "net.dot.Tests.log", appLogContent);
+
+        // Also add a SystemLog (should NOT be copied for simulators)
+        AddLogWithContent(LogType.SystemLog, "simulator.system.log", "System noise that should not appear");
+
+        var testTarget = new TestTargetOs(TestTarget.Simulator_iOS64, "13.5");
+        _appTester
+            .Setup(x => x.TestApp(
+                It.IsAny<AppBundleInformation>(), It.IsAny<TestTargetOs>(), It.IsAny<IDevice>(), It.IsAny<IDevice>(),
+                It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<bool>(), It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<(string, string)>>(), It.IsAny<XmlResultJargon>(),
+                It.IsAny<string[]?>(), It.IsAny<string[]?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestExecutingResult.Succeeded, SuccessResultLine));
+
+        // Act
+        var result = await _testOrchestrator.OrchestrateTest(
+            AppPath, testTarget, null,
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(3),
+            CommunicationChannel.UsbTunnel, XmlResultJargon.xUnit,
+            Array.Empty<string>(), Array.Empty<string>(),
+            includeWirelessDevices: false, resetSimulator: true, enableLldb: false,
+            signalAppEnd: false,
+            Array.Empty<(string, string)>(), Array.Empty<string>(),
+            new CancellationToken());
+
+        // Verify
+        Assert.Equal(ExitCode.SUCCESS, result);
+        var mainLogText = string.Join("\n", _mainLogLines);
+
+        // ApplicationLog content should be present
+        Assert.Contains("[PASS] MyTest.TestMethod1", mainLogText);
+        Assert.Contains("[FAIL] MyTest.TestMethod3", mainLogText);
+        Assert.Contains("==================== ApplicationLog ====================", mainLogText);
+        Assert.Contains("==================== End of ApplicationLog ====================", mainLogText);
+
+        // SystemLog content should NOT be present
+        Assert.DoesNotContain("System noise that should not appear", mainLogText);
+    }
+
+    [Fact]
+    public async Task MacCatalystTest_CopiesSystemLogToMainLog()
+    {
+        // Setup: reset mocks since MacCatalyst skips device finding, install, uninstall
+        _appInstaller.Reset();
+        _appUninstaller.Reset();
+        _deviceFinder.Reset();
+
+        // Add a SystemLog with test output (this is where MacCatalyst output goes)
+        var sysLogContent = "[PASS] MyMacTest.TestA\n[PASS] MyMacTest.TestB\n=== TEST EXECUTION SUMMARY ===\n";
+        AddLogWithContent(LogType.SystemLog, "MacCatalyst.system.log", sysLogContent);
+
+        // Also add an ApplicationLog (should NOT be copied for MacCatalyst — it won't exist in practice)
+        AddLogWithContent(LogType.ApplicationLog, "app.log", "App log content that should not appear");
+
+        var testTarget = new TestTargetOs(TestTarget.MacCatalyst, null);
+        _appTester
+            .Setup(x => x.TestMacCatalystApp(
+                It.IsAny<AppBundleInformation>(), It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<bool>(),
+                It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<(string, string)>>(),
+                It.IsAny<XmlResultJargon>(), It.IsAny<string[]?>(), It.IsAny<string[]?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestExecutingResult.Succeeded, SuccessResultLine));
+
+        // Act
+        var result = await _testOrchestrator.OrchestrateTest(
+            AppPath, testTarget, null,
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(3),
+            CommunicationChannel.UsbTunnel, XmlResultJargon.xUnit,
+            Array.Empty<string>(), Array.Empty<string>(),
+            includeWirelessDevices: false, resetSimulator: true, enableLldb: false,
+            signalAppEnd: true,
+            Array.Empty<(string, string)>(), Array.Empty<string>(),
+            new CancellationToken());
+
+        // Verify
+        Assert.Equal(ExitCode.SUCCESS, result);
+        var mainLogText = string.Join("\n", _mainLogLines);
+
+        // SystemLog content should be present (MacCatalyst uses SystemLog)
+        Assert.Contains("[PASS] MyMacTest.TestA", mainLogText);
+        Assert.Contains("TEST EXECUTION SUMMARY", mainLogText);
+        Assert.Contains("==================== SystemLog ====================", mainLogText);
+
+        // ApplicationLog content should NOT be present
+        Assert.DoesNotContain("App log content that should not appear", mainLogText);
+    }
+
+    [Fact]
+    public async Task DeviceTest_CopiesApplicationLogToMainLog()
+    {
+        // Setup: add an ApplicationLog with test output
+        var appLogContent = "[PASS] DeviceTest.Test1\n[FAIL] DeviceTest.Test2\n";
+        AddLogWithContent(LogType.ApplicationLog, "net.dot.Tests.log", appLogContent);
+
+        var testTarget = new TestTargetOs(TestTarget.Device_iOS, "14.2");
+        _appTester
+            .Setup(x => x.TestApp(
+                It.IsAny<AppBundleInformation>(), It.IsAny<TestTargetOs>(), It.IsAny<IDevice>(), It.IsAny<IDevice>(),
+                It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<bool>(), It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<(string, string)>>(), It.IsAny<XmlResultJargon>(),
+                It.IsAny<string[]?>(), It.IsAny<string[]?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TestExecutingResult.Succeeded, SuccessResultLine));
+
+        // Act
+        var result = await _testOrchestrator.OrchestrateTest(
+            AppPath, testTarget, null,
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(3),
+            CommunicationChannel.UsbTunnel, XmlResultJargon.xUnit,
+            Array.Empty<string>(), Array.Empty<string>(),
+            includeWirelessDevices: false, resetSimulator: false, enableLldb: false,
+            signalAppEnd: false,
+            Array.Empty<(string, string)>(), Array.Empty<string>(),
+            new CancellationToken());
+
+        // Verify
+        Assert.Equal(ExitCode.SUCCESS, result);
+        var mainLogText = string.Join("\n", _mainLogLines);
+
+        Assert.Contains("[PASS] DeviceTest.Test1", mainLogText);
+        Assert.Contains("[FAIL] DeviceTest.Test2", mainLogText);
+        Assert.Contains("==================== ApplicationLog ====================", mainLogText);
+    }
+
+    private void AddLogWithContent(LogType logType, string fileName, string content)
+    {
+        // Write content to a temp file so GetReader() works
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + "_" + fileName);
+        File.WriteAllText(tempPath, content);
+
+        var mockLog = new Mock<IFileBackedLog>();
+        mockLog.Setup(x => x.Description).Returns(logType.ToString());
+        mockLog.Setup(x => x.FullPath).Returns(tempPath);
+        mockLog.Setup(x => x.GetReader()).Returns(() => new StreamReader(tempPath));
+
+        _logs.Add(mockLog.Object);
+    }
+}


### PR DESCRIPTION
### Problem

When investigating test failures in Helix, the XHarness console output lacked a consistent, structured summary of what happened during a run. Key information — exit codes, device details, produced files, and Helix URLs — was scattered across verbose log output, making it difficult for both humans and automated tooling to quickly parse results.

Additionally, Android logcat output was dumped in its entirety to the console log, burying the relevant DOTNET-tagged entries in thousands of lines of system noise.

### Changes

#### New: `RunSummaryEmitter` (shared by both platforms)
Introduces a unified `RunSummaryEmitter` in `Microsoft.DotNet.XHarness.Common` that emits a structured JSON block delimited by `<<XHARNESS_RESULT_START>>` / `<<XHARNESS_RESULT_END>>` markers at the end of every run. The JSON contains:
- Exit code and its name
- Machine name and platform
- Device info (name, OS version, architecture)
- Manifest of produced files (test results, logs, etc.)
- Helix job/work item URLs when running in Helix (for direct log access)

Both Android and Apple platforms use this shared emitter, ensuring consistent output across all run types.

#### Android improvements
- **Logcat filtering**: Console output now shows only `DOTNET`-tagged logcat lines (the full unfiltered log is still written to the output file)
- **File tracking**: `InstrumentationRunner` tracks all produced files (test results XMLs, logcat, bugreport) via `DiagnosticsFile` and includes them in the summary
- **Device metadata**: Summary includes device serial, API version, and architecture (e.g., `arm64-v8a`, `x86`)

#### Apple improvements
- **`CopyLogsToMainLog` refactor**: Now runs for all targets including simulators (previously skipped). MacCatalyst correctly copies `SystemLog` instead of `ApplicationLog` since MacCatalyst apps run as native macOS processes
- **Log collection**: `BaseOrchestrator` collects all file-backed logs into the diagnostics summary with their types (executionlog, testlog, systemlog, applicationlog, xmllog, etc.)
- **MacCatalyst diagnostics**: Populates device info with local machine name and macOS version

#### Common infrastructure
- New `DiagnosticsFile` model in `CommandDiagnostics.cs` for tracking produced files
- `IDiagnosticsData.Files` property added for file manifest support
- `xharness-result.json` written to output directory for downstream tooling

### Example output

**Android device:**
```json
<<XHARNESS_RESULT_START>>
{
  "version": 1,
  "machineName": "DNCENGWIN-068",
  "exitCode": 0,
  "exitCodeName": "SUCCESS",
  "platform": "android",
  "helixWorkItemId": "System.Buffers.Tests-arm64-v8a",
  "helixJobId": "3cdb9380-8d1c-44af-89a8-caf90c38c09b",
  "helixConsoleUri": "https://helix.dot.net/api/2019-06-17/jobs/.../console",
  "helixFilesUri": "https://helix.dot.net/api/2019-06-17/jobs/.../files",
  "instrumentationExitCode": 0,
  "device": "09171JEC213198",
  "deviceOsVersion": "API 33",
  "architecture": "arm64-v8a",
  "files": [
    { "name": "testResults.xml", "type": "test-results" },
    { "name": "adb-logcat-net.dot.System.Buffers.Tests-net.dot.MonoRunner.log", "type": "logcat" }
  ]
}
<<XHARNESS_RESULT_END>>
```

**Apple iOS simulator:**
```json
<<XHARNESS_RESULT_START>>
{
  "version": 1,
  "machineName": "dci-mac-build-342",
  "exitCode": 0,
  "exitCodeName": "SUCCESS",
  "platform": "apple",
  "device": "iPhone 11 Pro (iOS 18.1) - created by XHarness",
  "deviceOsVersion": "18.1",
  "files": [
    { "name": "test-ios-simulator-64.log", "type": "executionlog" },
    { "name": "System.Numerics.Vectors.Tests.log", "type": "systemlog" },
    { "name": "net.dot.System.Numerics.Vectors.Tests.log", "type": "applicationlog" },
    { "name": "xunit-test-ios-simulator-64-20260331_070927.xml", "type": "xmllog" }
  ]
}
<<XHARNESS_RESULT_END>>
```

### Testing

- **`AdbRunnerLogFilterTests`** — validates DOTNET line filtering from logcat output
- **`InstrumentationRunnerSummaryTests`** — validates Android file tracking and JSON summary emission
- **`CopyLogsToMainLogTests`** — validates Apple log copying behavior for simulators, devices, and MacCatalyst