### PR TITLE
Add WASM app verbosity compatibility switch

### DIFF
--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoAppVerbosityArgument.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/Arguments/NoAppVerbosityArgument.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
+
+internal class NoAppVerbosityArgument : SwitchArgument
+{
+    public NoAppVerbosityArgument()
+        : base("no-app-verbosity", "Don't pass xharness verbosity to the app as '-verbosity <level>' arguments", false)
+    {
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/CommandArguments/WASM/WasmTestBrowserCommandArguments.cs
@@ -23,6 +23,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
     public DebuggerPortArgument DebuggerPort { get; set; } = new();
     public NoIncognitoArgument NoIncognito { get; } = new();
     public NoHeadlessArgument NoHeadless { get; } = new();
+    public NoAppVerbosityArgument NoAppVerbosity { get; } = new();
     public NoQuitArgument NoQuit { get; } = new();
     public BackgroundThrottlingArgument BackgroundThrottling { get; } = new();
     public LocaleArgument Locale { get; } = new("en-US");
@@ -55,6 +56,7 @@ internal class WasmTestBrowserCommandArguments : XHarnessCommandArguments, IWebS
             DebuggerPort,
             NoIncognito,
             NoHeadless,
+            NoAppVerbosity,
             NoQuit,
             BackgroundThrottling,
             Locale,

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/WASM/Browser/WasmBrowserTestRunner.cs
@@ -221,27 +221,7 @@ internal class WasmBrowserTestRunner
         var uriBuilder = new UriBuilder($"{serverURLs.Http}/{_arguments.HTMLFile}");
         var sb = new StringBuilder();
 
-        if (_arguments.DebuggerPort.Value != null)
-            sb.Append($"arg=--debug");
-
-        foreach (var envVariable in _arguments.WebServerHttpEnvironmentVariables.Value)
-        {
-            if (sb.Length > 0)
-                sb.Append('&');
-            sb.Append($"arg={HttpUtility.UrlEncode($"--setenv={envVariable}={serverURLs!.Http}")}");
-        }
-
-        if (_arguments.WebServerUseHttps)
-        {
-            foreach (var envVariable in _arguments.WebServerHttpsEnvironmentVariables.Value)
-            {
-                if (sb.Length > 0)
-                    sb.Append('&');
-                sb.Append($"arg={HttpUtility.UrlEncode($"--setenv={envVariable}={serverURLs!.Https}")}");
-            }
-        }
-
-        foreach (var arg in _passThroughArguments)
+        foreach (string arg in GetApplicationArguments(_arguments, _passThroughArguments, serverURLs))
         {
             if (sb.Length > 0)
                 sb.Append('&');
@@ -249,13 +229,38 @@ internal class WasmBrowserTestRunner
             sb.Append($"arg={HttpUtility.UrlEncode(arg)}");
         }
 
-        if (sb.Length > 0)
-            sb.Append('&');
-
-        sb.Append($"arg=-verbosity&arg={VerbosityToString()}");
-
         uriBuilder.Query = sb.ToString();
         return uriBuilder.ToString();
+    }
+
+    internal static string[] GetApplicationArguments(
+        WasmTestBrowserCommandArguments arguments,
+        IEnumerable<string> passThroughArguments,
+        ServerURLs serverURLs)
+    {
+        List<string> applicationArguments = new();
+
+        if (arguments.DebuggerPort.Value != null)
+            applicationArguments.Add("--debug");
+
+        foreach (string envVariable in arguments.WebServerHttpEnvironmentVariables.Value)
+            applicationArguments.Add($"--setenv={envVariable}={serverURLs.Http}");
+
+        if (arguments.WebServerUseHttps)
+        {
+            foreach (string envVariable in arguments.WebServerHttpsEnvironmentVariables.Value)
+                applicationArguments.Add($"--setenv={envVariable}={serverURLs.Https}");
+        }
+
+        applicationArguments.AddRange(passThroughArguments);
+
+        if (!arguments.NoAppVerbosity)
+        {
+            applicationArguments.Add("-verbosity");
+            applicationArguments.Add(VerbosityToString(arguments.Verbosity.Value));
+        }
+
+        return applicationArguments.ToArray();
     }
 
     // MinimumLogLevel.Critical,
@@ -264,7 +269,7 @@ internal class WasmBrowserTestRunner
     // MinimumLogLevel.Info,
     // MinimumLogLevel.Debug,
     // MinimumLogLevel.Verbose
-    private string VerbosityToString() => _arguments.Verbosity.Value switch
+    private static string VerbosityToString(LogLevel verbosity) => verbosity switch
     {
         LogLevel.Trace => "Verbose",
         LogLevel.Debug => "Debug",
@@ -273,6 +278,6 @@ internal class WasmBrowserTestRunner
         LogLevel.Error => "Error",
         LogLevel.Critical => "Critical",
         LogLevel.None => "Critical",
-        _ => throw new NotSupportedException($"The value '{_arguments.Verbosity.Value}' is not supported in conversion to MinimumLogLevel")
+        _ => throw new NotSupportedException($"The value '{verbosity}' is not supported in conversion to MinimumLogLevel")
     };
 }

--- a/tests/Microsoft.DotNet.XHarness.CLI.Tests/Commands/WasmBrowserTestRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.CLI.Tests/Commands/WasmBrowserTestRunnerTests.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Microsoft.DotNet.XHarness.CLI.CommandArguments.Wasm;
+using Microsoft.DotNet.XHarness.CLI.Commands;
+using Microsoft.DotNet.XHarness.CLI.Commands.Wasm;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.CLI.Tests.Commands;
+
+public class WasmBrowserTestRunnerTests
+{
+    [Fact]
+    public void WasmTestBrowserCommandParsesNoAppVerbosity()
+    {
+        string outputDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            var arguments = new WasmTestBrowserCommandArguments();
+            var command = new UnitTestCommand<WasmTestBrowserCommandArguments>(arguments);
+
+            int exitCode = command.Invoke(new[]
+            {
+                "--app=app",
+                $"--output-directory={outputDirectory}",
+                "--no-app-verbosity",
+            });
+
+            Assert.Equal(0, exitCode);
+            Assert.True(command.CommandRun);
+            Assert.True(arguments.NoAppVerbosity);
+        }
+        finally
+        {
+            if (Directory.Exists(outputDirectory))
+                Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApplicationArgumentsIncludeVerbosityByDefault()
+    {
+        var arguments = new WasmTestBrowserCommandArguments();
+        arguments.Verbosity.Action("Debug");
+
+        string[] applicationArguments = WasmBrowserTestRunner.GetApplicationArguments(
+            arguments,
+            new[] { "abc", "foobar" },
+            new ServerURLs("http://127.0.0.1:8000", null));
+
+        Assert.Equal(new[] { "abc", "foobar", "-verbosity", "Debug" }, applicationArguments);
+    }
+
+    [Fact]
+    public void ApplicationArgumentsSkipVerbosityWhenRequested()
+    {
+        var arguments = new WasmTestBrowserCommandArguments();
+        arguments.Verbosity.Action("Debug");
+        arguments.NoAppVerbosity.Action(string.Empty);
+
+        string[] applicationArguments = WasmBrowserTestRunner.GetApplicationArguments(
+            arguments,
+            new[] { "abc", "foobar" },
+            new ServerURLs("http://127.0.0.1:8000", null));
+
+        Assert.Equal(new[] { "abc", "foobar" }, applicationArguments);
+    }
+}


### PR DESCRIPTION
Add --no-app-verbosity to 'wasm test-browser' so callers can keep xharness logging verbosity without forwarding '-verbosity <level>' into the app arguments.

This restores a backward-compatible option for the .NET 8.0 runtime tests, where the forwarded verbosity arguments break older WASM browser tests that validate their command-line args strictly.

This is to unblock https://github.com/dotnet/runtime/pull/126322 - which brings latest xharness to the 8.0 servicing branch.
My thinking was that it's simpler to add a backward compat switch to xharness than to backport relatively large test change in the WASM space.