### PR TITLE
Bump Microsoft.Tools.Mlaunch from 1.1.92 to 1.1.113

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Selenium.WebDriver" Version="4.0.0-alpha05" />
-    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.1.92" />
+    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.1.113" />
     <PackageVersion Include="NUnit" Version="3.13.0" />
     <PackageVersion Include="NUnit.Engine" Version="3.13.0" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />


### PR DESCRIPTION
Fixes the iOS 18.5 simulator launch failure reported in dotnet/maui#35261.

## Problem

When mlaunch's watchdog-disable flow shuts down the iOS 18.5 simulator, it doesn't update the in-memory device state. Subsequent code thinks the device is still booted, skips re-booting, and `simctl launch` fails with exit code 149 (`Unable to lookup in current state: Shutdown`).

## Fix

The fix (`State = "Shutdown"` after `ShutdownAsync`) was added in mlaunch commit 4ba65e5 and is included in version 1.1.110+. This PR bumps to 1.1.113 (latest).

## Verification

- Reproduced the failure locally with mlaunch 1.1.92 against a booted iOS 18.5 simulator with watchdogs removed
- Built mlaunch from source (which includes the fix) and confirmed the app launches successfully
- Verified via IL disassembly that the 1.1.113 NuGet package contains the fix

Fixes dotnet/macios#25290

🤖 Pull request created by Copilot