### PR TITLE
Add structured environment details to XHarness JSON results

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -129,7 +129,7 @@ public class AdbRunner
         device.CpuMaxFrequencyKiloHertz ??=
             ParseFrequencyKiloHertz(GetDeviceProperty(AdbProperty.CpuMaxFrequency, device.DeviceSerial, logOnError: false))
             ?? ParseFrequencyKiloHertz(GetDeviceProperty(AdbProperty.CpuMaxFrequencyFallback, device.DeviceSerial, logOnError: false))
-            ?? ParseFrequencyKiloHertz(ParseCpuFrequencyFromCpuInfo(GetDeviceProperty(AdbProperty.CpuInfo, device.DeviceSerial)));
+            ?? ParseCpuFrequencyFromCpuInfoKiloHertz(GetDeviceProperty(AdbProperty.CpuInfo, device.DeviceSerial));
     }
 
     private static string GetCliAdbExePath()
@@ -1331,7 +1331,7 @@ public class AdbRunner
         return null;
     }
 
-    internal static string? ParseCpuFrequencyFromCpuInfo(string? cpuInfo)
+    internal static long? ParseCpuFrequencyFromCpuInfoKiloHertz(string? cpuInfo)
     {
         if (string.IsNullOrWhiteSpace(cpuInfo))
         {
@@ -1342,7 +1342,9 @@ public class AdbRunner
         {
             if (TryParseColonValue(line, "cpu MHz", out var cpuFrequency))
             {
-                return cpuFrequency;
+                return double.TryParse(cpuFrequency, out var megaHertz)
+                    ? (long)(megaHertz * 1000)
+                    : null;
             }
         }
 

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -1342,7 +1343,7 @@ public class AdbRunner
         {
             if (TryParseColonValue(line, "cpu MHz", out var cpuFrequency))
             {
-                return double.TryParse(cpuFrequency, out var megaHertz)
+                return double.TryParse(cpuFrequency, NumberStyles.Float, CultureInfo.InvariantCulture, out var megaHertz)
                     ? (long)(megaHertz * 1000)
                     : null;
             }

--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -21,9 +21,18 @@ public class AdbRunner
     {
         Architecture,
         ApiVersion,
+        BuildFingerprint,
         SupportedArchitectures,
         InstalledApps,
         BootCompletion,
+        CpuInfo,
+        CpuMaxFrequency,
+        CpuMaxFrequencyFallback,
+        Manufacturer,
+        MemInfo,
+        Model,
+        OperatingSystemVersion,
+        ProductName,
     }
 
     #region Constructor and state variables
@@ -33,8 +42,17 @@ public class AdbRunner
         { AdbProperty.SupportedArchitectures, new[] { "shell", "getprop", "ro.product.cpu.abilist" } },
         { AdbProperty.ApiVersion, new[] { "shell", "getprop", "ro.build.version.sdk" } },
         { AdbProperty.Architecture, new[] { "shell", "getprop", "ro.product.cpu.abi" } },
+        { AdbProperty.BuildFingerprint, new[] { "shell", "getprop", "ro.build.fingerprint" } },
         { AdbProperty.InstalledApps, new[] { "shell", "pm", "list", "packages", "-3" } },
         { AdbProperty.BootCompletion, new[] { "shell", "getprop", "sys.boot_completed" } },
+        { AdbProperty.CpuInfo, new[] { "shell", "cat", "/proc/cpuinfo" } },
+        { AdbProperty.CpuMaxFrequency, new[] { "shell", "cat", "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq" } },
+        { AdbProperty.CpuMaxFrequencyFallback, new[] { "shell", "cat", "/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq" } },
+        { AdbProperty.Manufacturer, new[] { "shell", "getprop", "ro.product.manufacturer" } },
+        { AdbProperty.MemInfo, new[] { "shell", "cat", "/proc/meminfo" } },
+        { AdbProperty.Model, new[] { "shell", "getprop", "ro.product.model" } },
+        { AdbProperty.OperatingSystemVersion, new[] { "shell", "getprop", "ro.build.version.release" } },
+        { AdbProperty.ProductName, new[] { "shell", "getprop", "ro.product.name" } },
     };
 
     private const string AdbEnvironmentVariableName = "ADB_EXE_PATH";
@@ -90,6 +108,28 @@ public class AdbRunner
             _log.LogDebug($"ADBRunner using ADB.exe supplied from {adbExePath}");
             _log.LogDebug($"Full resolved path:'{_absoluteAdbExePath}'");
         }
+    }
+
+    public void PopulateEnvironmentInfo(AndroidDevice device)
+    {
+        if (device is null)
+        {
+            throw new ArgumentNullException(nameof(device));
+        }
+
+        device.Manufacturer ??= GetDeviceProperty(AdbProperty.Manufacturer, device.DeviceSerial);
+        device.Model ??= GetDeviceProperty(AdbProperty.Model, device.DeviceSerial);
+        device.ProductName ??= GetDeviceProperty(AdbProperty.ProductName, device.DeviceSerial);
+        device.OperatingSystemVersion ??= GetDeviceProperty(AdbProperty.OperatingSystemVersion, device.DeviceSerial);
+        device.BuildFingerprint ??= GetDeviceProperty(AdbProperty.BuildFingerprint, device.DeviceSerial);
+        device.Architecture ??= GetDeviceProperty(AdbProperty.Architecture, device.DeviceSerial);
+        device.SupportedArchitectures ??= GetDeviceProperty(AdbProperty.SupportedArchitectures, device.DeviceSerial)?.Split(new[] { ',', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        device.CpuModel ??= ParseCpuModel(GetDeviceProperty(AdbProperty.CpuInfo, device.DeviceSerial));
+        device.TotalMemoryBytes ??= ParseTotalMemoryBytes(GetDeviceProperty(AdbProperty.MemInfo, device.DeviceSerial));
+        device.CpuMaxFrequencyKiloHertz ??=
+            ParseFrequencyKiloHertz(GetDeviceProperty(AdbProperty.CpuMaxFrequency, device.DeviceSerial, logOnError: false))
+            ?? ParseFrequencyKiloHertz(GetDeviceProperty(AdbProperty.CpuMaxFrequencyFallback, device.DeviceSerial, logOnError: false))
+            ?? ParseFrequencyKiloHertz(ParseCpuFrequencyFromCpuInfo(GetDeviceProperty(AdbProperty.CpuInfo, device.DeviceSerial)));
     }
 
     private static string GetCliAdbExePath()
@@ -1224,7 +1264,7 @@ public class AdbRunner
         return devices;
     }
 
-    private string? GetDeviceProperty(AdbProperty property, string? deviceName = null)
+    private string? GetDeviceProperty(AdbProperty property, string? deviceName = null, bool logOnError = true)
     {
         IEnumerable<string> args = s_commandList[property];
 
@@ -1251,13 +1291,131 @@ public class AdbRunner
 
         if (!result.Succeeded)
         {
-            _log.LogError($"Failed to get device's property {property}. Check if a device is attached / emulator is started" +
-                Environment.NewLine + result.StandardError);
+            if (logOnError)
+            {
+                _log.LogError($"Failed to get device's property {property}. Check if a device is attached / emulator is started" +
+                    Environment.NewLine + result.StandardError);
+            }
 
             return null;
         }
 
         return result.StandardOutput.Trim();
+    }
+
+    internal static string? ParseCpuModel(string? cpuInfo)
+    {
+        if (string.IsNullOrWhiteSpace(cpuInfo))
+        {
+            return null;
+        }
+
+        foreach (var line in cpuInfo.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (TryParseColonValue(line, "Hardware", out var hardware))
+            {
+                return hardware;
+            }
+
+            if (TryParseColonValue(line, "model name", out var modelName))
+            {
+                return modelName;
+            }
+
+            if (TryParseColonValue(line, "Processor", out var processor))
+            {
+                return processor;
+            }
+        }
+
+        return null;
+    }
+
+    internal static string? ParseCpuFrequencyFromCpuInfo(string? cpuInfo)
+    {
+        if (string.IsNullOrWhiteSpace(cpuInfo))
+        {
+            return null;
+        }
+
+        foreach (var line in cpuInfo.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (TryParseColonValue(line, "cpu MHz", out var cpuFrequency))
+            {
+                return cpuFrequency;
+            }
+        }
+
+        return null;
+    }
+
+    internal static long? ParseFrequencyKiloHertz(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        if (long.TryParse(trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0], out var kiloHertz))
+        {
+            return kiloHertz;
+        }
+
+        if (trimmed.EndsWith("MHz", StringComparison.OrdinalIgnoreCase)
+            && double.TryParse(trimmed.Replace("MHz", "", StringComparison.OrdinalIgnoreCase).Trim(), out var megaHertz))
+        {
+            return (long)(megaHertz * 1000);
+        }
+
+        if (trimmed.EndsWith("GHz", StringComparison.OrdinalIgnoreCase)
+            && double.TryParse(trimmed.Replace("GHz", "", StringComparison.OrdinalIgnoreCase).Trim(), out var gigaHertz))
+        {
+            return (long)(gigaHertz * 1_000_000);
+        }
+
+        return null;
+    }
+
+    internal static long? ParseTotalMemoryBytes(string? memInfo)
+    {
+        if (string.IsNullOrWhiteSpace(memInfo))
+        {
+            return null;
+        }
+
+        foreach (var line in memInfo.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!TryParseColonValue(line, "MemTotal", out var totalMemory))
+            {
+                continue;
+            }
+
+            if (long.TryParse(totalMemory.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0], out var kiloBytes))
+            {
+                return kiloBytes * 1024;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseColonValue(string line, string key, out string value)
+    {
+        value = string.Empty;
+        if (!line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var separatorIndex = line.IndexOf(':');
+        if (separatorIndex < 0 || separatorIndex == line.Length - 1)
+        {
+            return false;
+        }
+
+        value = line.Substring(separatorIndex + 1).Trim();
+        return true;
     }
 
     private bool TestFileExists(string path, string? deviceName = null)

--- a/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AndroidDevice.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.DotNet.XHarness.Android;
@@ -17,6 +18,24 @@ public record AndroidDevice
     public IReadOnlyCollection<string>? SupportedArchitectures { get; set; } = null;
 
     public IReadOnlyCollection<string>? InstalledApplications { get; set; } = null;
+
+    public string? Manufacturer { get; set; } = null;
+
+    public string? Model { get; set; } = null;
+
+    public string? ProductName { get; set; } = null;
+
+    public string? OperatingSystemVersion { get; set; } = null;
+
+    public string? BuildFingerprint { get; set; } = null;
+
+    public string? CpuModel { get; set; } = null;
+
+    public long? CpuMaxFrequencyKiloHertz { get; set; } = null;
+
+    public long? TotalMemoryBytes { get; set; } = null;
+
+    public bool IsEmulator => DeviceSerial.StartsWith("emulator", StringComparison.OrdinalIgnoreCase);
 
     public AndroidDevice(string deviceSerial) => DeviceSerial = deviceSerial;
 }

--- a/src/Microsoft.DotNet.XHarness.Android/AndroidEnvironmentReport.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AndroidEnvironmentReport.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.DotNet.XHarness.Common;
+
+namespace Microsoft.DotNet.XHarness.Android;
+
+public static class AndroidEnvironmentReport
+{
+    public static ExecutionEnvironmentInfo CreateEnvironmentInfo(AdbRunner runner, AndroidDevice device)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        ArgumentNullException.ThrowIfNull(device);
+
+        runner.PopulateEnvironmentInfo(device);
+
+        return new ExecutionEnvironmentInfo
+        {
+            Host = EnvironmentReportLogger.GetHostEnvironmentInfo(),
+            Target = new TargetEnvironmentInfo
+            {
+                Kind = device.IsEmulator ? "emulator" : "physical-device",
+                Name = device.Model ?? device.DeviceSerial,
+                Identifier = device.DeviceSerial,
+                OperatingSystem = "Android",
+                OperatingSystemVersion = device.OperatingSystemVersion,
+                ApiLevel = device.ApiVersion,
+                Architecture = device.Architecture,
+                SupportedArchitectures = device.SupportedArchitectures?.ToArray(),
+                Manufacturer = device.Manufacturer,
+                Model = device.Model,
+                ProductName = device.ProductName,
+                BuildFingerprint = device.BuildFingerprint,
+                CpuModel = device.CpuModel,
+                CpuMaxFrequencyHertz = device.CpuMaxFrequencyKiloHertz * 1000,
+                TotalMemoryBytes = device.TotalMemoryBytes,
+            },
+        };
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/InstrumentationRunner.cs
@@ -282,6 +282,7 @@ public class InstrumentationRunner
     {
         var device = _runner.GetActiveDevice();
         string? deviceOsVersion = device?.ApiVersion.HasValue == true ? $"API {device.ApiVersion}" : null;
+        var environment = device == null ? null : AndroidEnvironmentReport.CreateEnvironmentInfo(_runner, device);
 
         RunSummaryEmitter.EmitRunSummary(
             _logger,
@@ -291,7 +292,8 @@ public class InstrumentationRunner
             deviceOsVersion: deviceOsVersion,
             architecture: device?.Architecture,
             instrumentationExitCode: instrumentationExitCode,
-            producedFiles: producedFiles);
+            producedFiles: producedFiles,
+            environment: environment);
 
         RunSummaryEmitter.WriteResultJsonFile(
             outputDirectory,
@@ -301,6 +303,7 @@ public class InstrumentationRunner
             deviceOsVersion: deviceOsVersion,
             architecture: device?.Architecture,
             instrumentationExitCode: instrumentationExitCode,
-            producedFiles: producedFiles);
+            producedFiles: producedFiles,
+            environment: environment);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppleEnvironmentReport.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppleEnvironmentReport.cs
@@ -85,6 +85,7 @@ internal static class AppleEnvironmentReport
 
             var detailedInfo = await TryGetDetailedDeviceInfoAsync(processManager, hardwareDevice.UDID, cancellationToken);
             targetInfo.CpuModel = detailedInfo.CpuModel;
+            targetInfo.ProductName ??= detailedInfo.DeviceType;
             targetInfo.CpuMaxFrequencyHertz = detailedInfo.CpuMaxFrequencyHertz;
             targetInfo.TotalMemoryBytes = detailedInfo.TotalMemoryBytes;
             targetInfo.DetailAvailability = detailedInfo.DetailAvailability;
@@ -119,6 +120,10 @@ internal static class AppleEnvironmentReport
             var json = await File.ReadAllTextAsync(tempPath, cancellationToken);
             return ParseDetailedDeviceInfo(json, deviceIdentifier) ?? new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (matching devicectl entry not found)");
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch
         {
             return new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (failed to query devicectl metadata)");
@@ -138,7 +143,9 @@ internal static class AppleEnvironmentReport
         }
 
         return new AppleDetailedDeviceInfo(
-            CpuModel: FindStringValue(deviceElement, "cpu", "chip", "processor", "soc", "socName"),
+            CpuModel: FindStringValueAtPath(deviceElement, "hardwareProperties", "cpuType", "name")
+                ?? FindStringValue(deviceElement, "cpu", "chip", "processor", "soc", "socName"),
+            DeviceType: FindStringValueAtPath(deviceElement, "hardwareProperties", "deviceType"),
             CpuMaxFrequencyHertz: FindInt64Value(deviceElement, "cpuMaxFrequency", "clockSpeed", "maxClockSpeed", "cpuFrequency", "processorSpeed"),
             TotalMemoryBytes: FindInt64Value(deviceElement, "totalMemory", "physicalMemory", "memory", "ram"),
             DetailAvailability: null);
@@ -230,6 +237,36 @@ internal static class AppleEnvironmentReport
         return null;
     }
 
+    private static string? FindStringValueAtPath(JsonElement element, params string[] propertyPath)
+    {
+        foreach (var pathPart in propertyPath)
+        {
+            if (element.ValueKind != JsonValueKind.Object || !TryGetProperty(element, pathPart, out element))
+            {
+                return null;
+            }
+        }
+
+        return element.ValueKind == JsonValueKind.String
+            ? element.GetString()
+            : element.ToString();
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
     private static long? FindInt64Value(JsonElement element, params string[] propertyNames)
     {
         var rawValue = FindStringValue(element, propertyNames);
@@ -251,5 +288,5 @@ internal static class AppleEnvironmentReport
         return null;
     }
 
-    private sealed record AppleDetailedDeviceInfo(string? CpuModel = null, long? CpuMaxFrequencyHertz = null, long? TotalMemoryBytes = null, string? DetailAvailability = null);
+    private sealed record AppleDetailedDeviceInfo(string? CpuModel = null, string? DeviceType = null, long? CpuMaxFrequencyHertz = null, long? TotalMemoryBytes = null, string? DetailAvailability = null);
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/AppleEnvironmentReport.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppleEnvironmentReport.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
+
+namespace Microsoft.DotNet.XHarness.Apple;
+
+internal static class AppleEnvironmentReport
+{
+    public static ExecutionEnvironmentInfo CreateMacCatalystEnvironment()
+        => new()
+        {
+            Host = EnvironmentReportLogger.GetHostEnvironmentInfo(),
+            Target = new TargetEnvironmentInfo
+            {
+                Kind = "maccatalyst",
+                Name = Environment.MachineName,
+                Identifier = Environment.MachineName,
+                OperatingSystem = "macOS",
+                OperatingSystemVersion = RuntimeInformation.OSDescription,
+                Architecture = RuntimeInformation.ProcessArchitecture.ToString(),
+            },
+        };
+
+    public static async Task<ExecutionEnvironmentInfo> CreateTargetEnvironmentAsync(
+        IMlaunchProcessManager processManager,
+        IDevice device,
+        IDevice? companionDevice,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(processManager);
+        ArgumentNullException.ThrowIfNull(device);
+
+        return new ExecutionEnvironmentInfo
+        {
+            Host = EnvironmentReportLogger.GetHostEnvironmentInfo(),
+            Target = await CreateTargetInfoAsync(processManager, device, cancellationToken),
+            CompanionTarget = companionDevice == null ? null : await CreateTargetInfoAsync(processManager, companionDevice, cancellationToken),
+        };
+    }
+
+    private static async Task<TargetEnvironmentInfo> CreateTargetInfoAsync(
+        IMlaunchProcessManager processManager,
+        IDevice device,
+        CancellationToken cancellationToken)
+    {
+        var targetInfo = new TargetEnvironmentInfo
+        {
+            Kind = device is IHardwareDevice ? "physical-device" : "simulator",
+            Name = device.Name,
+            Identifier = device.UDID,
+            OperatingSystemVersion = device.OSVersion,
+        };
+
+        if (device is SimulatorDevice simulatorDevice)
+        {
+            targetInfo.OperatingSystem = device.OSVersion.Split(' ', 2)[0];
+            targetInfo.SimulatorRuntime = simulatorDevice.SimRuntime;
+            targetInfo.SimulatorDeviceType = simulatorDevice.SimDeviceType;
+            targetInfo.State = simulatorDevice.State.ToString();
+        }
+
+        if (device is IHardwareDevice hardwareDevice)
+        {
+            targetInfo.OperatingSystem = hardwareDevice.DevicePlatform == DevicePlatform.Unknown
+                ? null
+                : hardwareDevice.DevicePlatform.AsString();
+            targetInfo.Architecture = hardwareDevice.CpuArchitecture ?? hardwareDevice.Architecture.ToString();
+            targetInfo.ProductType = hardwareDevice.ProductType;
+            targetInfo.HardwareModel = hardwareDevice.HardwareModel;
+            targetInfo.ModelNumber = hardwareDevice.ModelNumber;
+            targetInfo.Connection = hardwareDevice.InterfaceType;
+            targetInfo.BuildVersion = hardwareDevice.BuildVersion;
+            targetInfo.AvailableStorageBytes = hardwareDevice.AmountDataAvailable;
+            targetInfo.TotalStorageBytes = hardwareDevice.TotalDataCapacity;
+
+            var detailedInfo = await TryGetDetailedDeviceInfoAsync(processManager, hardwareDevice.UDID, cancellationToken);
+            targetInfo.CpuModel = detailedInfo.CpuModel;
+            targetInfo.CpuMaxFrequencyHertz = detailedInfo.CpuMaxFrequencyHertz;
+            targetInfo.TotalMemoryBytes = detailedInfo.TotalMemoryBytes;
+            targetInfo.DetailAvailability = detailedInfo.DetailAvailability;
+        }
+
+        return targetInfo;
+    }
+
+    private static async Task<AppleDetailedDeviceInfo> TryGetDetailedDeviceInfoAsync(IMlaunchProcessManager processManager, string deviceIdentifier, CancellationToken cancellationToken)
+    {
+        if (processManager.XcodeVersion.Major < 15)
+        {
+            return new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (devicectl requires Xcode 15 or newer)");
+        }
+
+        var tempPath = Path.GetTempFileName();
+        try
+        {
+            var commandLog = new Microsoft.DotNet.XHarness.Common.Logging.MemoryLog();
+            var result = await processManager.ExecuteXcodeCommandAsync(
+                "devicectl",
+                new[] { "list", "devices", "-v", "--json-output", tempPath },
+                commandLog,
+                TimeSpan.FromMinutes(1),
+                cancellationToken);
+
+            if (!result.Succeeded || !File.Exists(tempPath))
+            {
+                return new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (devicectl device listing failed)");
+            }
+
+            var json = await File.ReadAllTextAsync(tempPath, cancellationToken);
+            return ParseDetailedDeviceInfo(json, deviceIdentifier) ?? new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (matching devicectl entry not found)");
+        }
+        catch
+        {
+            return new AppleDetailedDeviceInfo(DetailAvailability: "Unavailable (failed to query devicectl metadata)");
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    private static AppleDetailedDeviceInfo? ParseDetailedDeviceInfo(string json, string deviceIdentifier)
+    {
+        using var document = JsonDocument.Parse(json);
+        if (!TryFindDeviceElement(document.RootElement, deviceIdentifier, out var deviceElement))
+        {
+            return null;
+        }
+
+        return new AppleDetailedDeviceInfo(
+            CpuModel: FindStringValue(deviceElement, "cpu", "chip", "processor", "soc", "socName"),
+            CpuMaxFrequencyHertz: FindInt64Value(deviceElement, "cpuMaxFrequency", "clockSpeed", "maxClockSpeed", "cpuFrequency", "processorSpeed"),
+            TotalMemoryBytes: FindInt64Value(deviceElement, "totalMemory", "physicalMemory", "memory", "ram"),
+            DetailAvailability: null);
+    }
+
+    private static bool TryFindDeviceElement(JsonElement element, string deviceIdentifier, out JsonElement matchingElement)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if ((property.Name.Equals("identifier", StringComparison.OrdinalIgnoreCase)
+                    || property.Name.Equals("udid", StringComparison.OrdinalIgnoreCase)
+                    || property.Name.Equals("deviceIdentifier", StringComparison.OrdinalIgnoreCase))
+                    && property.Value.ValueKind == JsonValueKind.String
+                    && string.Equals(property.Value.GetString(), deviceIdentifier, StringComparison.OrdinalIgnoreCase))
+                {
+                    matchingElement = element;
+                    return true;
+                }
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (TryFindDeviceElement(property.Value, deviceIdentifier, out matchingElement))
+                {
+                    return true;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                if (TryFindDeviceElement(item, deviceIdentifier, out matchingElement))
+                {
+                    return true;
+                }
+            }
+        }
+
+        matchingElement = default;
+        return false;
+    }
+
+    private static string? FindStringValue(JsonElement element, params string[] propertyNames)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                foreach (var propertyName in propertyNames)
+                {
+                    if (!property.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        return property.Value.GetString();
+                    }
+
+                    if (property.Value.ValueKind == JsonValueKind.Number || property.Value.ValueKind == JsonValueKind.True || property.Value.ValueKind == JsonValueKind.False)
+                    {
+                        return property.Value.ToString();
+                    }
+                }
+
+                var nestedValue = FindStringValue(property.Value, propertyNames);
+                if (!string.IsNullOrWhiteSpace(nestedValue))
+                {
+                    return nestedValue;
+                }
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                var nestedValue = FindStringValue(item, propertyNames);
+                if (!string.IsNullOrWhiteSpace(nestedValue))
+                {
+                    return nestedValue;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static long? FindInt64Value(JsonElement element, params string[] propertyNames)
+    {
+        var rawValue = FindStringValue(element, propertyNames);
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return null;
+        }
+
+        if (long.TryParse(rawValue, out var numericValue))
+        {
+            return numericValue;
+        }
+
+        if (double.TryParse(rawValue, out var floatingValue))
+        {
+            return (long)floatingValue;
+        }
+
+        return null;
+    }
+
+    private sealed record AppleDetailedDeviceInfo(string? CpuModel = null, long? CpuMaxFrequencyHertz = null, long? TotalMemoryBytes = null, string? DetailAvailability = null);
+}

--- a/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/DeviceFinder.cs
@@ -75,6 +75,7 @@ public class DeviceFinder : IDeviceFinder
                 log,
                 includeLocked: false,
                 forceRefresh: false,
+                listExtraData: true,
                 includeWirelessDevices: includeWirelessDevices,
                 cancellationToken: cancellationToken);
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -36,6 +37,7 @@ public abstract class BaseOrchestrator : IDisposable
     private readonly IAppInstaller _appInstaller;
     private readonly IAppUninstaller _appUninstaller;
     private readonly IDeviceFinder _deviceFinder;
+    private readonly IMlaunchProcessManager _processManager;
     private readonly ILogger _logger;
     private readonly ILogs _logs;
     private readonly IFileBackedLog _mainLog;
@@ -62,6 +64,7 @@ public abstract class BaseOrchestrator : IDisposable
         IAppInstaller appInstaller,
         IAppUninstaller appUninstaller,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
@@ -73,6 +76,7 @@ public abstract class BaseOrchestrator : IDisposable
         _appInstaller = appInstaller ?? throw new ArgumentNullException(nameof(appInstaller));
         _appUninstaller = appUninstaller ?? throw new ArgumentNullException(nameof(appUninstaller));
         _deviceFinder = deviceFinder ?? throw new ArgumentNullException(nameof(deviceFinder));
+        _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
         _logger = consoleLogger ?? throw new ArgumentNullException(nameof(consoleLogger));
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
         _mainLog = mainLog ?? throw new ArgumentNullException(nameof(mainLog));
@@ -169,6 +173,7 @@ public abstract class BaseOrchestrator : IDisposable
             _diagnosticsData.Device = Environment.MachineName;
             _diagnosticsData.TargetOS = $"macOS {Environment.OSVersion.Version}";
             _diagnosticsData.IsDevice = false;
+            _diagnosticsData.Environment = AppleEnvironmentReport.CreateMacCatalystEnvironment();
 
             try
             {
@@ -288,6 +293,7 @@ public abstract class BaseOrchestrator : IDisposable
         }
 
         cancellationToken.ThrowIfCancellationRequested();
+        _diagnosticsData.Environment = await AppleEnvironmentReport.CreateTargetEnvironmentAsync(_processManager, device, companionDevice, cancellationToken);
 
         // Note down the actual test target
         // For simulators (e.g. "iOS 13.4"), we strip the iOS part and keep the version only, for devices there's no OS
@@ -413,7 +419,8 @@ public abstract class BaseOrchestrator : IDisposable
             deviceOsVersion: _diagnosticsData.TargetOS,
             architecture: null,
             instrumentationExitCode: null,
-            producedFiles: producedFiles);
+            producedFiles: producedFiles,
+            environment: _diagnosticsData.Environment);
 
         RunSummaryEmitter.WriteResultJsonFile(
             _logs.Directory,
@@ -423,7 +430,8 @@ public abstract class BaseOrchestrator : IDisposable
             deviceOsVersion: _diagnosticsData.TargetOS,
             architecture: null,
             instrumentationExitCode: null,
-            producedFiles: producedFiles);
+            producedFiles: producedFiles,
+            environment: _diagnosticsData.Environment);
     }
 
     public void Dispose()

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/InstallOrchestrator.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -38,13 +39,14 @@ public class InstallOrchestrator : BaseOrchestrator, IInstallOrchestrator
         IAppUninstaller appUninstaller,
         IAppBundleInformationParser appBundleInformationParser,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
     }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustRunOrchestrator.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -47,6 +48,7 @@ public class JustRunOrchestrator : RunOrchestrator, IJustRunOrchestrator
         IAppUninstaller appUninstaller,
         IAppRunnerFactory appRunnerFactory,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         IiOSExitCodeDetector iOSExitCodeDetector,
         IMacCatalystExitCodeDetector macCatalystExitCodeDetector,
         ILogger consoleLogger,
@@ -55,7 +57,7 @@ public class JustRunOrchestrator : RunOrchestrator, IJustRunOrchestrator
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, appRunnerFactory, deviceFinder, iOSExitCodeDetector, macCatalystExitCodeDetector, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, appRunnerFactory, deviceFinder, processManager, iOSExitCodeDetector, macCatalystExitCodeDetector, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
     }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/JustTestOrchestrator.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -52,13 +53,14 @@ public class JustTestOrchestrator : TestOrchestrator, IJustTestOrchestrator
         IAppUninstaller appUninstaller,
         IAppTesterFactory appTesterFactory,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, appTesterFactory, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, appTesterFactory, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
     }
 

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/RunOrchestrator.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -59,6 +60,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         IAppUninstaller appUninstaller,
         IAppRunnerFactory appRunnerFactory,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         IiOSExitCodeDetector iOSExitCodeDetector,
         IMacCatalystExitCodeDetector macCatalystExitCodeDetector,
         ILogger consoleLogger,
@@ -67,7 +69,7 @@ public class RunOrchestrator : BaseOrchestrator, IRunOrchestrator
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
         _iOSExitCodeDetector = iOSExitCodeDetector ?? throw new ArgumentNullException(nameof(iOSExitCodeDetector));
         _macCatalystExitCodeDetector = macCatalystExitCodeDetector ?? throw new ArgumentNullException(nameof(macCatalystExitCodeDetector));

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/SimulatorResetOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/SimulatorResetOrchestrator.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -35,13 +36,14 @@ public class SimulatorResetOrchestrator : BaseOrchestrator, ISimulatorResetOrche
         IAppInstaller appInstaller,
         IAppUninstaller appUninstaller,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(new FakeAppBundleInformationParser(), appInstaller, appUninstaller, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(new FakeAppBundleInformationParser(), appInstaller, appUninstaller, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
         _consoleLogger = consoleLogger;
     }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -56,13 +57,14 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
         IAppUninstaller appUninstaller,
         IAppTesterFactory appTesterFactory,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
         _appTesterFactory = appTesterFactory ?? throw new ArgumentNullException(nameof(appTesterFactory));
         _logger = consoleLogger ?? throw new ArgumentNullException(nameof(consoleLogger));

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/UninstallOrchestrator.cs
@@ -9,6 +9,7 @@ using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.CLI;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -38,13 +39,14 @@ public class UninstallOrchestrator : BaseOrchestrator, IUninstallOrchestrator
         IAppInstaller appInstaller,
         IAppUninstaller appUninstaller,
         IDeviceFinder deviceFinder,
+        IMlaunchProcessManager processManager,
         ILogger consoleLogger,
         ILogs logs,
         IFileBackedLog mainLog,
         IErrorKnowledgeBase errorKnowledgeBase,
         IDiagnosticsData diagnosticsData,
         IHelpers helpers)
-        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
+        : base(appBundleInformationParser, appInstaller, appUninstaller, deviceFinder, processManager, consoleLogger, logs, mainLog, errorKnowledgeBase, diagnosticsData, helpers)
     {
     }
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -47,7 +47,8 @@ Arguments:
             apiVersion: Arguments.ApiVersion.Value,
             bootTimeoutSeconds: Arguments.LaunchTimeout,
             runner: runner,
-            DiagnosticsData);
+            DiagnosticsData,
+            captureEnvironmentInfo: true);
     }
 
     public static ExitCode InvokeHelper(

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidInstallCommand.cs
@@ -59,7 +59,8 @@ Arguments:
         int? apiVersion,
         TimeSpan bootTimeoutSeconds,
         AdbRunner runner,
-        IDiagnosticsData diagnosticsData)
+        IDiagnosticsData diagnosticsData,
+        bool captureEnvironmentInfo = false)
     {
         using (logger.BeginScope("Initialization and setup of APK on device"))
         {
@@ -128,6 +129,11 @@ Arguments:
             }
 
             logger.LogDebug($"Working with {device.DeviceSerial} (API {device.ApiVersion})");
+
+            if (captureEnvironmentInfo)
+            {
+                diagnosticsData.Environment = AndroidEnvironmentReport.CreateEnvironmentInfo(runner, device);
+            }
 
             runner.CheckPackageVerificationSettings();
 

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -62,13 +62,14 @@ Arguments:
         }
 
         DiagnosticsData.CaptureDeviceInfo(device);
+        DiagnosticsData.Environment = AndroidEnvironmentReport.CreateEnvironmentInfo(runner, device);
 
         // Wait till at least device(s) are ready
         if (!runner.WaitForDevice())
         {
             return ExitCode.DEVICE_NOT_FOUND;
         }
-
+        logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
         logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
 
         // Empty log as we'll be uploading the full logcat for this execution

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidRunCommand.cs
@@ -70,7 +70,6 @@ Arguments:
             return ExitCode.DEVICE_NOT_FOUND;
         }
         logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
-        logger.LogDebug($"Working with API {runner.GetAdbVersion()}");
 
         // Empty log as we'll be uploading the full logcat for this execution
         runner.ClearAdbLog();

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidTestCommand.cs
@@ -48,7 +48,8 @@ Arguments:
             apiVersion: Arguments.ApiVersion.Value,
             bootTimeoutSeconds: Arguments.LaunchTimeout,
             runner,
-            DiagnosticsData);
+            DiagnosticsData,
+            captureEnvironmentInfo: true);
 
         if (Arguments.Wifi != WifiStatus.Unknown)
         {

--- a/src/Microsoft.DotNet.XHarness.Common/CommandDiagnostics.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CommandDiagnostics.cs
@@ -40,6 +40,11 @@ public interface IDiagnosticsData
     /// Files produced during the command execution.
     /// </summary>
     IList<DiagnosticsFile> Files { get; }
+
+    /// <summary>
+    /// Structured host and target environment details for the execution.
+    /// </summary>
+    ExecutionEnvironmentInfo? Environment { get; set; }
 }
 
 /// <summary>
@@ -71,6 +76,9 @@ public class CommandDiagnostics : IDiagnosticsData
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public IList<DiagnosticsFile> Files { get; } = new List<DiagnosticsFile>();
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ExecutionEnvironmentInfo? Environment { get; set; }
 
     public int Duration => (int)Math.Round(_timer.Elapsed.TotalSeconds);
 
@@ -105,6 +113,7 @@ public class CommandDiagnostics : IDiagnosticsData
                 WriteIndented = false,
 #endif
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
 
         _logger.LogDebug("Saving diagnostics data to '{path}'", targetFile);

--- a/src/Microsoft.DotNet.XHarness.Common/EnvironmentReportLogger.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/EnvironmentReportLogger.cs
@@ -1,0 +1,294 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32;
+
+namespace Microsoft.DotNet.XHarness.Common;
+
+public static class EnvironmentReportLogger
+{
+    public static HostEnvironmentInfo GetHostEnvironmentInfo()
+        => HostEnvironmentInfoProvider.GetHostEnvironmentInfo();
+
+    public static string FormatBytes(long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return "0 B";
+        }
+
+        string[] units = { "B", "KiB", "MiB", "GiB", "TiB" };
+        double value = bytes;
+        var unitIndex = 0;
+
+        while (value >= 1024 && unitIndex < units.Length - 1)
+        {
+            value /= 1024;
+            unitIndex++;
+        }
+
+        return $"{value:0.##} {units[unitIndex]}";
+    }
+
+    public static string FormatFrequencyHertz(long hertz)
+        => hertz <= 0 ? "0 Hz" : FormatFrequencyKiloHertz(hertz / 1000);
+
+    public static string FormatFrequencyKiloHertz(long kiloHertz)
+    {
+        if (kiloHertz <= 0)
+        {
+            return "0 kHz";
+        }
+
+        if (kiloHertz >= 1_000_000)
+        {
+            return $"{kiloHertz / 1_000_000d:0.##} GHz";
+        }
+
+        if (kiloHertz >= 1_000)
+        {
+            return $"{kiloHertz / 1_000d:0.##} MHz";
+        }
+
+        return $"{kiloHertz.ToString(CultureInfo.InvariantCulture)} kHz";
+    }
+
+    private static class HostEnvironmentInfoProvider
+    {
+        public static HostEnvironmentInfo GetHostEnvironmentInfo()
+        {
+            return new HostEnvironmentInfo
+            {
+                MachineName = Environment.MachineName,
+                OperatingSystem = RuntimeInformation.OSDescription,
+                OperatingSystemArchitecture = RuntimeInformation.OSArchitecture.ToString(),
+                ProcessArchitecture = RuntimeInformation.ProcessArchitecture.ToString(),
+                FrameworkDescription = RuntimeInformation.FrameworkDescription,
+                LogicalProcessorCount = Environment.ProcessorCount,
+                CpuModel = GetCpuModel(),
+                CpuMaxFrequencyHertz = GetCpuMaxFrequencyHertz(),
+                TotalMemoryBytes = GetTotalMemoryBytes(),
+            };
+        }
+
+        private static string? GetCpuModel()
+        {
+            try
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    using var cpuKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DESCRIPTION\System\CentralProcessor\0");
+                    return cpuKey?.GetValue("ProcessorNameString")?.ToString()?.Trim();
+                }
+
+                if (OperatingSystem.IsLinux())
+                {
+                    var cpuInfo = ReadFileIfExists("/proc/cpuinfo");
+                    return TryGetColonDelimitedValue(cpuInfo, "model name")
+                        ?? TryGetColonDelimitedValue(cpuInfo, "Hardware")
+                        ?? TryGetColonDelimitedValue(cpuInfo, "Processor");
+                }
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    return RunCommand("sysctl", "-n", "machdep.cpu.brand_string");
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static long? GetCpuMaxFrequencyHertz()
+        {
+            try
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    using var cpuKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DESCRIPTION\System\CentralProcessor\0");
+                    object? frequencyValue = cpuKey?.GetValue("~MHz");
+                    if (frequencyValue != null && long.TryParse(frequencyValue.ToString(), out var megaHertz))
+                    {
+                        return megaHertz * 1_000_000;
+                    }
+                }
+
+                if (OperatingSystem.IsLinux())
+                {
+                    var cpuFrequency = ReadFirstExistingFile(
+                        "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq",
+                        "/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq");
+                    if (TryParseLong(cpuFrequency, out var kiloHertz))
+                    {
+                        return kiloHertz * 1000;
+                    }
+
+                    var cpuInfo = ReadFileIfExists("/proc/cpuinfo");
+                    var cpuMhz = TryGetColonDelimitedValue(cpuInfo, "cpu MHz");
+                    if (double.TryParse(cpuMhz, NumberStyles.Float, CultureInfo.InvariantCulture, out var megaHertz))
+                    {
+                        return (long)Math.Round(megaHertz * 1_000_000);
+                    }
+                }
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    var frequency = RunCommand("sysctl", "-n", "hw.cpufrequency_max")
+                        ?? RunCommand("sysctl", "-n", "hw.cpufrequency");
+                    if (TryParseLong(frequency, out var hertz))
+                    {
+                        return hertz;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static long? GetTotalMemoryBytes()
+        {
+            try
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    if (GetPhysicallyInstalledSystemMemory(out var kiloBytes))
+                    {
+                        return kiloBytes * 1024;
+                    }
+                }
+
+                if (OperatingSystem.IsLinux())
+                {
+                    var memInfo = ReadFileIfExists("/proc/meminfo");
+                    var totalMemory = TryGetColonDelimitedValue(memInfo, "MemTotal");
+                    if (TryParseLong(totalMemory, out var kiloBytes))
+                    {
+                        return kiloBytes * 1024;
+                    }
+                }
+
+                if (OperatingSystem.IsMacOS())
+                {
+                    var memory = RunCommand("sysctl", "-n", "hw.memsize");
+                    if (TryParseLong(memory, out var bytes))
+                    {
+                        return bytes;
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static string? ReadFirstExistingFile(params string[] paths)
+        {
+            foreach (var path in paths)
+            {
+                var content = ReadFileIfExists(path);
+                if (!string.IsNullOrWhiteSpace(content))
+                {
+                    return content;
+                }
+            }
+
+            return null;
+        }
+
+        private static string? ReadFileIfExists(string path)
+            => File.Exists(path) ? File.ReadAllText(path).Trim() : null;
+
+        private static string? RunCommand(string fileName, params string[] arguments)
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    Arguments = string.Join(" ", arguments),
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+
+            process.Start();
+            if (!process.WaitForExit(5000))
+            {
+                try
+                {
+                    process.Kill(true);
+                }
+                catch
+                {
+                }
+
+                return null;
+            }
+
+            if (process.ExitCode != 0)
+            {
+                return null;
+            }
+
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            return string.IsNullOrWhiteSpace(output) ? null : output;
+        }
+
+        private static string? TryGetColonDelimitedValue(string? content, string key)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            foreach (var line in content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (!line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var separatorIndex = line.IndexOf(':');
+                if (separatorIndex < 0 || separatorIndex == line.Length - 1)
+                {
+                    continue;
+                }
+
+                return line.Substring(separatorIndex + 1).Trim();
+            }
+
+            return null;
+        }
+
+        private static bool TryParseLong(string? value, out long parsed)
+        {
+            parsed = 0;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var token = value.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)[0];
+            return long.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed);
+        }
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetPhysicallyInstalledSystemMemory(out long totalMemoryInKilobytes);
+    }
+}

--- a/src/Microsoft.DotNet.XHarness.Common/EnvironmentReportLogger.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/EnvironmentReportLogger.cs
@@ -227,6 +227,8 @@ public static class EnvironmentReportLogger
             };
 
             process.Start();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
             if (!process.WaitForExit(5000))
             {
                 try
@@ -240,12 +242,14 @@ public static class EnvironmentReportLogger
                 return null;
             }
 
+            var output = outputTask.GetAwaiter().GetResult().Trim();
+            _ = errorTask.GetAwaiter().GetResult();
+
             if (process.ExitCode != 0)
             {
                 return null;
             }
 
-            var output = process.StandardOutput.ReadToEnd().Trim();
             return string.IsNullOrWhiteSpace(output) ? null : output;
         }
 

--- a/src/Microsoft.DotNet.XHarness.Common/ExecutionEnvironmentInfo.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/ExecutionEnvironmentInfo.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.XHarness.Common;
+
+public sealed class ExecutionEnvironmentInfo
+{
+    public HostEnvironmentInfo? Host { get; set; }
+
+    public TargetEnvironmentInfo? Target { get; set; }
+
+    public TargetEnvironmentInfo? CompanionTarget { get; set; }
+}
+
+public sealed class HostEnvironmentInfo
+{
+    public string? MachineName { get; set; }
+
+    public string? OperatingSystem { get; set; }
+
+    public string? OperatingSystemArchitecture { get; set; }
+
+    public string? ProcessArchitecture { get; set; }
+
+    public string? FrameworkDescription { get; set; }
+
+    public int LogicalProcessorCount { get; set; }
+
+    public string? CpuModel { get; set; }
+
+    public long? CpuMaxFrequencyHertz { get; set; }
+
+    public long? TotalMemoryBytes { get; set; }
+}
+
+public sealed class TargetEnvironmentInfo
+{
+    public string? Kind { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Identifier { get; set; }
+
+    public string? OperatingSystem { get; set; }
+
+    public string? OperatingSystemVersion { get; set; }
+
+    public int? ApiLevel { get; set; }
+
+    public string? Architecture { get; set; }
+
+    public string[]? SupportedArchitectures { get; set; }
+
+    public string? Manufacturer { get; set; }
+
+    public string? Model { get; set; }
+
+    public string? ProductName { get; set; }
+
+    public string? ProductType { get; set; }
+
+    public string? HardwareModel { get; set; }
+
+    public string? ModelNumber { get; set; }
+
+    public string? Connection { get; set; }
+
+    public string? BuildFingerprint { get; set; }
+
+    public string? BuildVersion { get; set; }
+
+    public string? SimulatorRuntime { get; set; }
+
+    public string? SimulatorDeviceType { get; set; }
+
+    public string? State { get; set; }
+
+    public string? CpuModel { get; set; }
+
+    public long? CpuMaxFrequencyHertz { get; set; }
+
+    public long? TotalMemoryBytes { get; set; }
+
+    public long? AvailableStorageBytes { get; set; }
+
+    public long? TotalStorageBytes { get; set; }
+
+    public string? DetailAvailability { get; set; }
+}

--- a/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
@@ -31,11 +31,12 @@ public static class RunSummaryEmitter
         string? deviceOsVersion,
         string? architecture,
         int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
+        IReadOnlyList<DiagnosticsFile> producedFiles,
+        ExecutionEnvironmentInfo? environment = null)
     {
         EmitRunSummary(
             message => logger.LogInformation(message),
-            exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+            exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
     }
 
     /// <summary>
@@ -50,9 +51,10 @@ public static class RunSummaryEmitter
         string? deviceOsVersion,
         string? architecture,
         int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
+        IReadOnlyList<DiagnosticsFile> producedFiles,
+        ExecutionEnvironmentInfo? environment = null)
     {
-        EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+        EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
     }
 
     /// <summary>
@@ -67,9 +69,10 @@ public static class RunSummaryEmitter
         string? deviceOsVersion,
         string? architecture,
         int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
+        IReadOnlyList<DiagnosticsFile> producedFiles,
+        ExecutionEnvironmentInfo? environment = null)
     {
-        var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+        var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
 
         var options = new JsonSerializerOptions
         {
@@ -94,11 +97,12 @@ public static class RunSummaryEmitter
         string? deviceOsVersion,
         string? architecture,
         int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
+        IReadOnlyList<DiagnosticsFile> producedFiles,
+        ExecutionEnvironmentInfo? environment = null)
     {
         try
         {
-            var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles);
+            var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
 
             var options = new JsonSerializerOptions
             {
@@ -124,7 +128,8 @@ public static class RunSummaryEmitter
         string? deviceOsVersion,
         string? architecture,
         int? instrumentationExitCode,
-        IReadOnlyList<DiagnosticsFile> producedFiles)
+        IReadOnlyList<DiagnosticsFile> producedFiles,
+        ExecutionEnvironmentInfo? environment)
     {
         string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
         string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
@@ -182,6 +187,11 @@ public static class RunSummaryEmitter
         if (fileEntries.Count > 0)
         {
             resultData["files"] = fileEntries;
+        }
+
+        if (environment != null)
+        {
+            resultData["environment"] = environment;
         }
 
         return resultData;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/Device.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/Device.cs
@@ -27,19 +27,29 @@ public class Device : IHardwareDevice
         string? productVersion,
         string? productType,
         string interfaceType,
+        string? modelNumber = null,
+        long? amountDataAvailable = null,
+        long? totalDataCapacity = null,
         string? companionIdentifier = null,
         bool? isUsableForDebugging = null,
         bool isLocked = false,
-        bool isPaired = false)
+        bool isPaired = false,
+        string? cpuArchitecture = null,
+        string? hardwareModel = null)
     {
         DeviceIdentifier = deviceIdentifier;
         DeviceClass = deviceClass;
         CompanionIdentifier = companionIdentifier;
         Name = name;
         BuildVersion = buildVersion;
+        CpuArchitecture = cpuArchitecture;
         ProductVersion = productVersion;
         ProductType = productType;
+        HardwareModel = hardwareModel;
         InterfaceType = interfaceType;
+        ModelNumber = modelNumber;
+        AmountDataAvailable = amountDataAvailable;
+        TotalDataCapacity = totalDataCapacity;
         IsUsableForDebugging = isUsableForDebugging;
         IsLocked = isLocked;
         IsPaired = isPaired;
@@ -48,11 +58,16 @@ public class Device : IHardwareDevice
     public string DeviceIdentifier { get; }
     public DeviceClass DeviceClass { get; }
     public string? CompanionIdentifier { get; }
+    public long? AmountDataAvailable { get; }
     public string Name { get; }
     public string? BuildVersion { get; }
+    public string? CpuArchitecture { get; }
+    public string? HardwareModel { get; }
+    public string? ModelNumber { get; }
     public string? ProductVersion { get; }
     public string? ProductType { get; }
     public string InterfaceType { get; }
+    public long? TotalDataCapacity { get; }
     public bool? IsUsableForDebugging { get; }
     public bool IsLocked { get; }
     public bool IsPaired { get; }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
@@ -243,11 +243,19 @@ public class HardwareDeviceLoader : IHardwareDeviceLoader
             companionIdentifier: deviceNode.SelectSingleNode("CompanionIdentifier")?.InnerText,
             name: deviceNode.SelectSingleNode("Name")?.InnerText,
             buildVersion: deviceNode.SelectSingleNode("BuildVersion")?.InnerText,
+            cpuArchitecture: deviceNode.SelectSingleNode("CPUArchitecture")?.InnerText,
             productVersion: deviceNode.SelectSingleNode("ProductVersion")?.InnerText,
             productType: deviceNode.SelectSingleNode("ProductType")?.InnerText,
+            hardwareModel: deviceNode.SelectSingleNode("HardwareModel")?.InnerText,
             interfaceType: deviceNode.SelectSingleNode("InterfaceType")?.InnerText,
+            modelNumber: deviceNode.SelectSingleNode("ModelNumber")?.InnerText,
+            amountDataAvailable: TryParseLong(deviceNode.SelectSingleNode("AmountDataAvailable")?.InnerText),
+            totalDataCapacity: TryParseLong(deviceNode.SelectSingleNode("TotalDataCapacity")?.InnerText),
             isUsableForDebugging: usable == null ? (bool?)null : usable == "True",
             isLocked: bool.TryParse(deviceNode.SelectSingleNode("IsLocked")?.InnerText, out var locked) && locked,
             isPaired: bool.TryParse(deviceNode.SelectSingleNode("IsPaired")?.InnerText, out var isPaired) && isPaired);
     }
+
+    private static long? TryParseLong(string? value)
+        => long.TryParse(value, out var parsed) ? parsed : null;
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IHardwareDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/IHardwareDevice.cs
@@ -9,7 +9,11 @@ public interface IHardwareDevice : IDevice
     string DeviceIdentifier { get; }
     DeviceClass DeviceClass { get; }
     string? CompanionIdentifier { get; }
+    long? AmountDataAvailable { get; }
     string? BuildVersion { get; }
+    string? CpuArchitecture { get; }
+    string? HardwareModel { get; }
+    string? ModelNumber { get; }
     string? ProductVersion { get; }
     string? ProductType { get; }
     string InterfaceType { get; }
@@ -21,4 +25,5 @@ public interface IHardwareDevice : IDevice
     bool Supports64Bit { get; }
     bool Supports32Bit { get; }
     Architecture Architecture { get; }
+    long? TotalDataCapacity { get; }
 }

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -232,6 +232,24 @@ public class AdbRunnerTests : IDisposable
     }
 
     [Fact]
+    public void PopulateEnvironmentInfoLoadsDetailedDeviceMetadata()
+    {
+        var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
+        var device = runner.GetDevice(requiredDeviceId: _fakeDeviceList.Single(d => d.Manufacturer == "Contoso").DeviceSerial);
+
+        runner.PopulateEnvironmentInfo(device);
+
+        Assert.Equal("Contoso", device.Manufacturer);
+        Assert.Equal("Android Test Device", device.Model);
+        Assert.Equal("android-test-product", device.ProductName);
+        Assert.Equal("14", device.OperatingSystemVersion);
+        Assert.Equal("Contoso/test-device/test-device:14/AP1A.240505.001/1234567:userdebug/dev-keys", device.BuildFingerprint);
+        Assert.Equal("Qualcomm Technologies, Inc SM8650", device.CpuModel);
+        Assert.Equal(2_800_000, device.CpuMaxFrequencyKiloHertz);
+        Assert.Equal(8L * 1024 * 1024 * 1024, device.TotalMemoryBytes);
+    }
+
+    [Fact]
     public void RebootAndroidDevice()
     {
         var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
@@ -338,7 +356,15 @@ public class AdbRunnerTests : IDisposable
                 ApiVersion = 31,
                 Architecture = "arm64-v8a",
                 SupportedArchitectures = new[] { "arm64-v8a", "x86_64", "x86" },
-                InstalledApplications = new[] { "net.dot.E", "net.dot.F" }
+                InstalledApplications = new[] { "net.dot.E", "net.dot.F" },
+                Manufacturer = "Contoso",
+                Model = "Android Test Device",
+                ProductName = "android-test-product",
+                OperatingSystemVersion = "14",
+                BuildFingerprint = "Contoso/test-device/test-device:14/AP1A.240505.001/1234567:userdebug/dev-keys",
+                CpuModel = "Qualcomm Technologies, Inc SM8650",
+                CpuMaxFrequencyKiloHertz = 2_800_000,
+                TotalMemoryBytes = 8L * 1024 * 1024 * 1024
             },
 
             new AndroidDevice($"emulator-{r.Next(9999)}")
@@ -411,6 +437,31 @@ public class AdbRunnerTests : IDisposable
                     stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).ApiVersion + Environment.NewLine;
                 }
 
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.product.manufacturer"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).Manufacturer ?? string.Empty;
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.product.model"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).Model ?? string.Empty;
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.product.name"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).ProductName ?? string.Empty;
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.build.version.release"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).OperatingSystemVersion ?? string.Empty;
+                }
+
+                if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop ro.build.fingerprint"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).BuildFingerprint ?? string.Empty;
+                }
+
                 if ($"{arguments[argStart + 1]} {arguments[argStart + 2]}".Equals("getprop sys.boot_completed"))
                 {
                     // Newline is strange, but this is actually what it looks like
@@ -429,6 +480,22 @@ public class AdbRunnerTests : IDisposable
                 if (string.Join(" ", arguments.Skip(argStart).Take(5)).Equals("shell pm list packages -3"))
                 {
                     stdOut = "package:" + string.Join("\npackage:", _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).InstalledApplications);
+                }
+
+                if (string.Join(" ", arguments.Skip(argStart).Take(3)).Equals("shell cat /proc/cpuinfo"))
+                {
+                    stdOut = $"Processor\t: {_fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).CpuModel}{Environment.NewLine}" +
+                        $"cpu MHz\t\t: {_fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).CpuMaxFrequencyKiloHertz!.Value / 1000d:0.###}";
+                }
+
+                if (string.Join(" ", arguments.Skip(argStart).Take(3)).Equals("shell cat /proc/meminfo"))
+                {
+                    stdOut = $"MemTotal:        {_fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).TotalMemoryBytes!.Value / 1024} kB";
+                }
+
+                if (string.Join(" ", arguments.Skip(argStart).Take(3)).Equals("shell cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"))
+                {
+                    stdOut = _fakeDeviceList.Single(d => d.DeviceSerial == s_currentDeviceSerial).CpuMaxFrequencyKiloHertz?.ToString() ?? string.Empty;
                 }
 
                 exitCode = 0;

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -157,6 +157,34 @@ public class InstrumentationRunnerSummaryTests
         Assert.Equal(1, json.GetProperty("version").GetInt32());
     }
 
+    [Fact]
+    public void EmitJsonResultBlock_ContainsEnvironment()
+    {
+        var environment = new ExecutionEnvironmentInfo
+        {
+            Host = new HostEnvironmentInfo
+            {
+                MachineName = "host1",
+                CpuModel = "Test CPU",
+            },
+            Target = new TargetEnvironmentInfo
+            {
+                Kind = "emulator",
+                Identifier = "emulator-5554",
+                OperatingSystem = "Android",
+                ApiLevel = 35,
+            },
+        };
+
+        RunSummaryEmitter.EmitRunSummary(_mockLogger.Object, ExitCode.SUCCESS, "android", null, null, null, 0, new List<DiagnosticsFile>(), environment);
+
+        var json = ExtractJsonFromLogs();
+        var environmentJson = json.GetProperty("environment");
+        Assert.Equal("host1", environmentJson.GetProperty("host").GetProperty("machineName").GetString());
+        Assert.Equal("emulator", environmentJson.GetProperty("target").GetProperty("kind").GetString());
+        Assert.Equal(35, environmentJson.GetProperty("target").GetProperty("apiLevel").GetInt32());
+    }
+
     private JsonElement ExtractJsonFromLogs()
     {
         var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/CopyLogsToMainLogTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/CopyLogsToMainLogTests.cs
@@ -57,6 +57,7 @@ public class CopyLogsToMainLogTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appTesterFactory.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/InstallOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/InstallOrchestratorTests.cs
@@ -26,6 +26,7 @@ public class InstallOrchestratorTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appBundleInformationParser.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustRunOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustRunOrchestratorTests.cs
@@ -42,6 +42,7 @@ public class JustRunOrchestratorTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appRunnerFactory.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _iOSExitCodeDetector.Object,
             _macCatalystExitCodeDetector.Object,
             _logger.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustTestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/JustTestOrchestratorTests.cs
@@ -39,6 +39,7 @@ public class JustTestOrchestratorTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appTesterFactory.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/OrchestratorTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/OrchestratorTestBase.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Utilities;
@@ -33,6 +34,7 @@ public abstract class OrchestratorTestBase
     protected readonly Mock<IFileBackedLog> _mainLog;
     protected readonly Mock<ILogger> _logger;
     protected readonly Mock<IHelpers> _helpers;
+    protected readonly Mock<IMlaunchProcessManager> _processManager;
     protected readonly Mock<IAppInstaller> _appInstaller;
     protected readonly Mock<IAppUninstaller> _appUninstaller;
     protected readonly AppBundleInformation _appBundleInformation;
@@ -48,7 +50,12 @@ public abstract class OrchestratorTestBase
         _errorKnowledgeBase = new();
         _appInstaller = new();
         _appUninstaller = new();
+        _processManager = new();
         _logs = new();
+
+        _processManager
+            .SetupGet(x => x.XcodeVersion)
+            .Returns(new System.Version(14, 0));
 
         _logs.AddFile("system.log", LogType.SystemLog.ToString());
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/RunOrchestratorTests.cs
@@ -51,6 +51,7 @@ public class RunOrchestratorTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appRunnerFactory.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _iOSExitCodeDetector.Object,
             _macCatalystExitCodeDetector.Object,
             _logger.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/SimulatorResetOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/SimulatorResetOrchestratorTests.cs
@@ -23,6 +23,7 @@ public class SimulatorResetOrchestratorTests : OrchestratorTestBase
             _appInstaller.Object,
             _appUninstaller.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
@@ -49,6 +49,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             _appUninstaller.Object,
             _appTesterFactory.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/UninstallOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/UninstallOrchestratorTests.cs
@@ -26,6 +26,7 @@ public class UninstallOrchestratorTests : OrchestratorTestBase
             _appInstaller.Object,
             _appUninstaller.Object,
             _deviceFinder.Object,
+            _processManager.Object,
             _logger.Object,
             _logs,
             _mainLog.Object,

--- a/tests/Microsoft.DotNet.XHarness.Common.Tests/CommandDiagnosticsTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Common.Tests/CommandDiagnosticsTests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.Common.CLI;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Common.Tests;
+
+public class CommandDiagnosticsTests
+{
+    [Fact]
+    public void SaveToJsonFile_IncludesEnvironment()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".json");
+        try
+        {
+            using var loggerFactory = LoggerFactory.Create(_ => { });
+            var diagnostics = new CommandDiagnostics(loggerFactory.CreateLogger("test"), TargetPlatform.Android, "test")
+            {
+                ExitCode = ExitCode.SUCCESS,
+                Environment = new ExecutionEnvironmentInfo
+                {
+                    Host = new HostEnvironmentInfo
+                    {
+                        MachineName = "host1",
+                        OperatingSystem = "TestOS",
+                    },
+                    Target = new TargetEnvironmentInfo
+                    {
+                        Kind = "emulator",
+                        Identifier = "emulator-5554",
+                    },
+                },
+            };
+
+            diagnostics.SaveToJsonFile(tempPath);
+
+            using var document = JsonDocument.Parse(File.ReadAllText(tempPath));
+            var root = document.RootElement[0];
+            var environment = root.GetProperty("environment");
+            Assert.Equal("host1", environment.GetProperty("host").GetProperty("machineName").GetString());
+            Assert.Equal("emulator-5554", environment.GetProperty("target").GetProperty("identifier").GetString());
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
@@ -118,6 +118,13 @@ public class HardwareDeviceLoaderTests
         Assert.Equal(2, _devices.Connected64BitIOS.Count());
         Assert.Single(_devices.Connected32BitIOS);
         Assert.Empty(_devices.ConnectedTV);
+
+        var iPhone = _devices.Connected64BitIOS.Single(device => device.ProductType == "iPhone12,1");
+        Assert.Equal("arm64e", iPhone.CpuArchitecture);
+        Assert.Equal("N104AP", iPhone.HardwareModel);
+        Assert.Equal("MWL72", iPhone.ModelNumber);
+        Assert.Equal(43999293440, iPhone.AmountDataAvailable);
+        Assert.Equal(54814302208, iPhone.TotalDataCapacity);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add structured host and target environment information to XHarness JSON outputs
- populate Android environment details from ADB and Apple details from mlaunch/devicectl when available
- keep the data in structured JSON payloads instead of separate log-only reporting

## Validation
- `./.dotnet/dotnet build XHarness.slnx --nologo -v minimal`
- `./.dotnet/dotnet test tests/Microsoft.DotNet.XHarness.Common.Tests/Microsoft.DotNet.XHarness.Common.Tests.csproj --nologo -v minimal`
- `./.dotnet/dotnet test tests/Microsoft.DotNet.XHarness.Android.Tests/Microsoft.DotNet.XHarness.Android.Tests.csproj --nologo -v minimal`
- `./.dotnet/dotnet test tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests.csproj --nologo -v minimal`
- `./.dotnet/dotnet test tests/Microsoft.DotNet.XHarness.Apple.Tests/Microsoft.DotNet.XHarness.Apple.Tests.csproj --nologo -v minimal`

## Notes
- this is intended to let infra runs capture host-hardware data from the existing structured result objects