### PR TITLE
Bump mlaunch to 1.1.127 to support Xcode 27 simulators

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Selenium.WebDriver" Version="4.0.0-alpha05" />
-    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.1.113" />
+    <PackageVersion Include="Microsoft.Tools.Mlaunch" Version="1.1.127" />
     <PackageVersion Include="NUnit" Version="3.13.0" />
     <PackageVersion Include="NUnit.Engine" Version="3.13.0" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />


### PR DESCRIPTION
Xcode 27 removed the standalone Simulator.app; DeviceHub.app is its replacement as the simulator UI host. XHarness boots and launches apps on simulators via 'mlaunch --launchsimulator' / '--launchsimbundleid', which in older mlaunch opens Simulator.app and waits for the 'com.apple.iphonesimulator.ready' notification before booting the device. On Xcode 27 that app no longer exists, so the device never boots and simulator runs fail before any test executes.

mlaunch 1.1.127 adds DeviceHub support (gated on Xcode >= 27), so it boots simulators through DeviceHub on Xcode 27 while keeping the existing Simulator.app behavior on older Xcode versions.