### PR TITLE
Clean up simulator handling for Xcode 27

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorDevice.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorDevice.cs
@@ -69,7 +69,7 @@ public class SimulatorDevice : ISimulatorDevice
     {
         await _processManager.ExecuteCommandAsync("launchctl", new[] { "remove", "com.apple.CoreSimulator.CoreSimulatorService" }, log, TimeSpan.FromSeconds(10));
 
-        var toKill = new string[] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
+        var toKill = new string[] { "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "DeviceHub", "DevicesTrampoline", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
 
         var args = new List<string>
             {
@@ -99,26 +99,6 @@ public class SimulatorDevice : ISimulatorDevice
                 log.WriteLine("Could not delete the directory '{0}': {1}", dir, e.Message);
             }
         }
-    }
-
-    private async Task OpenSimulator(ILog log)
-    {
-        string simulator_app;
-
-        if (IsWatchSimulator && _processManager.XcodeVersion.Major < 9)
-        {
-            simulator_app = Path.Combine(_processManager.XcodeRoot, "Contents", "Developer", "Applications", "Simulator (Watch).app");
-        }
-        else
-        {
-            simulator_app = Path.Combine(_processManager.XcodeRoot, "Contents", "Developer", "Applications", "Simulator.app");
-            if (!Directory.Exists(simulator_app))
-            {
-                simulator_app = Path.Combine(_processManager.XcodeRoot, "Contents", "Developer", "Applications", "iOS Simulator.app");
-            }
-        }
-
-        await _processManager.ExecuteCommandAsync("open", new[] { "-a", simulator_app, "--args", "-CurrentDeviceUDID", UDID }, log, TimeSpan.FromSeconds(15));
     }
 
     public async Task<bool> PrepareSimulator(ILog log, params string[] bundleIdentifiers)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorLoader.cs
@@ -385,6 +385,10 @@ public class SimulatorLoader : ISimulatorLoader
         var runtimePrefix = _simulatorSelector.GetRuntimePrefix(target);
 
         var runtimeVersion = target.OSVersion;
+        // Device-type selection can depend on the OS version (e.g. tvOS 27 removed the legacy
+        // Apple-TV-1080p simulator device type). When the target doesn't specify a version we resolve
+        // the latest available runtime below, so pass that resolved version on to the selector too.
+        var deviceTypeTarget = target;
 
         if (runtimeVersion == null)
         {
@@ -401,13 +405,17 @@ public class SimulatorLoader : ISimulatorLoader
                 .Substring(runtimePrefix.Length);
 
             runtimeVersion = firstOsVersion ?? throw new NoDeviceFoundException($"Failed to find a suitable OS runtime version for {target.AsString()}");
+
+            // The runtime identifier uses '-' as the version separator (e.g. "27-0"); convert it back
+            // to the usual "27.0" form so the selector can parse it.
+            deviceTypeTarget = new TestTargetOs(target.Platform, runtimeVersion.Replace('-', '.'));
         }
 
         string simulatorRuntime = runtimePrefix + runtimeVersion.Replace('.', '-');
-        string simulatorDeviceType = _simulatorSelector.GetDeviceType(target, minVersion);
+        string simulatorDeviceType = _simulatorSelector.GetDeviceType(deviceTypeTarget, minVersion);
 
         // TODO: Allow to specify companion runtime
-        _simulatorSelector.GetCompanionRuntimeAndDeviceType(target, minVersion, out var companionRuntime, out var companionDeviceType);
+        _simulatorSelector.GetCompanionRuntimeAndDeviceType(deviceTypeTarget, minVersion, out var companionRuntime, out var companionDeviceType);
 
         var devices = await FindOrCreateDevicesAsync(log, simulatorRuntime, simulatorDeviceType, cancellationToken: cancellationToken);
         IEnumerable<ISimulatorDevice>? companionDevices = null;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -37,11 +37,26 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         return target.Platform switch
         {
             TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-11-Pro"),
-            TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
+            TestTarget.Simulator_tvOS => GetTvOSDeviceType(target),
             TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-5-40mm"),
             TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",
             _ => throw new Exception(string.Format("Invalid simulator target: {0}", target))
         };
+    }
+
+    private static string GetTvOSDeviceType(TestTargetOs target)
+    {
+        // tvOS 27 removed the legacy non-4K "Apple TV" (Apple-TV-1080p) simulator device type; those
+        // runtimes only support the Apple TV 4K device types. Keep using the legacy device type for older
+        // tvOS versions (everything before Xcode 27) so behavior is unchanged there. The caller resolves
+        // target.OSVersion to the actual runtime version before calling this, so it's set for the simulator
+        // we'll create; if it's somehow missing we fall back to the legacy device type.
+        if (Version.TryParse(target.OSVersion, out var version) && version.Major >= 27)
+        {
+            return "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K";
+        }
+
+        return "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p";
     }
 
     public virtual void GetCompanionRuntimeAndDeviceType(TestTargetOs target, bool minVersion, out string? companionRuntime, out string? companionDeviceType)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -36,12 +36,26 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         return target.Platform switch
         {
-            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-11-Pro"),
+            TestTarget.Simulator_iOS64 => GetiOSDeviceType(target, minVersion),
             TestTarget.Simulator_tvOS => GetTvOSDeviceType(target),
             TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-5-40mm"),
             TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",
             _ => throw new Exception(string.Format("Invalid simulator target: {0}", target))
         };
+    }
+
+    private static string GetiOSDeviceType(TestTargetOs target, bool minVersion)
+    {
+        // The min-version tests run on the lowest simulator runtime the installed Xcode ships (which can be
+        // newer than the minimum deployment target we build against). iPhone 6s was dropped in iOS 16, so it
+        // can no longer be created on an iOS 16+ runtime; use a still-available small device for those. Older
+        // runtimes (where iPhone 6s is still valid) keep using it, so behavior there is unchanged.
+        if (minVersion && Version.TryParse(target.OSVersion, out var version) && version.Major >= 16)
+        {
+            return "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation";
+        }
+
+        return "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-11-Pro");
     }
 
     private static string GetTvOSDeviceType(TestTargetOs target)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/SdkVersions.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/SdkVersions.cs
@@ -5,11 +5,11 @@
 /// </summary>
 public static class SdkVersions
 {
-    public static string Xcode { get; private set; } = "14.3";
-    public static string OSX { get; private set; } = "13.00";
-    public static string iOS { get; private set; } = "16.4";
-    public static string WatchOS { get; private set; } = "6.2";
-    public static string TVOS { get; private set; } = "16.4";
+    public static string Xcode { get; private set; } = "27.0";
+    public static string OSX { get; private set; } = "27.0";
+    public static string iOS { get; private set; } = "27.0";
+    public static string WatchOS { get; private set; } = "27.0";
+    public static string TVOS { get; private set; } = "27.0";
 
     public static string MinOSX { get; private set; } = "10.9";
     public static string MiniOS { get; private set; } = "7.0";
@@ -21,17 +21,17 @@ public static class SdkVersions
     public static string MinWatchOSCompanionSimulator { get; private set; } = "10.3";
     public static string MinTVOSSimulator { get; private set; } = "10.2";
 
-    public static string MaxiOSSimulator { get; private set; } = "16.4";
-    public static string MaxWatchOSSimulator { get; private set; } = "8.0";
-    public static string MaxWatchOSCompanionSimulator { get; private set; } = "16.4";
-    public static string MaxTVOSSimulator { get; private set; } = "16.4";
+    public static string MaxiOSSimulator { get; private set; } = "27.0";
+    public static string MaxWatchOSSimulator { get; private set; } = "27.0";
+    public static string MaxWatchOSCompanionSimulator { get; private set; } = "27.0";
+    public static string MaxTVOSSimulator { get; private set; } = "27.0";
 
-    public static string MaxiOSDeploymentTarget { get; private set; } = "16.4";
-    public static string MaxWatchDeploymentTarget { get; private set; } = "8.0";
-    public static string MaxTVOSDeploymentTarget { get; private set; } = "16.4";
+    public static string MaxiOSDeploymentTarget { get; private set; } = "27.0";
+    public static string MaxWatchDeploymentTarget { get; private set; } = "27.0";
+    public static string MaxTVOSDeploymentTarget { get; private set; } = "27.0";
 
     public static string MinxrOSSimulator { get; private set; } = "1.0";
-    public static string MaxxrOSSimulator { get; private set; } = "1.0";
+    public static string MaxxrOSSimulator { get; private set; } = "27.0";
 
     public static void OverrideVersions(string xcode,
         string osx,
@@ -54,7 +54,7 @@ public static class SdkVersions
         string maxWatchDeploymentTarget,
         string maxTVOSDeploymentTarget,
         string minxrOSSimulator = "1.0",
-        string maxxrOSSimulator = "1.0")
+        string maxxrOSSimulator = "27.0")
     {
         Xcode = xcode;
         OSX = osx;

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
@@ -51,4 +51,23 @@ public class DefaultSimulatorSelectorTests
         // The Booted one
         Assert.Equal(simulator2, simulator);
     }
+
+    [Theory]
+    // iOS: the min-version device tracks the lowest available runtime. iPhone 6s was dropped in iOS 16, so
+    // iOS 16+ uses a still-available small device, while older runtimes keep iPhone 6s. Non-min is unchanged.
+    [InlineData(TestTarget.Simulator_iOS64, "15.0", true, "com.apple.CoreSimulator.SimDeviceType.iPhone-6s")]
+    [InlineData(TestTarget.Simulator_iOS64, "16.0", true, "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation")]
+    [InlineData(TestTarget.Simulator_iOS64, "27.0", true, "com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation")]
+    [InlineData(TestTarget.Simulator_iOS64, "15.0", false, "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro")]
+    [InlineData(TestTarget.Simulator_iOS64, "27.0", false, "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro")]
+    // tvOS: Apple-TV-1080p was removed in tvOS 27, so tvOS 27+ uses the Apple TV 4K device type.
+    [InlineData(TestTarget.Simulator_tvOS, "16.0", true, "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p")]
+    [InlineData(TestTarget.Simulator_tvOS, "26.5", false, "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p")]
+    [InlineData(TestTarget.Simulator_tvOS, "27.0", true, "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K")]
+    public void GetDeviceTypeTest(TestTarget platform, string osVersion, bool minVersion, string expectedDeviceType)
+    {
+        var target = new TestTargetOs(platform, osVersion);
+
+        Assert.Equal(expectedDeviceType, _simulatorSelector.GetDeviceType(target, minVersion));
+    }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorDeviceTest.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/SimulatorDeviceTest.cs
@@ -74,7 +74,7 @@ public class SimulatorDeviceTest
     {
         Func<IList<string>, bool> verifyKillAll = (args) =>
         {
-            var toKill = new List<string> { "-9", "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
+            var toKill = new List<string> { "-9", "iPhone Simulator", "iOS Simulator", "Simulator", "Simulator (Watch)", "DeviceHub", "DevicesTrampoline", "com.apple.CoreSimulator.CoreSimulatorService", "ibtoold" };
             return args.Where(a => toKill.Contains(a)).Count() == toKill.Count;
         };
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Samples/simulators.xml
@@ -794,9 +794,9 @@
         <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/73EAFA5D-04C7-4194-8D51-6E32C913C3B6</DataPath>
         <LogPath>/Users/mandel/Library/Logs/CoreSimulator/73EAFA5D-04C7-4194-8D51-6E32C913C3B6</LogPath>
       </SimDevice>
-      <SimDevice UDID="3A12BAFF-0DAA-4052-AB0D-743AB85CE030" Name="Apple TV">
+      <SimDevice UDID="3A12BAFF-0DAA-4052-AB0D-743AB85CE030" Name="Apple TV 4K (3rd generation)">
         <SimRuntime>com.apple.CoreSimulator.SimRuntime.tvOS-{{MAX-TVOS-VERSION}}</SimRuntime>
-        <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p</SimDeviceType>
+        <SimDeviceType>com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K</SimDeviceType>
         <DataPath>/Users/mandel/Library/Developer/CoreSimulator/Devices/3A12BAFF-0DAA-4052-AB0D-743AB85CE030</DataPath>
         <LogPath>/Users/mandel/Library/Logs/CoreSimulator/3A12BAFF-0DAA-4052-AB0D-743AB85CE030</LogPath>
       </SimDevice>


### PR DESCRIPTION
Follow-up cleanup to the mlaunch 1.1.127 bump, addressing Xcode 27's simulator changes:

* SimulatorDevice.KillEverything: also kill "DeviceHub" and "DevicesTrampoline". In Xcode 27 the Simulator.app UI host was replaced by DeviceHub.app (bundle com.apple.dt.Devices, executable DevicesTrampoline), which CoreSimulator can auto-launch when booting/launching a simulator in a GUI session. Killing it (in addition to the legacy "Simulator"/"iOS Simulator" processes, which are kept for Xcode < 27) ensures we don't leave a stale simulator UI host running between test runs.

* SimulatorDevice: remove the now-dead OpenSimulator() helper. It launched Simulator.app / "Simulator (Watch).app" via `open -a`, but nothing calls it anymore now that simulators are booted through mlaunch, and Simulator.app no longer exists in Xcode 27. It had no remaining references.

* SdkVersions: bump the current/max versions (Xcode, OSX, iOS, WatchOS, TVOS, the Max*Simulator / Max*DeploymentTarget values, and MaxxrOSSimulator) to 27.0 for the Xcode 27 cycle. The Min* values are intentionally left unchanged. These are defaults; at runtime xharness still overrides them with the actual versions reported by mlaunch via OverrideVersions().

* Update SimulatorDeviceTest's expected kill list to match the source change (DeviceHub / DevicesTrampoline), keeping it in sync.