### PR TITLE
Report wall-clock device log diagnostic as warning

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
@@ -19,6 +19,8 @@ public interface IDeviceLogCapturer : IDisposable
 
 public class DeviceLogCapturer : IDeviceLogCapturer
 {
+    internal const string WallClockAdjustmentWarning = "Wall Clock adjustment detected - results might be strange while using --end";
+
     private readonly ILog _mainLog;
     private readonly ILog _deviceLog;
     private readonly string _deviceUdid;
@@ -152,12 +154,58 @@ public class DeviceLogCapturer : IDeviceLogCapturer
 
             if (errors.Length > 0)
             {
-                _mainLog.WriteLine($"Errors while reading device logs: {errors}");
+                LogReadDiagnostics(_mainLog, errors.ToString());
             }
         }
 
         CleanupOutputPath();
     }
+
+    internal static void LogReadDiagnostics(ILog mainLog, string errors)
+    {
+        string diagnostics = errors.TrimEnd();
+        if (HasOnlyKnownWarningDiagnostics(diagnostics))
+        {
+            mainLog.WriteLine($"Warnings while reading device logs: {diagnostics}");
+        }
+        else
+        {
+            mainLog.WriteLine($"Errors while reading device logs: {diagnostics}");
+        }
+    }
+
+    internal static bool HasOnlyKnownWarningDiagnostics(string errors)
+    {
+        if (string.IsNullOrWhiteSpace(errors))
+        {
+            return false;
+        }
+
+        using StringReader reader = new StringReader(errors);
+        bool sawWarning = false;
+        string? line;
+
+        while ((line = reader.ReadLine()) is not null)
+        {
+            line = line.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            if (!IsKnownWarningDiagnostic(line))
+            {
+                return false;
+            }
+
+            sawWarning = true;
+        }
+
+        return sawWarning;
+    }
+
+    internal static bool IsKnownWarningDiagnostic(string diagnostic)
+        => string.Equals(diagnostic, WallClockAdjustmentWarning, StringComparison.Ordinal);
 
     private void CleanupOutputPath()
     {
@@ -169,4 +217,3 @@ public class DeviceLogCapturer : IDeviceLogCapturer
 
     public void Dispose() => StopCapture();
 }
-

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Logging/DeviceLogCapturer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -20,6 +21,10 @@ public interface IDeviceLogCapturer : IDisposable
 public class DeviceLogCapturer : IDeviceLogCapturer
 {
     internal const string WallClockAdjustmentWarning = "Wall Clock adjustment detected - results might be strange while using --end";
+    private static readonly HashSet<string> KnownWarningDiagnostics = new(StringComparer.Ordinal)
+    {
+        WallClockAdjustmentWarning,
+    };
 
     private readonly ILog _mainLog;
     private readonly ILog _deviceLog;
@@ -205,7 +210,7 @@ public class DeviceLogCapturer : IDeviceLogCapturer
     }
 
     internal static bool IsKnownWarningDiagnostic(string diagnostic)
-        => string.Equals(diagnostic, WallClockAdjustmentWarning, StringComparison.Ordinal);
+        => KnownWarningDiagnostics.Contains(diagnostic);
 
     private void CleanupOutputPath()
     {

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.DotNet.XHarness.iOS.Shared.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/DeviceLogCapturerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/DeviceLogCapturerTests.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests;
+
+public class DeviceLogCapturerTests
+{
+    [Fact]
+    public void HasOnlyKnownWarningDiagnosticsReturnsTrueForKnownWarning()
+    {
+        string errors = $"{DeviceLogCapturer.WallClockAdjustmentWarning}\n";
+
+        Assert.True(DeviceLogCapturer.HasOnlyKnownWarningDiagnostics(errors));
+    }
+
+    [Fact]
+    public void HasOnlyKnownWarningDiagnosticsReturnsFalseWhenOtherErrorsArePresent()
+    {
+        string errors = $"{DeviceLogCapturer.WallClockAdjustmentWarning}\nPermission denied\n";
+
+        Assert.False(DeviceLogCapturer.HasOnlyKnownWarningDiagnostics(errors));
+    }
+
+    [Fact]
+    public void HasOnlyKnownWarningDiagnosticsReturnsFalseWhenWarningLineContainsOtherText()
+    {
+        string errors = $"warning: {DeviceLogCapturer.WallClockAdjustmentWarning}\n";
+
+        Assert.False(DeviceLogCapturer.HasOnlyKnownWarningDiagnostics(errors));
+    }
+
+    [Fact]
+    public void IsKnownWarningDiagnosticReturnsTrueForWallClockWarning()
+    {
+        Assert.True(DeviceLogCapturer.IsKnownWarningDiagnostic(DeviceLogCapturer.WallClockAdjustmentWarning));
+    }
+
+    [Fact]
+    public void LogReadDiagnosticsReportsWallClockAdjustmentAsWarning()
+    {
+        Mock<ILog> log = new Mock<ILog>();
+        string errors = $"{DeviceLogCapturer.WallClockAdjustmentWarning}\n";
+
+        DeviceLogCapturer.LogReadDiagnostics(log.Object, errors);
+
+        log.Verify(l => l.WriteLine($"Warnings while reading device logs: {DeviceLogCapturer.WallClockAdjustmentWarning}"), Times.Once);
+        log.Verify(l => l.WriteLine(It.Is<string>(s => s.StartsWith("Errors while reading device logs:", System.StringComparison.Ordinal))), Times.Never);
+    }
+
+    [Fact]
+    public void LogReadDiagnosticsPreservesErrorsWhenStderrContainsOtherMessages()
+    {
+        Mock<ILog> log = new Mock<ILog>();
+        string errors = $"{DeviceLogCapturer.WallClockAdjustmentWarning}\nPermission denied\n";
+
+        DeviceLogCapturer.LogReadDiagnostics(log.Object, errors);
+
+        log.Verify(l => l.WriteLine($"Errors while reading device logs: {DeviceLogCapturer.WallClockAdjustmentWarning}\nPermission denied"), Times.Once);
+        log.Verify(l => l.WriteLine(It.Is<string>(s => s.StartsWith("Warnings while reading device logs:", System.StringComparison.Ordinal))), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

This updates Apple device log capture so the known `Wall Clock adjustment detected - results might be strange while using --end` diagnostic is reported as a warning when it is the only stderr output from log reading.

The main reason for the change is that this message is non-fatal, but the current `Errors while reading device logs:` wording makes it easy for people and tooling consuming the logs to treat it as the failure reason.

The change keeps the existing error path for any other stderr content and adds tests to cover:

- warning-only stderr
- mixed warning + error stderr
- warning text embedded in another line, which must still remain an error

## Testing

- `dotnet test tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests.csproj`

> [!NOTE]
> This PR description was created by GitHub Copilot.
