### PR TITLE
Improve Android emulator recovery in Helix tests

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Android/AdbRunner.cs
@@ -444,14 +444,13 @@ public class AdbRunner
             _log.LogWarning($"Error restarting ADB server during recovery: {e.Message}");
         }
 
-        // Step 3: Re-check for devices after ADB reset - if a device reappeared, we are done
+        // Step 3: Re-check for devices after ADB reset - if an online device reappeared, we are done
         var recheckResult = RunAdbCommand(new[] { "devices", "-l" }, TimeSpan.FromSeconds(30));
         _log.LogInformation($"Devices after ADB server reset:{Environment.NewLine}{recheckResult.StandardOutput}");
 
-        var recheckLines = recheckResult.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-        if (recheckLines.Length >= 2)
+        if (HasOnlineDevice(recheckResult.StandardOutput))
         {
-            _log.LogInformation("Device(s) reappeared after ADB server reset; skipping emulator service restart");
+            _log.LogInformation("Online device(s) reappeared after ADB server reset; skipping emulator service restart");
             return true;
         }
 
@@ -488,7 +487,14 @@ public class AdbRunner
             {
                 var emuResult = RunAdbCommand(new[] { "emu", "restart" }, TimeSpan.FromSeconds(30));
                 _log.LogDebug($"adb emu restart output: {emuResult.StandardOutput}");
-                restartAttempted = true;
+                if (emuResult.Succeeded)
+                {
+                    restartAttempted = true;
+                }
+                else
+                {
+                    _log.LogWarning($"adb emu restart failed (exit code {emuResult.ExitCode}):{Environment.NewLine}{emuResult.StandardError}");
+                }
             }
             catch (Exception e)
             {
@@ -502,14 +508,13 @@ public class AdbRunner
             return false;
         }
 
-        // Step 5: Wait for a device to reappear
-        _log.LogInformation("Waiting for emulator to reappear after recovery (max 5 minutes)...");
+        // Step 5: Wait for an online device to reappear
+        _log.LogInformation("Waiting for emulator to come online after recovery (max 5 minutes)...");
         bool deviceAppeared = Retry(
             () =>
             {
                 var r = RunAdbCommand(new[] { "devices", "-l" }, TimeSpan.FromSeconds(30));
-                var lines = r.StandardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-                return lines.Length >= 2;
+                return HasOnlineDevice(r.StandardOutput);
             },
             retryInterval: TimeSpan.FromSeconds(10),
             retryPeriod: TimeSpan.FromMinutes(5));
@@ -543,6 +548,20 @@ public class AdbRunner
             _log.LogWarning("Emulator appeared but did not complete boot within the timeout after recovery");
             return false;
         }
+    }
+
+    private static bool HasOnlineDevice(string adbDevicesOutput)
+    {
+        foreach (string line in adbDevicesOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string[] parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length >= 2 && parts[1].Equals("device", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidDeviceCommand.cs
+++ b/src/Microsoft.DotNet.XHarness.CLI/Commands/Android/AndroidDeviceCommand.cs
@@ -60,11 +60,22 @@ Arguments:
 
         // enumerate the devices attached and their architectures
         // Tell ADB to only use that one (will always use the present one for systems w/ only 1 machine)
-        var device = runner.GetDevice(
+        AndroidDevice? FindDevice() => runner.GetDevice(
             loadApiVersion: true,
             loadArchitecture: true,
             requiredApiVersion: Arguments.ApiVersion.Value,
             requiredArchitectures: apkRequiredArchitecture);
+
+        var device = FindDevice();
+
+        if (device is null)
+        {
+            logger.LogWarning("No compatible device found on first attempt; trying emulator recovery...");
+            if (runner.TryRecoverEmulator())
+            {
+                device = FindDevice();
+            }
+        }
 
         if (device is null)
         {

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/AdbRunnerTests.cs
@@ -25,6 +25,7 @@ public class AdbRunnerTests : IDisposable
     private static int s_bootCompleteCheckTimes = 0;
     private static int s_devicesCallCount = 0;
     private static int s_devicesReturnEmptyForNFirstCalls = 0;
+    private static int s_devicesReturnOfflineForNFirstCalls = 0;
     private readonly Mock<ILogger> _mainLog;
     private readonly Mock<IAdbProcessManager> _processManager;
     private readonly List<AndroidDevice> _fakeDeviceList;
@@ -41,6 +42,7 @@ public class AdbRunnerTests : IDisposable
         // Reset call counters for each test
         s_devicesCallCount = 0;
         s_devicesReturnEmptyForNFirstCalls = 0;
+        s_devicesReturnOfflineForNFirstCalls = 0;
 
         // Fake ADB executable since its path is checked 
         Directory.CreateDirectory(s_scratchAndOutputPath);
@@ -324,6 +326,21 @@ public class AdbRunnerTests : IDisposable
         VerifyAdbCall(Times.Once(), "start-server");
     }
 
+    [Fact]
+    public void TryRecoverEmulator_WhenDeviceStaysOfflineAfterAdbReset_RestartsEmulator()
+    {
+        // The device is listed throughout recovery, but it only becomes usable after the emulator restart.
+        s_devicesReturnOfflineForNFirstCalls = 2;
+        s_bootCompleteCheckTimes = 1;
+
+        var runner = new AdbRunner(_mainLog.Object, _processManager.Object, s_adbPath);
+        bool result = runner.TryRecoverEmulator();
+
+        Assert.True(result);
+        VerifyAdbCall(Times.AtLeast(3), "devices", "-l");
+        VerifyAdbCall(Times.Once(), "emu", "restart");
+    }
+
     #endregion
 
     #region Helper Functions
@@ -413,7 +430,9 @@ public class AdbRunnerTests : IDisposable
                     int transportId = 1;
                     foreach (var device in _fakeDeviceList)
                     {
-                        string state = device == _fakeDeviceList.Last() ? "offline" : "online";
+                        string state = s_devicesCallCount <= s_devicesReturnOfflineForNFirstCalls || device == _fakeDeviceList.Last()
+                            ? "offline"
+                            : "device";
                         s.AppendLine($"{device.DeviceSerial}          {state} transportid:{transportId++}");
                     }
                 }

--- a/tests/integration-tests/Android/Commands.Tests.proj
+++ b/tests/integration-tests/Android/Commands.Tests.proj
@@ -23,7 +23,7 @@
       <XHarnessApkToTest Include="$(TestAppDestinationDir)\$(TestPackageName)-x86.apk">
         <AndroidPackageName>net.dot.$(TestPackageName)</AndroidPackageName>
         <AndroidInstrumentationName>net.dot.MonoRunner</AndroidInstrumentationName>
-        <WorkItemTimeout>00:12:00</WorkItemTimeout>
+        <WorkItemTimeout>00:30:00</WorkItemTimeout>
         <CustomCommands>
         <![CDATA[
           set -ex;


### PR DESCRIPTION
## Summary

- Continue emulator recovery when `adb devices` still reports the emulator as `offline`
- Apply emulator recovery to the `xharness android device` command
- Give the Android Manual Commands work item the same 30-minute timeout used by runtime Android work items
- Add regression coverage for an emulator that remains offline after the ADB server reset

## Rationale

The Manual Commands work item could spend most of its 12-minute timeout polling an offline emulator. Helix then terminated the work item with exit code 143 before XHarness could complete recovery or return `DEVICE_NOT_FOUND`, preventing Arcade's diagnostics processor from requesting its normal retry and machine reboot.

The updated recovery path only considers an ADB `device` state successful. An emulator that remains `offline` now proceeds to the emulator restart step, and the longer timeout allows XHarness to finish recovery or return a classifiable exit code.

Fixes #1623

## Testing

- `Build.cmd -configuration Debug -test -projects tests\Microsoft.DotNet.XHarness.Android.Tests\Microsoft.DotNet.XHarness.Android.Tests.csproj`
- `Build.cmd -configuration Debug -projects src\Microsoft.DotNet.XHarness.CLI\Microsoft.DotNet.XHarness.CLI.csproj`
- Validated the Manual Commands shell script with `bash -n`
