### PR TITLE
[release/10.0] Bump .NET SDK 10.0.109 -> 10.0.110 (CG DOTNET-Security-10.0)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.109"
+    "dotnet": "10.0.110"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26367.6",


### PR DESCRIPTION
Bumps the .NET SDK used to build `release/10.0` from **10.0.109** to **10.0.110** to resolve Component Governance alert **DOTNET-Security-10.0** (AzDO work item [11658](https://dnceng.visualstudio.com/internal/_workitems/edit/11658)).

- 10.0.109 shipped in the 10.0.9 servicing release and has a security advisory flagged by CG.
- **10.0.110** is the 10.0.1xx feature-band SDK from the latest security release **10.0.10** (2026-07-14) — same feature band, drop-in patch.

Only `global.json` `tools.dotnet` changes.
