### PR TITLE
[release/10.0] Isolate Apple test temp directories

### DIFF
--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
@@ -25,8 +25,8 @@ public abstract class AppRunTestBase : IDisposable
     protected const string SimulatorDeviceName = "Test iPhone simulator";
     protected const string DeviceName = "Test iPhone";
 
-    protected static readonly string s_outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-    protected static readonly string s_appPath = Path.Combine(s_outputPath, AppName);
+    protected readonly string _outputPath;
+    protected readonly string _appPath;
 
     protected static readonly IHardwareDevice s_mockDevice = Mock.Of<IHardwareDevice>(x =>
         x.BuildVersion == "17A577" &&
@@ -39,14 +39,7 @@ public abstract class AppRunTestBase : IDisposable
         x.ProductType == "iPhone12,1" &&
         x.ProductVersion == "13.0");
 
-    protected readonly AppBundleInformation _appBundleInfo =
-        new(appName: AppName,
-            bundleIdentifier: AppBundleIdentifier,
-            appPath: s_appPath,
-            launchAppPath: s_appPath,
-            supports32b: false,
-            extension: null,
-            bundleExecutable: BundleExecutable);
+    protected readonly AppBundleInformation _appBundleInfo;
 
     protected readonly string _simulatorLogPath = Path.Combine(Path.GetTempPath(), "simulator-logs");
 
@@ -63,6 +56,17 @@ public abstract class AppRunTestBase : IDisposable
 
     protected AppRunTestBase()
     {
+        _outputPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _appPath = Path.Combine(_outputPath, AppName);
+        _appBundleInfo = new AppBundleInformation(
+            appName: AppName,
+            bundleIdentifier: AppBundleIdentifier,
+            appPath: _appPath,
+            launchAppPath: _appPath,
+            supports32b: false,
+            extension: null,
+            bundleExecutable: BundleExecutable);
+
         _mainLog = new Mock<IFileBackedLog>();
 
         _processManager = new Mock<IMlaunchProcessManager>();
@@ -76,7 +80,7 @@ public abstract class AppRunTestBase : IDisposable
         _logs = new Mock<ILogs>();
         _logs
             .SetupGet(x => x.Directory)
-            .Returns(Path.Combine(s_outputPath, "logs"));
+            .Returns(Path.Combine(_outputPath, "logs"));
         _logs
             .Setup(x => x.CreateFile($"{AppBundleIdentifier}-mocked_timestamp.log", It.IsAny<LogType>()))
             .Returns($"./{AppBundleIdentifier}-mocked_timestamp.log");
@@ -111,22 +115,16 @@ public abstract class AppRunTestBase : IDisposable
             .Setup(x => x.GetLocalIpAddresses())
             .Returns(new[] { IPAddress.Loopback, IPAddress.IPv6Loopback });
 
-        Directory.CreateDirectory(s_outputPath);
+        Directory.CreateDirectory(_outputPath);
     }
 
     public void Dispose()
     {
-        try
+        if (Directory.Exists(_outputPath))
         {
-            Directory.Delete(s_outputPath, true);
+            Directory.Delete(_outputPath, true);
         }
-        catch
-        {
-            // Concurrency can cause these
-        }
-        finally
-        {
-            GC.SuppressFinalize(this);
-        }
+
+        GC.SuppressFinalize(this);
     }
 }

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBaseTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBaseTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Apple.Tests.AppOperations;
+
+public class AppRunTestBaseTests
+{
+    [Fact]
+    public void InstancesHaveIsolatedOutputDirectories()
+    {
+        using var second = new TestAppRun();
+        string firstOutputPath;
+
+        using (var first = new TestAppRun())
+        {
+            firstOutputPath = first.OutputPath;
+            Assert.NotEqual(first.OutputPath, second.OutputPath);
+            Assert.True(Directory.Exists(first.OutputPath));
+            Assert.True(Directory.Exists(second.OutputPath));
+        }
+
+        Assert.False(Directory.Exists(firstOutputPath));
+        Assert.True(Directory.Exists(second.OutputPath));
+    }
+
+    private sealed class TestAppRun : AppRunTestBase
+    {
+        public string OutputPath => _outputPath;
+    }
+}

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -314,7 +314,7 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args[0] == "-n" && args[1] == "-W" && args[2] == s_appPath),
+                   It.Is<IList<string>>(args => args[0] == "-n" && args[1] == "-W" && args[2] == _appPath),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
@@ -665,7 +665,7 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args.Count == 2 && args[0] == "-n" && args[1] == s_appPath),
+                   It.Is<IList<string>>(args => args.Count == 2 && args[0] == "-n" && args[1] == _appPath),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -63,8 +63,6 @@ public class AppTesterTests : AppRunTestBase
         var factory3 = new Mock<ITestReporterFactory>();
         factory3.SetReturnsDefault(_testReporter.Object);
         _testReporterFactory = factory3.Object;
-
-        Directory.CreateDirectory(s_outputPath);
     }
 
     [Theory]
@@ -468,7 +466,7 @@ public class AppTesterTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args.Contains(s_appPath) && args.Contains("--foo=bar") && args.Contains("--foo=bar")),
+                   It.Is<IList<string>>(args => args.Contains(_appPath) && args.Contains("--foo=bar") && args.Contains("--foo=bar")),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -466,7 +466,7 @@ public class AppTesterTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    "open",
-                   It.Is<IList<string>>(args => args.Contains(_appPath) && args.Contains("--foo=bar") && args.Contains("--foo=bar")),
+                   It.Is<IList<string>>(args => args.Contains(_appPath) && args.Contains("--foo=bar") && args.Contains("--xyz")),
                    _mainLog.Object,
                    It.IsAny<ILog>(),
                    It.IsAny<ILog>(),


### PR DESCRIPTION
## Summary

Backport of https://github.com/dotnet/xharness/pull/1656 to `release/10.0`.

- Cherry-picks the two reviewed source commits in their original order.
- Isolates Apple test temporary directories and verifies all Mac Catalyst app arguments.
- Applied cleanly; no conflict adaptations were required for the release branch.

## Validation

- `dotnet test tests\Microsoft.DotNet.XHarness.Apple.Tests\Microsoft.DotNet.XHarness.Apple.Tests.csproj --filter "FullyQualifiedName~Microsoft.DotNet.XHarness.Apple.Tests.AppOperations.AppRunTestBaseTests|FullyQualifiedName~Microsoft.DotNet.XHarness.Apple.Tests.AppOperations.AppRunnerTests|FullyQualifiedName~Microsoft.DotNet.XHarness.Apple.Tests.AppOperations.AppTesterTests" --nologo` (19 passed)
