### PR TITLE
Add repository co-owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @vitek-karas @davidnguyen-tech


### PR DESCRIPTION
## Summary

- add a repository-wide CODEOWNERS rule
- designate @vitek-karas and @davidnguyen-tech as co-owners

## Validation

- GitHub CODEOWNERS validation reports no errors against dotnet/xharness
