### PR TITLE
[release/9.0] Use macOS 26 ARM64 simulator queue

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -178,9 +178,12 @@ public abstract class AppRunnerBase
 
         _mainLog.WriteLine("Launching the app");
 
+        // Capture mlaunch stdout so the app's reported exit code can be detected.
+        var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+
         if (waitForExit)
         {
-            var result = await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
+            var result = await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, appOutputLog, appOutputLog, timeout, cancellationToken: cancellationToken);
             simulatorScanToken?.Cancel();
             return result;
         }
@@ -194,7 +197,7 @@ public abstract class AppRunnerBase
 
         _mainLog.WriteLine("Waiting for the app to launch..");
 
-        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, Log.CreateAggregatedLog(_mainLog, scanLog), timeout, cancellationToken: cancellationToken);
+        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, Log.CreateAggregatedLog(_mainLog, scanLog), appOutputLog, appOutputLog, timeout, cancellationToken: cancellationToken);
         await Task.WhenAny(runTask, appLaunched.Task);
 
         if (!appLaunched.Task.IsCompleted)

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -36,7 +36,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
     {
         return target.Platform switch
         {
-            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-XS"),
+            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-11-Pro"),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
             TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm"),
             TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -69,6 +69,8 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
@@ -431,11 +433,13 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
                    It.IsAny<CancellationToken>()))
-            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            .Callback((MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
             {
                 appLog = log;
                 appLaunchedTask.SetResult();
@@ -484,6 +488,8 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
@@ -534,11 +540,13 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
                    It.IsAny<CancellationToken>()))
-            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            .Callback((MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
             {
                 appLaunchedTask.SetResult();
             })
@@ -588,6 +596,8 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -129,6 +129,8 @@ public class AppTesterTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    _mainLog.Object,
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
@@ -51,4 +51,14 @@ public class DefaultSimulatorSelectorTests
         // The Booted one
         Assert.Equal(simulator2, simulator);
     }
+
+    [Theory]
+    [InlineData(true, "com.apple.CoreSimulator.SimDeviceType.iPhone-6s")]
+    [InlineData(false, "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro")]
+    public void GetDeviceTypeForIosSimulator(bool minVersion, string expectedDeviceType)
+    {
+        var deviceType = _simulatorSelector.GetDeviceType(new TestTargetOs(TestTarget.Simulator_iOS64, null), minVersion);
+
+        Assert.Equal(expectedDeviceType, deviceType);
+    }
 }

--- a/tests/integration-tests/Apple/Device.iOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.iOS.Tests.proj
@@ -5,12 +5,12 @@
 
     <!-- apple test / ios-device -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-device;TestAppBundleName=System.Buffers.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-device;TestArch=arm64;TestAppBundleName=System.Buffers.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-device -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-device;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-device;TestArch=arm64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Device.tvOS.Tests.proj
+++ b/tests/integration-tests/Apple/Device.tvOS.Tests.proj
@@ -5,12 +5,12 @@
 
     <!-- apple test / tvos-device -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-device;TestAppBundleName=System.Buffers.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-device;TestArch=arm64;TestAppBundleName=System.Buffers.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / tvos-device -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-device;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-device;TestArch=arm64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -5,7 +5,7 @@
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=x64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=x64;TestAppBundleName=System.Numerics.Vectors.Tests.app;IncludesTestRunner=false;ExpectedExitCode=0</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-simlator-64 -->
@@ -25,7 +25,7 @@
 
     <!-- apple test / tvos-simulator -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=x64;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=x64;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app;IncludesTestRunner=false;ExpectedExitCode=0</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Scouting.Tests.proj
@@ -5,27 +5,27 @@
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=x64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-simlator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=x64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=x64;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=x64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / tvos-simulator -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-simulator;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=x64;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.15.amd64.open"/>
-    <HelixTargetQueue Include="osx.14.arm64.open"/>
+    <HelixTargetQueue Include="osx.26.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,32 +1,44 @@
 <Project Sdk="Microsoft.DotNet.Helix.Sdk">
 
+  <PropertyGroup>
+    <IsArm64Queue>$(HelixTargetQueue.Contains('arm64'))</IsArm64Queue>
+    <IsAmd64Queue>$(HelixTargetQueue.Contains('amd64'))</IsAmd64Queue>
+    <TestArch Condition="'$(IsArm64Queue)' == 'true'">arm64</TestArch>
+    <TestArch Condition="'$(IsAmd64Queue)' == 'true'">x64</TestArch>
+  </PropertyGroup>
+
+  <Target Name="ValidateArchitecture" BeforeTargets="Build">
+    <Error Condition="'$(HelixTargetQueue)' != '' and '$(IsArm64Queue)' != 'true' and '$(IsAmd64Queue)' != 'true'"
+           Text="Unable to detect architecture from HelixTargetQueue '$(HelixTargetQueue)'. Queue name must contain 'arm64' or 'amd64'." />
+  </Target>
+
   <ItemGroup>
     <HelixTargetQueue Include="osx.15.amd64.open"/>
     <HelixTargetQueue Include="osx.26.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-simlator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=$(TestArch);TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=$(TestArch);TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / tvos-simulator -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-simulator;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=$(TestArch);TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -18,7 +18,7 @@
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=System.Numerics.Vectors.Tests.app;IncludesTestRunner=false;ExpectedExitCode=0</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-simlator-64 -->
@@ -38,7 +38,7 @@
 
     <!-- apple test / tvos-simulator -->
     <XHarnessAppleProject Include="TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=$(TestArch);TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=$(TestArch);TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app;IncludesTestRunner=false;ExpectedExitCode=0</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/TestAppBundle.proj
+++ b/tests/integration-tests/Apple/TestAppBundle.proj
@@ -13,9 +13,9 @@
   <Import Project="../Storage.props"/>
 
   <PropertyGroup>
-    <AppStorageUrl>$(AssetsBaseUri)/ios/test-app/$(TestTarget)</AppStorageUrl>
+    <AppStorageUrl>$(AssetsBaseUri)/ios/test-app-new/$(TestTarget)/$(TestArch)</AppStorageUrl>
     <XHarnessTestAppBundleUrl>$(AppStorageUrl)/$(TestAppBundleName).zip</XHarnessTestAppBundleUrl>
-    <TestAppDestinationDir>$(ArtifactsTmpDir)test-app\$(TestTarget)</TestAppDestinationDir>
+    <TestAppDestinationDir>$(ArtifactsTmpDir)test-app-new\$(TestTarget)\$(TestArch)</TestAppDestinationDir>
   </PropertyGroup>
 
   <Target Name="Build" Returns="@(XHarnessAppFoldersToTest)">


### PR DESCRIPTION
Updates the Apple ARM64 simulator integration tests to use the `osx.26.arm64.open` Helix queue with compatible simulator selection and architecture-specific test app assets.

Also captures mlaunch output so refreshed test apps can report their expected exit code.