### PR TITLE
[release/8.0] Update Apple ARM64 simulator Helix queue

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -178,9 +178,12 @@ public abstract class AppRunnerBase
 
         _mainLog.WriteLine("Launching the app");
 
+        // Capture mlaunch output because simctl writes the app exit code to stdout.
+        var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+
         if (waitForExit)
         {
-            var result = await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, timeout, cancellationToken: cancellationToken);
+            var result = await _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, appOutputLog, appOutputLog, timeout, cancellationToken: cancellationToken);
             simulatorScanToken?.Cancel();
             return result;
         }
@@ -194,7 +197,8 @@ public abstract class AppRunnerBase
 
         _mainLog.WriteLine("Waiting for the app to launch..");
 
-        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, Log.CreateAggregatedLog(_mainLog, scanLog), timeout, cancellationToken: cancellationToken);
+        var launchOutputLog = Log.CreateAggregatedLog(appOutputLog, scanLog);
+        var runTask = _processManager.ExecuteCommandAsync(mlaunchArguments, _mainLog, launchOutputLog, launchOutputLog, timeout, cancellationToken: cancellationToken);
         await Task.WhenAny(runTask, appLaunched.Task);
 
         if (!appLaunched.Task.IsCompleted)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -203,27 +203,47 @@ public class AppTester : AppRunnerBase, IAppTester
                 timeout,
                 null,
                 (level, message) => _mainLog.WriteLine(message));
+            IResultFileHandler resultFileHandler = new ResultFileHandler(_processManager, _mainLog);
+            bool usesSimulatorResultFile = isSimulator &&
+                deviceListener.TestLog != null &&
+                resultFileHandler.IsSimulatorVersionSupported(device.OSVersion);
 
-            deviceListener.ConnectedTask
-                .TimeoutAfter(testLaunchTimeout)
-                .ContinueWith(async (Task<bool> task) =>
+            // iOS 18+ simulator apps write results to their data container instead of connecting over TCP.
+            if (usesSimulatorResultFile)
+            {
+                if (!await resultFileHandler.ClearSimulatorResultsAsync(
+                    runMode,
+                    device.OSVersion,
+                    device.UDID,
+                    appInformation.BundleIdentifier,
+                    cancellationToken))
                 {
-                    testReporter.LaunchCallback(task);
+                    throw new InvalidOperationException("Failed to clear previous test results from simulator.");
+                }
+            }
+            else
+            {
+                deviceListener.ConnectedTask
+                    .TimeoutAfter(testLaunchTimeout)
+                    .ContinueWith(async (Task<bool> task) =>
+                    {
+                        testReporter.LaunchCallback(task);
 
-                    // Stop listening so that TCP doesn't get connected before here and when we evaluate why we failed
-                    // If no TCP happens, app didn't start in time => APP_LAUNCH_TIMEOUT
-                    // If TCP connects during this method or right after - a very narrow race condition - we would categorize it as TIMED_OUT
-                    // because we would consider the app run started and actually timing out.
-                    if (!deviceListener.ConnectedTask.IsCompleted)
-                    {
-                        await deviceListener.StopAsync();
-                    }
-                    else if (task.IsCompleted && task.Result)
-                    {
-                        ListenerConnected = true;
-                    }
-                }, cancellationToken)
-                .DoNotAwait();
+                        // Stop listening so that TCP doesn't get connected before here and when we evaluate why we failed
+                        // If no TCP happens, app didn't start in time => APP_LAUNCH_TIMEOUT
+                        // If TCP connects during this method or right after - a very narrow race condition - we would categorize it as TIMED_OUT
+                        // because we would consider the app run started and actually timing out.
+                        if (!deviceListener.ConnectedTask.IsCompleted)
+                        {
+                            await deviceListener.StopAsync();
+                        }
+                        else if (task.IsCompleted && task.Result)
+                        {
+                            ListenerConnected = true;
+                        }
+                    }, cancellationToken)
+                    .DoNotAwait();
+            }
 
             _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{device.Name}' ***");
 
@@ -251,10 +271,13 @@ public class AppTester : AppRunnerBase, IAppTester
                     mlaunchArguments,
                     crashReporter,
                     testReporter,
+                    resultFileHandler,
+                    deviceListener,
                     (ISimulatorDevice)device,
                     companionDevice as ISimulatorDevice,
                     timeout,
-                    cancellationToken);
+                    cancellationToken,
+                    runMode);
             }
             else
             {
@@ -304,10 +327,13 @@ public class AppTester : AppRunnerBase, IAppTester
         MlaunchArguments mlaunchArguments,
         ICrashSnapshotReporter crashReporter,
         ITestReporter testReporter,
+        IResultFileHandler resultFileHandler,
+        ISimpleListener deviceListener,
         ISimulatorDevice simulator,
         ISimulatorDevice? companionSimulator,
         TimeSpan timeout,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        RunMode runMode)
     {
         var result = await RunSimulatorApp(
             appInformation,
@@ -320,6 +346,17 @@ public class AppTester : AppRunnerBase, IAppTester
             cancellationToken);
 
         await testReporter.CollectSimulatorResult(result);
+
+        if (deviceListener.TestLog != null)
+        {
+            await resultFileHandler.CopySimulatorResultsAsync(
+                runMode,
+                simulator.OSVersion,
+                simulator.UDID,
+                appInformation.BundleIdentifier,
+                deviceListener.TestLog.FullPath,
+                cancellationToken);
+        }
     }
 
     private async Task RunDeviceTests(

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/SimulatorSelector.cs
@@ -40,7 +40,7 @@ public class DefaultSimulatorSelector : ISimulatorSelector
         {
             TestTarget.Simulator_iOS => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
             TestTarget.Simulator_iOS32 => "com.apple.CoreSimulator.SimDeviceType.iPhone-5",
-            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-XS"),
+            TestTarget.Simulator_iOS64 => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "iPhone-6s" : "iPhone-11-Pro"),
             TestTarget.Simulator_tvOS => "com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p",
             TestTarget.Simulator_watchOS => "com.apple.CoreSimulator.SimDeviceType." + (minVersion ? "Apple-Watch-38mm" : "Apple-Watch-Series-3-38mm"),
             TestTarget.Simulator_xrOS => "com.apple.CoreSimulator.SimDeviceType.Apple-Vision-Pro",

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.iOS.Shared;
+
+public interface IResultFileHandler
+{
+    bool IsSimulatorVersionSupported(string osVersion);
+
+    Task<bool> ClearSimulatorResultsAsync(
+        RunMode runMode,
+        string osVersion,
+        string udid,
+        string bundleIdentifier,
+        CancellationToken cancellationToken);
+
+    Task<bool> CopySimulatorResultsAsync(
+        RunMode runMode,
+        string osVersion,
+        string udid,
+        string bundleIdentifier,
+        string hostDestinationPath,
+        CancellationToken cancellationToken);
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+
+#nullable enable
+namespace Microsoft.DotNet.XHarness.iOS.Shared;
+
+public class ResultFileHandler : IResultFileHandler
+{
+    private readonly IMlaunchProcessManager _processManager;
+    private readonly IFileBackedLog _mainLog;
+
+    public ResultFileHandler(IMlaunchProcessManager processManager, IFileBackedLog mainLog)
+    {
+        _processManager = processManager;
+        _mainLog = mainLog;
+    }
+
+    public bool IsSimulatorVersionSupported(string osVersion)
+    {
+        string[] osVersionParts = osVersion.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        return osVersionParts.Length >= 2 &&
+            Version.TryParse(osVersionParts[1], out Version? parsedVersion) &&
+            parsedVersion.Major >= 18;
+    }
+
+    public async Task<bool> ClearSimulatorResultsAsync(
+        RunMode runMode,
+        string osVersion,
+        string udid,
+        string bundleIdentifier,
+        CancellationToken cancellationToken)
+    {
+        if (!IsSimulatorVersionSupported(osVersion))
+        {
+            return true;
+        }
+
+        string sourcePath = GetSimulatorResultsPath(runMode);
+        string command = $"rm -f \"$(xcrun simctl get_app_container {udid} {bundleIdentifier} data){sourcePath}\"";
+        var result = await _processManager.ExecuteCommandAsync(
+            "/bin/bash",
+            new[] { "-c", command },
+            _mainLog,
+            _mainLog,
+            _mainLog,
+            TimeSpan.FromMinutes(1),
+            cancellationToken: cancellationToken);
+
+        if (result.Succeeded)
+        {
+            return true;
+        }
+
+        _mainLog.WriteLine("Failed to clear previous test results from simulator.");
+        return false;
+    }
+
+    public async Task<bool> CopySimulatorResultsAsync(
+        RunMode runMode,
+        string osVersion,
+        string udid,
+        string bundleIdentifier,
+        string hostDestinationPath,
+        CancellationToken cancellationToken)
+    {
+        string[] osVersionParts = osVersion.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        if (osVersionParts.Length < 2 || !Version.TryParse(osVersionParts[1], out _))
+        {
+            _mainLog.WriteLine("Simulator OS version is not in the expected format, skipping result copying.");
+            return false;
+        }
+
+        if (!IsSimulatorVersionSupported(osVersion))
+        {
+            return true;
+        }
+
+        string sourcePath = GetSimulatorResultsPath(runMode);
+        string command = $"cp \"$(xcrun simctl get_app_container {udid} {bundleIdentifier} data){sourcePath}\" \"{hostDestinationPath}\"";
+
+        await _processManager.ExecuteCommandAsync(
+            "/bin/bash",
+            new[] { "-c", command },
+            _mainLog,
+            _mainLog,
+            _mainLog,
+            TimeSpan.FromMinutes(1),
+            cancellationToken: cancellationToken);
+
+        if (File.Exists(hostDestinationPath))
+        {
+            return true;
+        }
+
+        _mainLog.WriteLine($"Failed to copy results file from simulator. Expected at: {hostDestinationPath}");
+        return false;
+    }
+
+    // This path is set by iOSApplicationEntryPointBase in the architecture-specific test apps.
+    private static string GetSimulatorResultsPath(RunMode runMode)
+        => runMode == RunMode.iOS ||
+            runMode == RunMode.Sim64 ||
+            runMode == RunMode.Sim32 ||
+            runMode == RunMode.Classic
+            ? "/Documents/test-results.xml"
+            : "/Library/Caches/Documents/test-results.xml";
+}

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunTestBase.cs
@@ -94,6 +94,7 @@ public abstract class AppRunTestBase : IDisposable
         _mockSimulator = Mock.Of<ISimulatorDevice>(x =>
             x.UDID == "58F21118E4D34FD69EAB7860BB9B38A0" &&
             x.Name == SimulatorDeviceName &&
+            x.OSVersion == "Simulator 26.0" &&
             x.LogPath == _simulatorLogPath &&
             x.SystemLog == Path.Combine(_simulatorLogPath, "system.log"));
 

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppRunnerTests.cs
@@ -69,6 +69,8 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
@@ -431,13 +433,15 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
                    It.IsAny<CancellationToken>()))
-            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            .Callback((MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
             {
-                appLog = log;
+                appLog = stdoutLog;
                 appLaunchedTask.SetResult();
             })
             .Returns(new TaskCompletionSource<ProcessExecutionResult>().Task); // This task must never complete (it represents running app)
@@ -484,6 +488,8 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
@@ -534,11 +540,13 @@ public class AppRunnerTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),
                    It.IsAny<CancellationToken>()))
-            .Callback((MlaunchArguments args, ILog log, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
+            .Callback((MlaunchArguments args, ILog log, ILog stdoutLog, ILog stderrLog, TimeSpan timeout, Dictionary<string, string> env, int verbosity, CancellationToken? ct) =>
             {
                 appLaunchedTask.SetResult();
             })
@@ -588,6 +596,8 @@ public class AppRunnerTests : AppRunTestBase
             .Verify(
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -129,6 +129,8 @@ public class AppTesterTests : AppRunTestBase
                 x => x.ExecuteCommandAsync(
                    It.Is<MlaunchArguments>(args => args.AsCommandLine() == expectedArgs),
                    _mainLog.Object,
+                   It.IsAny<ILog>(),
+                   It.IsAny<ILog>(),
                    It.IsAny<TimeSpan>(),
                    It.IsAny<Dictionary<string, string>>(),
                    It.IsAny<int>(),

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -75,6 +75,7 @@ public class AppTesterTests : AppRunTestBase
         var testResultFilePath = Path.GetTempFileName();
         var listenerLogFile = Mock.Of<IFileBackedLog>(x => x.FullPath == testResultFilePath);
         File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
+        _listener.SetupGet(x => x.TestLog).Returns(listenerLogFile);
 
         _logs
             .Setup(x => x.Create("test-ios-simulator-64-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
@@ -93,6 +94,17 @@ public class AppTesterTests : AppRunTestBase
             .Returns(captureLog.Object);
 
         _listenerFactory.Setup(f => f.UseTunnel).Returns(useTunnel);
+        _processManager
+            .Setup(x => x.ExecuteCommandAsync(
+                "/bin/bash",
+                It.IsAny<IList<string>>(),
+                _mainLog.Object,
+                _mainLog.Object,
+                _mainLog.Object,
+                TimeSpan.FromMinutes(1),
+                null,
+                It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(new ProcessExecutionResult { ExitCode = 0 });
 
         // Act
         var appTester = new AppTester(
@@ -136,6 +148,39 @@ public class AppTesterTests : AppRunTestBase
                    It.IsAny<int>(),
                    It.IsAny<CancellationToken>()),
                 Times.Once);
+
+        _processManager.Verify(
+            x => x.ExecuteCommandAsync(
+                "/bin/bash",
+                It.Is<IList<string>>(args =>
+                    args.Count == 2 &&
+                    args[0] == "-c" &&
+                    args[1].StartsWith("cp ") &&
+                    args[1].Contains("get_app_container") &&
+                    args[1].Contains("/Library/Caches/Documents/test-results.xml")),
+                _mainLog.Object,
+                _mainLog.Object,
+                _mainLog.Object,
+                TimeSpan.FromMinutes(1),
+                null,
+                It.IsAny<CancellationToken?>()),
+            Times.Once);
+
+        _processManager.Verify(
+            x => x.ExecuteCommandAsync(
+                "/bin/bash",
+                It.Is<IList<string>>(args =>
+                    args.Count == 2 &&
+                    args[0] == "-c" &&
+                    args[1].StartsWith("rm -f") &&
+                    args[1].Contains("/Library/Caches/Documents/test-results.xml")),
+                _mainLog.Object,
+                _mainLog.Object,
+                _mainLog.Object,
+                TimeSpan.FromMinutes(1),
+                null,
+                It.IsAny<CancellationToken?>()),
+            Times.Once);
 
         _processManager
             .Verify(

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/DefaultSimulatorSelectorTests.cs
@@ -51,4 +51,14 @@ public class DefaultSimulatorSelectorTests
         // The Booted one
         Assert.Equal(simulator2, simulator);
     }
+
+    [Fact]
+    public void SelectsIOS26CompatibleDeviceType()
+    {
+        var target = new TestTargetOs(TestTarget.Simulator_iOS64, "26.0");
+
+        Assert.Equal(
+            "com.apple.CoreSimulator.SimDeviceType.iPhone-11-Pro",
+            _simulatorSelector.GetDeviceType(target, minVersion: false));
+    }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
@@ -1,0 +1,181 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.XHarness.Common.Execution;
+using Microsoft.DotNet.XHarness.Common.Logging;
+using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared.Tests;
+
+public class ResultFileHandlerTests : IDisposable
+{
+    private readonly string _tempFile = Path.GetTempFileName();
+    private readonly Mock<IMlaunchProcessManager> _processManager = new();
+    private readonly Mock<IFileBackedLog> _mainLog = new();
+
+    public ResultFileHandlerTests()
+    {
+        _processManager
+            .Setup(p => p.ExecuteCommandAsync(
+                It.IsAny<string>(),
+                It.IsAny<IList<string>>(),
+                It.IsAny<ILog>(),
+                It.IsAny<ILog>(),
+                It.IsAny<ILog>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken?>()))
+            .ReturnsAsync(new ProcessExecutionResult { ExitCode = 0 });
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(_tempFile))
+        {
+            File.Delete(_tempFile);
+        }
+    }
+
+    [Theory]
+    [InlineData("Simulator 17.4", false)]
+    [InlineData("Simulator 18.0", true)]
+    [InlineData("Simulator 26.0", true)]
+    [InlineData("invalid", false)]
+    public void DetectsSimulatorFileResultSupport(string osVersion, bool expected)
+    {
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+
+        Assert.Equal(expected, handler.IsSimulatorVersionSupported(osVersion));
+    }
+
+    [Theory]
+    [InlineData("Simulator")]
+    [InlineData("Simulator invalid")]
+    public async Task InvalidOsVersionReturnsFalse(string osVersion)
+    {
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+
+        bool result = await handler.CopySimulatorResultsAsync(
+            RunMode.iOS,
+            osVersion,
+            "udid",
+            "bundle",
+            _tempFile,
+            CancellationToken.None);
+
+        Assert.False(result);
+        _mainLog.Verify(
+            l => l.WriteLine("Simulator OS version is not in the expected format, skipping result copying."),
+            Times.Once);
+        _processManager.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SimulatorBeforeIos18DoesNotCopyResults()
+    {
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+
+        bool result = await handler.CopySimulatorResultsAsync(
+            RunMode.iOS,
+            "Simulator 17.4",
+            "udid",
+            "bundle",
+            _tempFile,
+            CancellationToken.None);
+
+        Assert.True(result);
+        _processManager.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(RunMode.Sim64, "/Documents/test-results.xml")]
+    [InlineData(RunMode.TvOS, "/Library/Caches/Documents/test-results.xml")]
+    public async Task SimulatorIos18OrNewerClearsPreviousResults(RunMode runMode, string sourcePath)
+    {
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+        const string udid = "simulator-udid";
+        const string bundleIdentifier = "net.dot.test";
+
+        bool result = await handler.ClearSimulatorResultsAsync(
+            runMode,
+            "Simulator 26.0",
+            udid,
+            bundleIdentifier,
+            CancellationToken.None);
+
+        Assert.True(result);
+        string expectedCommand = $"rm -f \"$(xcrun simctl get_app_container {udid} {bundleIdentifier} data){sourcePath}\"";
+        _processManager.Verify(
+            p => p.ExecuteCommandAsync(
+                "/bin/bash",
+                It.Is<IList<string>>(args => args.SequenceEqual(new[] { "-c", expectedCommand })),
+                _mainLog.Object,
+                _mainLog.Object,
+                _mainLog.Object,
+                TimeSpan.FromMinutes(1),
+                null,
+                CancellationToken.None),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(RunMode.Sim64, "/Documents/test-results.xml")]
+    [InlineData(RunMode.TvOS, "/Library/Caches/Documents/test-results.xml")]
+    public async Task SimulatorIos18OrNewerCopiesResults(RunMode runMode, string sourcePath)
+    {
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+        const string udid = "simulator-udid";
+        const string bundleIdentifier = "net.dot.test";
+
+        bool result = await handler.CopySimulatorResultsAsync(
+            runMode,
+            "Simulator 26.0",
+            udid,
+            bundleIdentifier,
+            _tempFile,
+            CancellationToken.None);
+
+        Assert.True(result);
+        string expectedCommand = $"cp \"$(xcrun simctl get_app_container {udid} {bundleIdentifier} data){sourcePath}\" \"{_tempFile}\"";
+        _processManager.Verify(
+            p => p.ExecuteCommandAsync(
+                "/bin/bash",
+                It.Is<IList<string>>(args => args.SequenceEqual(new[] { "-c", expectedCommand })),
+                _mainLog.Object,
+                _mainLog.Object,
+                _mainLog.Object,
+                TimeSpan.FromMinutes(1),
+                null,
+                CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MissingCopiedFileReturnsFalse()
+    {
+        File.Delete(_tempFile);
+        var handler = new ResultFileHandler(_processManager.Object, _mainLog.Object);
+
+        bool result = await handler.CopySimulatorResultsAsync(
+            RunMode.iOS,
+            "Simulator 18.0",
+            "udid",
+            "bundle",
+            _tempFile,
+            CancellationToken.None);
+
+        Assert.False(result);
+        _mainLog.Verify(
+            l => l.WriteLine($"Failed to copy results file from simulator. Expected at: {_tempFile}"),
+            Times.Once);
+    }
+}

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -1,33 +1,46 @@
 <Project DefaultTargets="Test">
   <Import Project="../Helix.SDK.configuration.props"/>
 
+  <!-- Detect architecture from Helix target queue name -->
+  <PropertyGroup>
+    <IsArm64Queue>$(HelixTargetQueue.Contains('arm64'))</IsArm64Queue>
+    <IsAmd64Queue>$(HelixTargetQueue.Contains('amd64'))</IsAmd64Queue>
+    <TestArch Condition="'$(IsArm64Queue)' == 'true'">arm64</TestArch>
+    <TestArch Condition="'$(IsAmd64Queue)' == 'true'">x64</TestArch>
+  </PropertyGroup>
+
+  <Target Name="ValidateArchitecture" BeforeTargets="Build">
+    <Error Condition="'$(HelixTargetQueue)' != '' and '$(IsArm64Queue)' != 'true' and '$(IsAmd64Queue)' != 'true'"
+           Text="Unable to detect architecture from HelixTargetQueue '$(HelixTargetQueue)'. Queue name must contain 'arm64' or 'amd64'." />
+  </Target>
+
   <ItemGroup>
     <HelixTargetQueue Include="osx.15.amd64.open"/>
     <HelixTargetQueue Include="osx.26.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=System.Numerics.Vectors.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / ios-simlator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=ios-simulator-64;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=ios-simulator-64;TestArch=$(TestArch);TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / maccatalyst -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=$(TestArch);TestAppBundleName=System.Collections.NonGeneric.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple run / maccatalyst -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=maccatalyst;TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
+      <AdditionalProperties>TestTarget=maccatalyst;TestArch=$(TestArch);TestAppBundleName=iOS.Simulator.PInvoke.Test.app;IncludesTestRunner=false;ExpectedExitCode=42</AdditionalProperties>
     </XHarnessAppleProject>
 
     <!-- apple test / tvos-simulator -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">
-      <AdditionalProperties>TestTarget=tvos-simulator;TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
+      <AdditionalProperties>TestTarget=tvos-simulator;TestArch=$(TestArch);TestAppBundleName=Microsoft.Extensions.Configuration.Ini.Tests.app</AdditionalProperties>
     </XHarnessAppleProject>
   </ItemGroup>
 

--- a/tests/integration-tests/Apple/Simulator.Tests.proj
+++ b/tests/integration-tests/Apple/Simulator.Tests.proj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <HelixTargetQueue Include="osx.15.amd64.open"/>
-    <HelixTargetQueue Include="osx.14.arm64.open"/>
+    <HelixTargetQueue Include="osx.26.arm64.open"/>
 
     <!-- apple test / ios-simulator-64 -->
     <XHarnessAppleProject Include="$(MSBuildThisFileDirectory)\TestAppBundle.proj">

--- a/tests/integration-tests/Apple/TestAppBundle.proj
+++ b/tests/integration-tests/Apple/TestAppBundle.proj
@@ -9,8 +9,12 @@
 
   <PropertyGroup>
     <AppStorageUrl>$(AssetsBaseUri)/ios/test-app/$(TestTarget)</AppStorageUrl>
-    <XHarnessTestAppBundleUrl>$(AppStorageUrl)/$(TestAppBundleName).zip</XHarnessTestAppBundleUrl>
     <TestAppDestinationDir>$(ArtifactsTmpDir)test-app\$(TestTarget)</TestAppDestinationDir>
+
+    <!-- Other release/8.0 projects still consume the original architecture-neutral assets. -->
+    <AppStorageUrl Condition="'$(TestArch)' != ''">$(AssetsBaseUri)/ios/test-app-new/$(TestTarget)/$(TestArch)</AppStorageUrl>
+    <TestAppDestinationDir Condition="'$(TestArch)' != ''">$(ArtifactsTmpDir)test-app-new\$(TestTarget)\$(TestArch)</TestAppDestinationDir>
+    <XHarnessTestAppBundleUrl>$(AppStorageUrl)/$(TestAppBundleName).zip</XHarnessTestAppBundleUrl>
   </PropertyGroup>
 
   <Target Name="Build" Returns="@(XHarnessAppFoldersToTest)">


### PR DESCRIPTION
## Summary

- replace the Apple ARM64 simulator Helix queue with `osx.26.arm64.open`
- select an iOS 26-compatible simulator and use architecture-specific x64/ARM64 test assets
- capture simulator application output while preserving no-wait launch detection
- collect file-based simulator test results on Apple OS 18+ without relying on TCP

## Validation

- `ResultFileHandlerTests` and `TestReporterTests` (29 passed)
- `AppRunnerTests` and `AppTesterTests` (18 passed)
- evaluated `Simulator.Tests.proj` for both ARM64 and x64 Helix queues
- confirmed all referenced architecture-specific test assets are available