### PR TITLE
Validate Android failed-test detection across runner paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Other parameters can be overrided as well if needed.
 
 Currently we support Xunit and NUnit test assemblies but the `Microsoft.DotNet.XHarness.Tests.Runners` supports implementation of custom runner too.
 
+### Android test-result ownership
+
+Both `xharness android test` and `xharness android run` use the same final result handling in XHarness. Android instrumentations must report a `return-code` and can report a results file using `test-results-path` (xUnit v2 or NUnit v3) or the legacy `nunit2-results-path` (NUnit v2). When instrumentation reports the expected successful exit code, XHarness pulls recognized result files and returns `TESTS_FAILED` if any report failed tests.
+
+This XHarness analysis is the common final safeguard for standard and custom runners, including NativeAOT-style runners that produce xUnit v2 XML. Custom runners should still propagate failed tests through their instrumentation return code. That runner-side check remains necessary when a result file is missing, cannot be pulled, is malformed, uses an unknown format, or when a nonzero expected exit code intentionally defines success.
+
 ## Development instructions
 When working on XHarness, there are couple of neat hacks that can improve the inner loop.
 The repository can either be built using regular .NET, assuming you have new enough version:

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerTests.cs
@@ -29,7 +29,11 @@ public class InstrumentationRunnerTests : IDisposable
 
     public void Dispose()
     {
-        Directory.Delete(_tempDirectory, true);
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerTests.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.XHarness.Android.Execution;
+using Microsoft.DotNet.XHarness.Common.CLI;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.XHarness.Android.Tests;
+
+public class InstrumentationRunnerTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly string _adbPath;
+
+    public InstrumentationRunnerTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDirectory);
+        _adbPath = Path.Combine(_tempDirectory, "adb");
+        File.WriteAllText(_adbPath, string.Empty);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempDirectory, true);
+        GC.SuppressFinalize(this);
+    }
+
+    public static TheoryData<string, string, string> FailedResultScenarios => new()
+    {
+        {
+            "standard xUnit runner",
+            "test-results-path",
+            """
+            <assemblies>
+              <assembly name="Tests" total="2" passed="1" failed="1" skipped="0" errors="0" />
+            </assemblies>
+            """
+        },
+        {
+            "NativeAOT generated xUnit runner",
+            "test-results-path",
+            """
+            <assemblies>
+              <assembly name="Tests" test-framework="XUnitWrapperGenerator-generated-runner"
+                        total="2" passed="1" failed="1" skipped="0" errors="0">
+                <collection name="Collection" total="2" passed="1" failed="1" skipped="0" errors="0" />
+              </assembly>
+            </assemblies>
+            """
+        },
+        {
+            "NUnit v2 runner",
+            "nunit2-results-path",
+            """<test-results name="Tests" total="2" errors="0" failures="1" not-run="0" />"""
+        },
+        {
+            "NUnit v3 runner",
+            "test-results-path",
+            """<test-run id="2" testcasecount="2" result="Failed" total="2" passed="1" failed="1" />"""
+        },
+    };
+
+    [Theory]
+    [MemberData(nameof(FailedResultScenarios))]
+    public void FailedTestResultsFromSupportedAndroidRunnerPathsOverrideSuccessfulInstrumentation(
+        string runnerName,
+        string resultPathKey,
+        string resultXml)
+    {
+        string outputDirectory = Path.Combine(_tempDirectory, runnerName.Replace(' ', '-'));
+        var processManager = new ResultProducingAdbProcessManager(resultPathKey, resultXml);
+        var adbRunner = new AdbRunner(Mock.Of<ILogger>(), processManager, _adbPath);
+        var instrumentationRunner = new InstrumentationRunner(Mock.Of<ILogger>(), adbRunner);
+
+        ExitCode exitCode = instrumentationRunner.RunApkInstrumentation(
+            apkPackageName: "net.dot.Tests",
+            instrumentationName: "net.dot.MonoRunner",
+            instrumentationArguments: new Dictionary<string, string>(),
+            outputDirectory,
+            deviceOutputFolder: null,
+            timeout: TimeSpan.FromMinutes(1),
+            expectedExitCode: (int)ExitCode.SUCCESS);
+
+        Assert.Equal(ExitCode.TESTS_FAILED, exitCode);
+        Assert.True(File.Exists(Path.Combine(outputDirectory, "testResults.xml")));
+    }
+
+    private sealed class ResultProducingAdbProcessManager : IAdbProcessManager
+    {
+        private const string DeviceResultsPath = "/data/user/0/net.dot.Tests/files/testResults.xml";
+
+        private readonly string _resultPathKey;
+        private readonly string _resultXml;
+
+        public ResultProducingAdbProcessManager(string resultPathKey, string resultXml)
+        {
+            _resultPathKey = resultPathKey;
+            _resultXml = resultXml;
+        }
+
+        public string DeviceSerial { get; set; } = "";
+
+        public ProcessExecutionResults Run(string filename, IEnumerable<string> arguments, TimeSpan timeout)
+        {
+            string[] args = arguments.ToArray();
+            int commandIndex = args[0] == "-s" ? 2 : 0;
+
+            return args[commandIndex] switch
+            {
+                "shell" => SuccessfulResult(
+                    $"INSTRUMENTATION_RESULT: return-code=0{Environment.NewLine}" +
+                    $"INSTRUMENTATION_RESULT: {_resultPathKey}={DeviceResultsPath}"),
+                "pull" => PullResultFile(args[commandIndex + 2]),
+                "logcat" => SuccessfulResult(""),
+                _ => throw new InvalidOperationException($"Unexpected fake ADB command: {string.Join(" ", args)}"),
+            };
+        }
+
+        private ProcessExecutionResults PullResultFile(string destinationDirectory)
+        {
+            Directory.CreateDirectory(destinationDirectory);
+            File.WriteAllText(Path.Combine(destinationDirectory, "testResults.xml"), _resultXml);
+            return SuccessfulResult("");
+        }
+
+        private static ProcessExecutionResults SuccessfulResult(string standardOutput)
+            => new()
+            {
+                ExitCode = (int)AdbExitCodes.SUCCESS,
+                StandardOutput = standardOutput,
+            };
+    }
+}


### PR DESCRIPTION
## Summary

- exercise `InstrumentationRunner` end to end with successful instrumentation and failed result XML from standard xUnit, NativeAOT-generated xUnit, NUnit v2, and NUnit v3 runners
- document that result parsing is XHarness's common final safeguard for both `android test` and `android run`
- document why custom runners must continue propagating failures through their instrumentation return code

## Testing

- `Build.cmd -test -projects tests\Microsoft.DotNet.XHarness.Android.Tests\Microsoft.DotNet.XHarness.Android.Tests.csproj -configuration Debug -verbosity minimal`

Closes #1669