### PR TITLE
Handle Helix dead-letter console URLs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,6 +175,7 @@ XHarness uses standardized exit codes (see `src/Microsoft.DotNet.XHarness.Common
 - Check device/simulator state before test execution
 - Verify app signing and provisioning for Apple platforms
 - Monitor TCP connections for test result streaming
+- If Helix `ConsoleOutputUri` is the `helix-workitem-deadletter.txt` sentinel, use the canonical `/api/2019-06-17/jobs/{jobId}/workitems/{workItem}/console` endpoint; an uploaded console log may still be available there.
 
 ## Development Workflow
 

--- a/.github/workflows/runtime-failure-observer-http
+++ b/.github/workflows/runtime-failure-observer-http
@@ -23,6 +23,9 @@ DEFINITION_IDS = (154, 223, 224, 225, 226, 228, 260, 261, 265)
 AZDO_HOST = "dev.azure.com"
 AZDO_PATH_PREFIX = "/dnceng-public/public/_apis/build/"
 HELIX_HOST = "helix.dot.net"
+HELIX_DEADLETTER_URL = (
+    "https://dotnet.github.io/core-eng/helix-workitem-deadletter.txt"
+)
 USER_AGENT = "xharness-runtime-failure-observer/1.0"
 
 _AZDO_BUILD_PATH = re.compile(r"^/dnceng-public/public/_apis/build/builds$")
@@ -37,7 +40,7 @@ _HELIX_WORK_ITEMS_PATH = re.compile(
 )
 _HELIX_CONSOLE_PATH = re.compile(
     r"^/api/(?:2019-06-17/)?jobs/[0-9a-f-]{36}/workitems/"
-    r"[^/]+/files/console(?:\.[A-Za-z0-9_-]+)?\.log$",
+    r"[^/]+/(?:console|files/console(?:\.[A-Za-z0-9_-]+)?\.log)$",
     re.IGNORECASE,
 )
 _BLOB_CONSOLE_PATH = re.compile(
@@ -401,6 +404,14 @@ def _helix_work_items_url(job_id: str) -> str:
     )
 
 
+def _helix_console_url(job_id: str, work_item: str) -> str:
+    encoded_work_item = urllib.parse.quote(work_item, safe="")
+    return (
+        f"https://{HELIX_HOST}/api/2019-06-17/jobs/{job_id}/workitems/"
+        f"{encoded_work_item}/console"
+    )
+
+
 def _json_items(payload: bytes) -> list[dict]:
     try:
         document = json.loads(payload)
@@ -432,7 +443,7 @@ def _case_insensitive_field(item: dict, field_name: str):
     return None
 
 
-def _console_url(payload: bytes, work_item: str) -> str:
+def _console_url(payload: bytes, job_id: str, work_item: str) -> str:
     matches = [
         item
         for item in _json_items(payload)
@@ -449,6 +460,8 @@ def _console_url(payload: bytes, work_item: str) -> str:
     console_url = _case_insensitive_field(matches[0], "ConsoleOutputUri")
     if not isinstance(console_url, str) or not console_url:
         raise TransportError("Helix work item did not contain a console output URL")
+    if console_url == HELIX_DEADLETTER_URL:
+        console_url = _helix_console_url(job_id, work_item)
     _validate_url(console_url, {"helix-console"})
     return console_url
 
@@ -484,7 +497,7 @@ def _run(args: argparse.Namespace) -> None:
         work_items = _request_bytes(
             _helix_work_items_url(args.job_id), {"helix-work-items"}, JSON_LIMIT
         )
-        console_url = _console_url(work_items, args.work_item)
+        console_url = _console_url(work_items, args.job_id, args.work_item)
         _write_output(
             _request_bytes(console_url, {"helix-console"}, LOG_LIMIT),
             args.output,

--- a/.github/workflows/tests/test_runtime_failure_observer_http.py
+++ b/.github/workflows/tests/test_runtime_failure_observer_http.py
@@ -88,10 +88,14 @@ class UrlValidationTests(unittest.TestCase):
             observer_http._validate_url(url, {"helix-console"})
 
     def test_helix_work_items_use_specific_family(self):
-        url = observer_http._helix_work_items_url(
-            "00000000-0000-0000-0000-000000000000"
-        )
+        job_id = "00000000-0000-0000-0000-000000000000"
+        url = observer_http._helix_work_items_url(job_id)
         observer_http._validate_url(url, {"helix-work-items"})
+        console_url = observer_http._helix_console_url(
+            job_id, "runtime tests/arm64"
+        )
+        observer_http._validate_url(console_url, {"helix-console"})
+        self.assertIn("runtime%20tests%2Farm64/console", console_url)
 
     def test_redirect_handler_rejects_family_escape(self):
         handler = observer_http._ValidatingRedirectHandler({"azdo"})
@@ -194,6 +198,8 @@ class RequestBehaviorTests(unittest.TestCase):
 
 
 class HelixTraversalTests(unittest.TestCase):
+    JOB_ID = "00000000-0000-0000-0000-000000000000"
+
     def test_console_url_is_selected_by_exact_work_item_name(self):
         payload = b"""[
           {
@@ -203,7 +209,22 @@ class HelixTraversalTests(unittest.TestCase):
         ]"""
         self.assertIn(
             "console.1.log",
-            observer_http._console_url(payload, "runtime-tests"),
+            observer_http._console_url(payload, self.JOB_ID, "runtime-tests"),
+        )
+
+    def test_console_url_uses_api_for_deadletter_sentinel(self):
+        payload = b"""[
+          {
+            "Name": "runtime tests/arm64",
+            "ConsoleOutputUri": "https://dotnet.github.io/core-eng/helix-workitem-deadletter.txt"
+          }
+        ]"""
+        self.assertEqual(
+            observer_http._console_url(
+                payload, self.JOB_ID, "runtime tests/arm64"
+            ),
+            "https://helix.dot.net/api/2019-06-17/jobs/"
+            f"{self.JOB_ID}/workitems/runtime%20tests%2Farm64/console",
         )
 
     def test_console_url_rejects_untrusted_metadata(self):
@@ -214,7 +235,7 @@ class HelixTraversalTests(unittest.TestCase):
           }
         ]"""
         with self.assertRaises(observer_http.TransportError):
-            observer_http._console_url(payload, "runtime-tests")
+            observer_http._console_url(payload, self.JOB_ID, "runtime-tests")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- recognize Helix's dead-letter `ConsoleOutputUri` sentinel
- fall back to the canonical Helix work-item console endpoint
- encode work-item names and add regression coverage
- document the Helix console fallback for future investigations

This fixes the second failure reported in #1689 after the observer progressed past the denied shell-loop problem addressed by #1690.

## Validation

- affected observer helper test classes: 13 passed
- fetched the console for the exact failed Helix work item through the fallback: 32,742 bytes