### PR TITLE
Improve diagnostics for Apple apps that exit before test startup

### DIFF
--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunner.cs
@@ -130,7 +130,8 @@ public class AppRunner : AppRunnerBase, IAppRunner
             _mainLog,
             crashLogs,
             isDevice: !isSimulator,
-            device.Name);
+            device.Name,
+            appInformation);
 
         _mainLog.WriteLine($"*** Executing '{appInformation.AppName}' on {target.AsString()} '{device.Name}' ***");
 

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppRunnerBase.cs
@@ -31,6 +31,9 @@ public abstract class AppRunnerBase
 
     private bool _appEndSignalDetected = false;
 
+    protected bool AppEndSignalDetected => _appEndSignalDetected;
+    protected IReadableLog? SimulatorApplicationLog { get; private set; }
+
     protected AppRunnerBase(
         IMlaunchProcessManager processManager,
         ICaptureLogFactory captureLogFactory,
@@ -182,6 +185,7 @@ public abstract class AppRunnerBase
         // This is needed for exit code detection, as the app exit code (e.g., DOTNET.APP_EXIT_CODE)
         // is printed to stdout by the simulator and captured by mlaunch
         var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
+        SimulatorApplicationLog = appOutputLog;
 
         if (waitForExit)
         {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -6,9 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common;
+using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.Common.Utilities;
 using Microsoft.DotNet.XHarness.iOS.Shared;
@@ -23,6 +25,7 @@ namespace Microsoft.DotNet.XHarness.Apple;
 public interface IAppTester
 {
     bool ListenerConnected { get; }
+    AppleLaunchDiagnostics? LaunchDiagnostics { get; }
 
     Task<(TestExecutingResult Result, string ResultMessage)> TestApp(
         AppBundleInformation appInformation,
@@ -58,6 +61,15 @@ public interface IAppTester
 /// </summary>
 public class AppTester : AppRunnerBase, IAppTester
 {
+    private static readonly Regex[] s_appExitCodeRegexes =
+    {
+        new(@"The app '[^']+' exited with exit code (?<exitCode>-?\d+)", RegexOptions.Compiled),
+        new(@"The app terminated with the exit code (?<exitCode>-?\d+)\.", RegexOptions.Compiled),
+        new(@"terminated \(with exit code '(?<exitCode>-?\d+)' and/or crashing signal", RegexOptions.Compiled),
+        new(@"DOTNET\.APP_EXIT_CODE:\s*(?<exitCode>-?\d+)\s*$", RegexOptions.Compiled),
+        new(@"Service exited with abnormal code:\s*(?<exitCode>-?\d+)\s*$", RegexOptions.Compiled),
+    };
+
     private readonly IMlaunchProcessManager _processManager;
     private readonly ISimpleListenerFactory _listenerFactory;
     private readonly ICrashSnapshotReporterFactory _snapshotReporterFactory;
@@ -73,6 +85,7 @@ public class AppTester : AppRunnerBase, IAppTester
     /// This is used later to determine if a cause for a failed run is a failing TCP connection.
     /// </summary>
     public bool ListenerConnected { get; private set; }
+    public AppleLaunchDiagnostics? LaunchDiagnostics { get; private set; }
 
     public AppTester(
         IMlaunchProcessManager processManager,
@@ -111,6 +124,8 @@ public class AppTester : AppRunnerBase, IAppTester
         string[]? skippedTestClasses = null,
         CancellationToken cancellationToken = default)
     {
+        LaunchDiagnostics = CreateLaunchDiagnostics(appInformation);
+
         var testLog = _logs.Create($"test-{TestTarget.MacCatalyst.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
         var appOutputLog = _logs.Create(appInformation.BundleIdentifier + ".log", LogType.ApplicationLog.ToString(), timestamp: true);
 
@@ -169,6 +184,7 @@ public class AppTester : AppRunnerBase, IAppTester
     {
         var runMode = target.Platform.ToRunMode();
         var isSimulator = target.Platform.IsSimulator();
+        LaunchDiagnostics = CreateLaunchDiagnostics(appInformation);
 
         var testLog = _logs.Create($"test-{target.AsString()}-{_helpers.Timestamp}.log", LogType.TestLog.ToString(), timestamp: false);
 
@@ -187,9 +203,7 @@ public class AppTester : AppRunnerBase, IAppTester
             var deviceListenerPort = deviceListener.InitializeAndGetPort();
             deviceListener.StartAsync();
 
-            using var crashLogs = new Logs(_logs.Directory);
-
-            ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, crashLogs, isDevice: !isSimulator, device.Name);
+            ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, _logs, isDevice: !isSimulator, device.Name, appInformation);
             using ITestReporter testReporter = _testReporterFactory.Create(
                 _mainLog,
                 _mainLog,
@@ -315,7 +329,9 @@ public class AppTester : AppRunnerBase, IAppTester
             }
 
             // Check the final status, copy all the required data
-            return await testReporter.ParseResult();
+            var result = await testReporter.ParseResult();
+            CompleteLaunchDiagnostics(testReporter, crashReporter, deviceListener);
+            return result;
         }
     }
 
@@ -344,6 +360,7 @@ public class AppTester : AppRunnerBase, IAppTester
             waitForExit: true,
             cancellationToken);
 
+        RecordLaunchResult(result, SimulatorApplicationLog);
         await testReporter.CollectSimulatorResult(result);
 
         // On iOS 18 and later, transferring results over a TCP tunnel isn’t supported.
@@ -358,6 +375,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 simulator.UDID,
                 appInformation.BundleIdentifier,
                 deviceListener.TestLog.FullPath);
+            RecordResultFileCopy(resultFileHandler, runMode, resultsCopied);
 
             // If results weren't copied, it likely means the app crashed before tests could run
             // Try to retrieve the crash report, but only if the test run didn't already complete.
@@ -371,13 +389,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 }
                 else
                 {
-                    _mainLog.WriteLine("Test results file not found, app may have crashed before tests started.");
-                    await resultFileHandler.CopyCrashReportAsync(
-                        simulator.UDID,
-                        simulator.Name,
-                        appInformation,
-                        _mainLog,
-                        isSimulator: true);
+                    _mainLog.WriteLine("Test results file not found. Checking the pre-launch crash report snapshot for a matching report.");
                 }
             }
 
@@ -448,6 +460,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 envVars,
                 cancellationToken: cancellationToken));
 
+            RecordLaunchResult(result, appOutputLog as IReadableLog);
             await testReporter.CollectDeviceResult(result);
         }
         finally
@@ -480,6 +493,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 device.UDID,
                 appInformation.BundleIdentifier,
                 deviceListener.TestLog.FullPath);
+            RecordResultFileCopy(resultFileHandler, runMode, resultsCopied);
 
             // If results weren't copied, it likely means the app crashed before tests could run
             // Try to retrieve the crash report, but only if the test run didn't already complete.
@@ -493,13 +507,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 }
                 else
                 {
-                    _mainLog.WriteLine("Test results file not found, app may have crashed before tests started.");
-                    await resultFileHandler.CopyCrashReportAsync(
-                        device.UDID,
-                        device.Name,
-                        appInformation,
-                        _mainLog,
-                        isSimulator: false);
+                    _mainLog.WriteLine("Test results file not found. Checking the pre-launch crash report snapshot for a matching report.");
                 }
             }
 
@@ -539,9 +547,7 @@ public class AppTester : AppRunnerBase, IAppTester
         deviceListener.StartAsync();
         var (enableCoverage, coverageFileName) = GetCoverageSettings(extraEnvVariables);
 
-        using var crashLogs = new Logs(_logs.Directory);
-
-        ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, crashLogs, isDevice: false, null);
+        ICrashSnapshotReporter crashReporter = _snapshotReporterFactory.Create(_mainLog, _logs, isDevice: false, null, appInformation);
         IResultFileHandler resultFileHandler = new ResultFileHandler(_processManager, _mainLog);
         using ITestReporter testReporter = _testReporterFactory.Create(
             _mainLog,
@@ -602,6 +608,7 @@ public class AppTester : AppRunnerBase, IAppTester
             await crashReporter.StartCaptureAsync();
 
             var result = await RunMacCatalystApp(appInformation, appOutputLog, timeout, waitForExit: true, extraAppArguments, envVariables, combinedCancellationToken.Token);
+            RecordLaunchResult(result, appOutputLog as IReadableLog);
             await testReporter.CollectSimulatorResult(result);
 
             if (enableCoverage)
@@ -626,7 +633,113 @@ public class AppTester : AppRunnerBase, IAppTester
             deviceListener.Cancel();
         }
 
-        return await testReporter.ParseResult();
+        var parsedResult = await testReporter.ParseResult();
+        CompleteLaunchDiagnostics(testReporter, crashReporter, deviceListener);
+        return parsedResult;
+    }
+
+    private static AppleLaunchDiagnostics CreateLaunchDiagnostics(AppBundleInformation appInformation)
+        => new()
+        {
+            BundleId = appInformation.BundleIdentifier,
+        };
+
+    private void RecordLaunchResult(ProcessExecutionResult result, IReadableLog? appOutputLog)
+    {
+        if (LaunchDiagnostics is null)
+        {
+            return;
+        }
+
+        LaunchDiagnostics.LauncherExitCode = result.ExitCode;
+        LaunchDiagnostics.AppExitCode = TryReadAppExitCode(appOutputLog);
+    }
+
+    private void RecordResultFileCopy(IResultFileHandler resultFileHandler, RunMode runMode, bool resultsCopied)
+    {
+        if (LaunchDiagnostics is null)
+        {
+            return;
+        }
+
+        LaunchDiagnostics.TestResultFile.Path = ResultFileHandler.GetAppContainerSourcePath(runMode, "test-results.xml");
+        LaunchDiagnostics.TestResultFile.CopyAttempts = resultFileHandler.LastCopyAttempts;
+        LaunchDiagnostics.TestResultFile.Exists = resultsCopied;
+    }
+
+    private void CompleteLaunchDiagnostics(
+        ITestReporter testReporter,
+        ICrashSnapshotReporter crashReporter,
+        ISimpleListener deviceListener)
+    {
+        if (LaunchDiagnostics is null)
+        {
+            return;
+        }
+
+        LaunchDiagnostics.TestProtocolStarted = LaunchDiagnostics.TestResultFile.CopyAttempts > 0
+            ? null
+            : testReporter.TestExecutionStarted;
+        LaunchDiagnostics.TestEndSignalDetected = AppEndSignalDetected;
+        LaunchDiagnostics.CrashReport = crashReporter.CaptureDiagnostics ?? new AppleCrashReportDiagnostics();
+        if (LaunchDiagnostics.TestResultFile.CopyAttempts == 0)
+        {
+            LaunchDiagnostics.TestResultFile.Path = deviceListener.TestLog?.FullPath ?? string.Empty;
+            LaunchDiagnostics.TestResultFile.Exists =
+                deviceListener.TestLog is not null && File.Exists(deviceListener.TestLog.FullPath);
+        }
+    }
+
+    private static int? TryReadAppExitCode(IReadableLog? appOutputLog)
+    {
+        if (appOutputLog is null)
+        {
+            return null;
+        }
+
+        if (appOutputLog is IFileBackedLog fileBackedLog && !File.Exists(fileBackedLog.FullPath))
+        {
+            return null;
+        }
+
+        StreamReader? reader;
+        try
+        {
+            reader = appOutputLog.GetReader();
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return null;
+        }
+
+        if (reader is null)
+        {
+            return null;
+        }
+
+        using (reader)
+        {
+            string? line;
+            int? exitCode = null;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                foreach (Regex regex in s_appExitCodeRegexes)
+                {
+                    Match match = regex.Match(line);
+                    if (match.Success && int.TryParse(match.Groups["exitCode"].Value, out int parsedExitCode))
+                    {
+                        exitCode = parsedExitCode;
+                        break;
+                    }
+                }
+            }
+
+            return exitCode;
+        }
     }
 
     private static (bool EnableCoverage, string CoverageFileName) GetCoverageSettings(IEnumerable<(string, string?)> extraEnvVariables)

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -215,9 +215,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 runMode,
                 xmlResultJargon,
                 device.Name,
-                timeout,
-                null,
-                (level, message) => _mainLog.WriteLine(message));
+                timeout);
             IResultFileHandler resultFileHandler = new ResultFileHandler(_processManager, _mainLog);
 
             // For iOS 18+ devices/simulators, result files are copied directly from the app container
@@ -389,7 +387,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 }
                 else
                 {
-                    _mainLog.WriteLine("Test results file not found. Checking the pre-launch crash report snapshot for a matching report.");
+                    _mainLog.WriteLine("Test results file not found. New crash reports will be matched when the run result is finalized.");
                 }
             }
 
@@ -507,7 +505,7 @@ public class AppTester : AppRunnerBase, IAppTester
                 }
                 else
                 {
-                    _mainLog.WriteLine("Test results file not found. Checking the pre-launch crash report snapshot for a matching report.");
+                    _mainLog.WriteLine("Test results file not found. New crash reports will be matched when the run result is finalized.");
                 }
             }
 
@@ -560,9 +558,7 @@ public class AppTester : AppRunnerBase, IAppTester
             RunMode.MacOS,
             xmlResultJargon,
             null,
-            timeout,
-            null,
-            (level, message) => _mainLog.WriteLine(message));
+            timeout);
 
         deviceListener.ConnectedTask
             .TimeoutAfter(testLaunchTimeout)
@@ -646,25 +642,18 @@ public class AppTester : AppRunnerBase, IAppTester
 
     private void RecordLaunchResult(ProcessExecutionResult result, IReadableLog? appOutputLog)
     {
-        if (LaunchDiagnostics is null)
-        {
-            return;
-        }
-
-        LaunchDiagnostics.LauncherExitCode = result.ExitCode;
-        LaunchDiagnostics.AppExitCode = TryReadAppExitCode(appOutputLog);
+        AppleLaunchDiagnostics launchDiagnostics = GetLaunchDiagnostics();
+        launchDiagnostics.LauncherExitCode = result.ExitCode;
+        launchDiagnostics.AppExitCode = TryReadAppExitCode(appOutputLog);
     }
 
     private void RecordResultFileCopy(IResultFileHandler resultFileHandler, RunMode runMode, bool resultsCopied)
     {
-        if (LaunchDiagnostics is null)
-        {
-            return;
-        }
-
-        LaunchDiagnostics.TestResultFile.Path = ResultFileHandler.GetAppContainerSourcePath(runMode, "test-results.xml");
-        LaunchDiagnostics.TestResultFile.CopyAttempts = resultFileHandler.LastCopyAttempts;
-        LaunchDiagnostics.TestResultFile.Exists = resultsCopied;
+        AppleLaunchDiagnostics launchDiagnostics = GetLaunchDiagnostics();
+        launchDiagnostics.TestProtocolExpected = false;
+        launchDiagnostics.TestResultFile.Path = ResultFileHandler.GetAppContainerSourcePath(runMode, "test-results.xml");
+        launchDiagnostics.TestResultFile.CopyAttempts = resultFileHandler.LastCopyAttempts;
+        launchDiagnostics.TestResultFile.Exists = resultsCopied;
     }
 
     private void CompleteLaunchDiagnostics(
@@ -672,23 +661,20 @@ public class AppTester : AppRunnerBase, IAppTester
         ICrashSnapshotReporter crashReporter,
         ISimpleListener deviceListener)
     {
-        if (LaunchDiagnostics is null)
+        AppleLaunchDiagnostics launchDiagnostics = GetLaunchDiagnostics();
+        launchDiagnostics.TestProtocolConnected = testReporter.TestProtocolConnected;
+        launchDiagnostics.TestEndSignalDetected = AppEndSignalDetected;
+        launchDiagnostics.CrashReport = crashReporter.CaptureDiagnostics ?? new AppleCrashReportDiagnostics();
+        if (launchDiagnostics.TestResultFile.CopyAttempts == 0)
         {
-            return;
-        }
-
-        LaunchDiagnostics.TestProtocolStarted = testReporter.TestExecutionStarted
-            ? true
-            : LaunchDiagnostics.TestResultFile.CopyAttempts > 0 ? null : false;
-        LaunchDiagnostics.TestEndSignalDetected = AppEndSignalDetected;
-        LaunchDiagnostics.CrashReport = crashReporter.CaptureDiagnostics ?? new AppleCrashReportDiagnostics();
-        if (LaunchDiagnostics.TestResultFile.CopyAttempts == 0)
-        {
-            LaunchDiagnostics.TestResultFile.Path = deviceListener.TestLog?.FullPath ?? string.Empty;
-            LaunchDiagnostics.TestResultFile.Exists =
+            launchDiagnostics.TestResultFile.Path = deviceListener.TestLog?.FullPath ?? string.Empty;
+            launchDiagnostics.TestResultFile.Exists =
                 deviceListener.TestLog is not null && File.Exists(deviceListener.TestLog.FullPath);
         }
     }
+
+    private AppleLaunchDiagnostics GetLaunchDiagnostics()
+        => LaunchDiagnostics ?? throw new InvalidOperationException("Launch diagnostics have not been initialized.");
 
     private static int? TryReadAppExitCode(IReadableLog? appOutputLog)
     {

--- a/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/AppOperations/AppTester.cs
@@ -677,9 +677,9 @@ public class AppTester : AppRunnerBase, IAppTester
             return;
         }
 
-        LaunchDiagnostics.TestProtocolStarted = LaunchDiagnostics.TestResultFile.CopyAttempts > 0
-            ? null
-            : testReporter.TestExecutionStarted;
+        LaunchDiagnostics.TestProtocolStarted = testReporter.TestExecutionStarted
+            ? true
+            : LaunchDiagnostics.TestResultFile.CopyAttempts > 0 ? null : false;
         LaunchDiagnostics.TestEndSignalDetected = AppEndSignalDetected;
         LaunchDiagnostics.CrashReport = crashReporter.CaptureDiagnostics ?? new AppleCrashReportDiagnostics();
         if (LaunchDiagnostics.TestResultFile.CopyAttempts == 0)

--- a/src/Microsoft.DotNet.XHarness.Apple/CrashSnapshotReporterFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/CrashSnapshotReporterFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.XHarness.Apple;
 
 public interface ICrashSnapshotReporterFactory
 {
-    ICrashSnapshotReporter Create(ILog log, ILogs logs, bool isDevice, string? deviceName);
+    ICrashSnapshotReporter Create(ILog log, ILogs logs, bool isDevice, string? deviceName, AppBundleInformation appInformation);
 }
 
 public class CrashSnapshotReporterFactory : ICrashSnapshotReporterFactory
@@ -24,6 +24,6 @@ public class CrashSnapshotReporterFactory : ICrashSnapshotReporterFactory
         _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
     }
 
-    public ICrashSnapshotReporter Create(ILog log, ILogs logs, bool isDevice, string? deviceName) =>
-        new CrashSnapshotReporter(_processManager, log, logs, isDevice, deviceName);
+    public ICrashSnapshotReporter Create(ILog log, ILogs logs, bool isDevice, string? deviceName, AppBundleInformation appInformation) =>
+        new CrashSnapshotReporter(_processManager, log, logs, isDevice, deviceName, appInformation);
 }

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/BaseOrchestrator.cs
@@ -44,6 +44,7 @@ public abstract class BaseOrchestrator : IDisposable
     private readonly IErrorKnowledgeBase _errorKnowledgeBase;
     private readonly IDiagnosticsData _diagnosticsData;
     private readonly IHelpers _helpers;
+    private readonly Dictionary<string, object?> _runSummaryData = new();
 
     private bool _lldbFileCreated;
 
@@ -121,6 +122,18 @@ public abstract class BaseOrchestrator : IDisposable
         }
 
         return exitCode;
+    }
+
+    protected void SetRunSummaryData(string key, object? value)
+    {
+        if (value is null)
+        {
+            _runSummaryData.Remove(key);
+        }
+        else
+        {
+            _runSummaryData[key] = value;
+        }
     }
 
     private async Task<ExitCode> OrchestrateOperationInternal(
@@ -420,7 +433,8 @@ public abstract class BaseOrchestrator : IDisposable
             architecture: null,
             instrumentationExitCode: null,
             producedFiles: producedFiles,
-            environment: _diagnosticsData.Environment);
+            environment: _diagnosticsData.Environment,
+            additionalData: _runSummaryData);
 
         RunSummaryEmitter.WriteResultJsonFile(
             _logs.Directory,
@@ -431,7 +445,8 @@ public abstract class BaseOrchestrator : IDisposable
             architecture: null,
             instrumentationExitCode: null,
             producedFiles: producedFiles,
-            environment: _diagnosticsData.Environment);
+            environment: _diagnosticsData.Environment,
+            additionalData: _runSummaryData);
     }
 
     public void Dispose()

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -251,6 +251,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             skippedTestClasses: classMethodFilters?.ToArray(),
             cancellationToken: cancellationToken);
 
+        SetRunSummaryData("appleLaunch", appTester.LaunchDiagnostics);
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
 
         // Copy application logs to the main log for better failure investigation.
@@ -286,6 +287,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
             skippedTestClasses: classMethodFilters?.ToArray(),
             cancellationToken: cancellationToken);
 
+        SetRunSummaryData("appleLaunch", appTester.LaunchDiagnostics);
         ExitCode exitCode = ParseResult(testResult, resultMessage, appTester.ListenerConnected);
 
         // Copy system log to the main log — MacCatalyst output goes to SystemLog, not ApplicationLog
@@ -337,7 +339,7 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
 
             // TCP errors are encounter all the time but they are not always the cause of the failure
             // If the app crashed, TCP_CONNECTION_FAILED and there was not other exit code we will return TCP_CONNECTION_FAILED
-            if (defaultExitCode == ExitCode.APP_CRASH && tcpErrorFound)
+            if ((defaultExitCode == ExitCode.APP_CRASH || defaultExitCode == ExitCode.APP_EXITED_BEFORE_TEST_START) && tcpErrorFound)
             {
                 return ExitCode.TCP_CONNECTION_FAILED;
             }
@@ -362,6 +364,9 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
 
             case TestExecutingResult.Crashed:
                 return LogProblem("Application test run crashed", ExitCode.APP_CRASH);
+
+            case TestExecutingResult.AppExitedBeforeTestStart:
+                return LogProblem("Application exited before the test protocol started", ExitCode.APP_EXITED_BEFORE_TEST_START);
 
             case TestExecutingResult.LaunchTimedOut:
                 _logger.LogError("Application launch timed out before the test execution has started");

--- a/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
+++ b/src/Microsoft.DotNet.XHarness.Apple/Orchestration/TestOrchestrator.cs
@@ -366,7 +366,10 @@ public class TestOrchestrator : BaseOrchestrator, ITestOrchestrator
                 return LogProblem("Application test run crashed", ExitCode.APP_CRASH);
 
             case TestExecutingResult.AppExitedBeforeTestStart:
-                return LogProblem("Application exited before the test protocol started", ExitCode.APP_EXITED_BEFORE_TEST_START);
+                return LogProblem("Application exited before test startup was observed", ExitCode.APP_EXITED_BEFORE_TEST_START);
+
+            case TestExecutingResult.TestResultsMissing:
+                return LogProblem("Application did not produce a test results file", ExitCode.TEST_RESULTS_MISSING);
 
             case TestExecutingResult.LaunchTimedOut:
                 _logger.LogError("Application launch timed out before the test execution has started");

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
@@ -121,5 +121,10 @@ public enum ExitCode
     /// <summary>
     /// The Apple app exited before the test protocol started without a matching crash report
     /// </summary>
-    APP_EXITED_BEFORE_TEST_START = 93
+    APP_EXITED_BEFORE_TEST_START = 93,
+
+    /// <summary>
+    /// The test protocol connected, but the application did not produce test results
+    /// </summary>
+    TEST_RESULTS_MISSING = 94
 }

--- a/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/CLI/ExitCode.cs
@@ -116,5 +116,10 @@ public enum ExitCode
     /// Failure when TCP tunnel between XHarness and the device fail
     /// or the device cannot connect to TCP tunnel
     /// </summary>
-    TCP_CONNECTION_FAILED = 92
+    TCP_CONNECTION_FAILED = 92,
+
+    /// <summary>
+    /// The Apple app exited before the test protocol started without a matching crash report
+    /// </summary>
+    APP_EXITED_BEFORE_TEST_START = 93
 }

--- a/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
+++ b/src/Microsoft.DotNet.XHarness.Common/RunSummaryEmitter.cs
@@ -32,11 +32,12 @@ public static class RunSummaryEmitter
         string? architecture,
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles,
-        ExecutionEnvironmentInfo? environment = null)
+        ExecutionEnvironmentInfo? environment = null,
+        IReadOnlyDictionary<string, object?>? additionalData = null)
     {
         EmitRunSummary(
             message => logger.LogInformation(message),
-            exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
+            exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment, additionalData);
     }
 
     /// <summary>
@@ -52,9 +53,10 @@ public static class RunSummaryEmitter
         string? architecture,
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles,
-        ExecutionEnvironmentInfo? environment = null)
+        ExecutionEnvironmentInfo? environment = null,
+        IReadOnlyDictionary<string, object?>? additionalData = null)
     {
-        EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
+        EmitJsonResultBlock(logInfo, exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment, additionalData);
     }
 
     /// <summary>
@@ -70,9 +72,10 @@ public static class RunSummaryEmitter
         string? architecture,
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles,
-        ExecutionEnvironmentInfo? environment = null)
+        ExecutionEnvironmentInfo? environment = null,
+        IReadOnlyDictionary<string, object?>? additionalData = null)
     {
-        var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
+        var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment, additionalData);
 
         var options = new JsonSerializerOptions
         {
@@ -98,11 +101,12 @@ public static class RunSummaryEmitter
         string? architecture,
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles,
-        ExecutionEnvironmentInfo? environment = null)
+        ExecutionEnvironmentInfo? environment = null,
+        IReadOnlyDictionary<string, object?>? additionalData = null)
     {
         try
         {
-            var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment);
+            var resultData = BuildResultData(exitCode, platform, deviceName, deviceOsVersion, architecture, instrumentationExitCode, producedFiles, environment, additionalData);
 
             var options = new JsonSerializerOptions
             {
@@ -129,7 +133,8 @@ public static class RunSummaryEmitter
         string? architecture,
         int? instrumentationExitCode,
         IReadOnlyList<DiagnosticsFile> producedFiles,
-        ExecutionEnvironmentInfo? environment)
+        ExecutionEnvironmentInfo? environment,
+        IReadOnlyDictionary<string, object?>? additionalData)
     {
         string? helixJobId = Environment.GetEnvironmentVariable("HELIX_CORRELATION_ID");
         string? helixWorkItem = Environment.GetEnvironmentVariable("HELIX_WORKITEM_FRIENDLYNAME");
@@ -192,6 +197,17 @@ public static class RunSummaryEmitter
         if (environment != null)
         {
             resultData["environment"] = environment;
+        }
+
+        if (additionalData != null)
+        {
+            foreach (var (key, value) in additionalData)
+            {
+                if (!resultData.TryAdd(key, value))
+                {
+                    throw new ArgumentException($"Additional run-summary key '{key}' conflicts with a core result field.", nameof(additionalData));
+                }
+            }
         }
 
         return resultData;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppleLaunchDiagnostics.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppleLaunchDiagnostics.cs
@@ -8,7 +8,8 @@ public sealed class AppleLaunchDiagnostics
     public string BundleId { get; set; } = string.Empty;
     public int? LauncherExitCode { get; set; }
     public int? AppExitCode { get; set; }
-    public bool? TestProtocolStarted { get; set; }
+    public bool TestProtocolExpected { get; set; } = true;
+    public bool TestProtocolConnected { get; set; }
     public bool TestEndSignalDetected { get; set; }
     public AppleTestResultFileDiagnostics TestResultFile { get; set; } = new();
     public AppleCrashReportDiagnostics CrashReport { get; set; } = new();

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/AppleLaunchDiagnostics.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/AppleLaunchDiagnostics.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.XHarness.iOS.Shared;
+
+public sealed class AppleLaunchDiagnostics
+{
+    public string BundleId { get; set; } = string.Empty;
+    public int? LauncherExitCode { get; set; }
+    public int? AppExitCode { get; set; }
+    public bool? TestProtocolStarted { get; set; }
+    public bool TestEndSignalDetected { get; set; }
+    public AppleTestResultFileDiagnostics TestResultFile { get; set; } = new();
+    public AppleCrashReportDiagnostics CrashReport { get; set; } = new();
+}
+
+public sealed class AppleTestResultFileDiagnostics
+{
+    public string Path { get; set; } = string.Empty;
+    public int CopyAttempts { get; set; }
+    public bool Exists { get; set; }
+}
+
+public sealed class AppleCrashReportDiagnostics
+{
+    public int ReportsBeforeLaunch { get; set; }
+    public int ReportsCreatedDuringRun { get; set; }
+    public AppleCrashReportMetadata? MatchedReport { get; set; }
+}
+
+public sealed class AppleCrashReportMetadata
+{
+    public string Name { get; set; } = string.Empty;
+    public string? BugType { get; set; }
+    public string? BundleId { get; set; }
+    public string? ProcessName { get; set; }
+    public int? ProcessId { get; set; }
+    public string? Timestamp { get; set; }
+    public string MatchReason { get; set; } = string.Empty;
+}

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
@@ -207,6 +207,7 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
             string content = File.ReadAllText(path);
             using var reader = new StringReader(content);
             string firstLine = reader.ReadLine();
+            string headerLine = firstLine?.TrimStart('\uFEFF', ' ', '\t');
 
             string bundleId = null;
             string processName = null;
@@ -214,10 +215,10 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
             string timestamp = null;
             int? processId = null;
 
-            if (!string.IsNullOrWhiteSpace(firstLine) &&
-                firstLine.TrimStart('\uFEFF', ' ', '\t').StartsWith("{", StringComparison.Ordinal))
+            if (!string.IsNullOrWhiteSpace(headerLine) &&
+                headerLine.StartsWith("{", StringComparison.Ordinal))
             {
-                using (JsonDocument header = JsonDocument.Parse(firstLine))
+                using (JsonDocument header = JsonDocument.Parse(headerLine))
                 {
                     JsonElement root = header.RootElement;
                     bundleId = GetString(root, "bundleID");

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/CrashSnapshotReporter.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Logging;
@@ -17,6 +18,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared;
 
 public interface ICrashSnapshotReporter
 {
+    AppleCrashReportDiagnostics CaptureDiagnostics { get; }
+
     Task EndCaptureAsync(TimeSpan timeout);
     Task StartCaptureAsync();
 }
@@ -28,15 +31,20 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
     private readonly ILogs _logs;
     private readonly bool _isDevice;
     private readonly string _deviceName;
+    private readonly AppBundleInformation _appInformation;
     private readonly Func<string> _tempFileProvider;
     private readonly string _symbolicateCrashPath;
     private HashSet<string> _initialCrashes;
+    private int _matchedReportScore;
+
+    public AppleCrashReportDiagnostics CaptureDiagnostics { get; } = new();
 
     public CrashSnapshotReporter(IMlaunchProcessManager processManager,
         ILog log,
         ILogs logs,
         bool isDevice,
         string deviceName,
+        AppBundleInformation appInformation,
         Func<string> tempFileProvider = null)
     {
         _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
@@ -44,6 +52,7 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
         _isDevice = isDevice;
         _deviceName = deviceName;
+        _appInformation = appInformation ?? throw new ArgumentNullException(nameof(appInformation));
         _tempFileProvider = tempFileProvider ?? Path.GetTempFileName;
 
         _symbolicateCrashPath = Path.Combine(processManager.XcodeRoot, "Contents", "SharedFrameworks", "DTDeviceKitBase.framework", "Versions", "A", "Resources", "symbolicatecrash");
@@ -58,7 +67,12 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
         }
     }
 
-    public async Task StartCaptureAsync() => _initialCrashes = await CreateCrashReportsSnapshotAsync();
+    public async Task StartCaptureAsync()
+    {
+        _initialCrashes = await CreateCrashReportsSnapshotAsync();
+        CaptureDiagnostics.ReportsBeforeLaunch = _initialCrashes.Count;
+        _log.WriteLine("Crash reports before launch: {0}", _initialCrashes.Count);
+    }
 
     public async Task EndCaptureAsync(TimeSpan timeout)
     {
@@ -67,20 +81,24 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
             throw new InvalidOperationException("CrashSnapshotReport capturing was ended without being started first!");
         }
 
-        _log.WriteLine($"No crash reports, waiting {(int)timeout.TotalSeconds} seconds for the crash report service...");
+        WriteInventory("crash-reports-before.txt", "Crash reports before launch", _initialCrashes);
+        _log.WriteLine($"Checking for crash reports created during this run, waiting up to {(int)timeout.TotalSeconds} seconds...");
 
         // Check for crash reports
         var stopwatch = Stopwatch.StartNew();
 
         do
         {
-            var newCrashFiles = await CreateCrashReportsSnapshotAsync();
+            var allCrashFiles = await CreateCrashReportsSnapshotAsync();
+            var newCrashFiles = new HashSet<string>(allCrashFiles);
             newCrashFiles.ExceptWith(_initialCrashes);
+            CaptureDiagnostics.ReportsCreatedDuringRun = newCrashFiles.Count;
 
             if (newCrashFiles.Count == 0)
             {
                 if (stopwatch.Elapsed.TotalSeconds > timeout.TotalSeconds)
                 {
+                    WriteInventory("crash-reports-after.txt", "Crash reports after launch", allCrashFiles);
                     break;
                 }
                 else
@@ -91,13 +109,12 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
                 continue;
             }
 
+            WriteInventory("crash-reports-after.txt", "Crash reports after launch", allCrashFiles);
             _log.WriteLine("Found {0} new crash report(s)", newCrashFiles.Count);
 
-            IEnumerable<IFileBackedLog> crashReports;
             if (!_isDevice)
             {
-                crashReports = new List<IFileBackedLog>(newCrashFiles.Count);
-                foreach (var path in newCrashFiles)
+                foreach (var path in newCrashFiles.OrderBy(path => path, StringComparer.Ordinal))
                 {
                     // It can happen that the crash log is still being written to so we have to retry
                     int retry = 1;
@@ -107,7 +124,8 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
                         {
                             var fileName = Path.GetFileName(path);
                             _log.WriteLine($"  - Adding {path}");
-                            _logs.AddFile(path, $"Crash report: {fileName}");
+                            var report = _logs.AddFile(path, $"Crash report: {fileName}");
+                            MatchCrashReport(fileName, report.FullPath);
                             _log.WriteLine($"    Successfully copied {fileName}");
                             break;
                         }
@@ -129,18 +147,10 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
             }
             else
             {
-                // Download crash reports from the device. We put them in the project directory so that they're automatically deleted on wrench
-                // (if we put them in /tmp, they'd never be deleted).
-                crashReports = newCrashFiles
-                    .Select(async crash => await ProcessCrash(crash))
-                    .Select(t => t.Result)
-                    .Where(c => c != null);
-            }
-
-            foreach (var cp in crashReports)
-            {
-                WrenchLog.WriteLine("AddFile: {0}", cp.FullPath);
-                _log.WriteLine("    {0}", cp.FullPath);
+                foreach (var crash in newCrashFiles.OrderBy(path => path, StringComparer.Ordinal))
+                {
+                    await ProcessCrash(crash);
+                }
             }
 
             break;
@@ -148,7 +158,7 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
         } while (true);
     }
 
-    private async Task<IFileBackedLog> ProcessCrash(string crashFile)
+    private async Task ProcessCrash(string crashFile)
     {
         var name = Path.GetFileName(crashFile);
         var crashReportFile = _logs.Create(name, $"Crash report: {name}", timestamp: false);
@@ -166,12 +176,176 @@ public class CrashSnapshotReporter : ICrashSnapshotReporter
         if (result.Succeeded)
         {
             _log.WriteLine("Downloaded crash report {0} to {1}", crashFile, crashReportFile.FullPath);
-            return await GetSymbolicateCrashReportAsync(crashReportFile);
+            MatchCrashReport(name, crashReportFile.FullPath);
+            var processedReport = await GetSymbolicateCrashReportAsync(crashReportFile);
+            WrenchLog.WriteLine("AddFile: {0}", processedReport.FullPath);
+            _log.WriteLine("    {0}", processedReport.FullPath);
         }
         else
         {
             _log.WriteLine("Could not download crash report {0}", crashFile);
-            return null;
+        }
+    }
+
+    private void MatchCrashReport(string name, string path)
+    {
+        var (metadata, score) = ParseCrashReportMetadata(name, path);
+        if (metadata is null || score <= _matchedReportScore)
+        {
+            return;
+        }
+
+        _matchedReportScore = score;
+        CaptureDiagnostics.MatchedReport = metadata;
+        _log.WriteLine("Matched crash report {0} to {1} ({2})", name, _appInformation.BundleIdentifier, metadata.MatchReason);
+    }
+
+    private (AppleCrashReportMetadata? Metadata, int Score) ParseCrashReportMetadata(string name, string path)
+    {
+        try
+        {
+            string content = File.ReadAllText(path);
+            using var reader = new StringReader(content);
+            string firstLine = reader.ReadLine();
+
+            string bundleId = null;
+            string processName = null;
+            string bugType = null;
+            string timestamp = null;
+            int? processId = null;
+
+            if (!string.IsNullOrWhiteSpace(firstLine) &&
+                firstLine.TrimStart('\uFEFF', ' ', '\t').StartsWith("{", StringComparison.Ordinal))
+            {
+                using (JsonDocument header = JsonDocument.Parse(firstLine))
+                {
+                    JsonElement root = header.RootElement;
+                    bundleId = GetString(root, "bundleID");
+                    processName = GetString(root, "app_name") ?? GetString(root, "name");
+                    bugType = GetString(root, "bug_type");
+                    timestamp = GetString(root, "timestamp");
+                }
+
+                string body = reader.ReadToEnd();
+                if (!string.IsNullOrWhiteSpace(body))
+                {
+                    try
+                    {
+                        using JsonDocument payload = JsonDocument.Parse(body);
+                        JsonElement root = payload.RootElement;
+                        processName ??= GetString(root, "procName");
+                        bugType ??= GetString(root, "bug_type");
+                        timestamp ??= GetString(root, "captureTime");
+                        processId = GetInt32(root, "pid");
+                        bundleId ??= GetNestedString(root, "bundleInfo", "CFBundleIdentifier");
+                    }
+                    catch (JsonException e)
+                    {
+                        _log.WriteLine("Crash report {0} has an incomplete payload: {1}", name, e.Message);
+                    }
+                }
+            }
+            else
+            {
+                foreach (string line in content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
+                {
+                    if (line.StartsWith("Identifier:", StringComparison.Ordinal))
+                    {
+                        bundleId = line.Substring("Identifier:".Length).Trim();
+                    }
+                    else if (line.StartsWith("Process:", StringComparison.Ordinal))
+                    {
+                        string process = line.Substring("Process:".Length).Trim();
+                        int pidStart = process.LastIndexOf('[');
+                        int pidEnd = process.LastIndexOf(']');
+                        processName = pidStart > 0 ? process.Substring(0, pidStart).Trim() : process;
+                        if (pidStart > 0 && pidEnd > pidStart &&
+                            int.TryParse(process.Substring(pidStart + 1, pidEnd - pidStart - 1), out int pid))
+                        {
+                            processId = pid;
+                        }
+                    }
+                    else if (line.StartsWith("Date/Time:", StringComparison.Ordinal))
+                    {
+                        timestamp = line.Substring("Date/Time:".Length).Trim();
+                    }
+                }
+            }
+
+            string expectedProcessName = _appInformation.BundleExecutable ?? _appInformation.AppName;
+            bool bundleMatches = string.Equals(bundleId, _appInformation.BundleIdentifier, StringComparison.Ordinal);
+            bool processMatches =
+                string.Equals(processName, expectedProcessName, StringComparison.Ordinal) ||
+                string.Equals(processName, _appInformation.AppName, StringComparison.Ordinal);
+            if (!bundleMatches && !processMatches)
+            {
+                return (null, 0);
+            }
+
+            int score;
+            string matchReason;
+            if (bundleMatches)
+            {
+                score = 2;
+                matchReason = "bundle identifier";
+            }
+            else
+            {
+                score = 1;
+                matchReason = "process name";
+            }
+
+            return (new AppleCrashReportMetadata
+            {
+                Name = name,
+                BugType = bugType,
+                BundleId = bundleId,
+                ProcessName = processName,
+                ProcessId = processId,
+                Timestamp = timestamp,
+                MatchReason = matchReason,
+            }, score);
+        }
+        catch (IOException e)
+        {
+            _log.WriteLine("Failed to inspect crash report {0}: {1}", name, e.Message);
+            return (null, 0);
+        }
+        catch (UnauthorizedAccessException e)
+        {
+            _log.WriteLine("Failed to inspect crash report {0}: {1}", name, e.Message);
+            return (null, 0);
+        }
+        catch (JsonException e)
+        {
+            _log.WriteLine("Failed to inspect crash report {0}: {1}", name, e.Message);
+            return (null, 0);
+        }
+    }
+
+    private static string GetString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out JsonElement property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static string GetNestedString(JsonElement element, string parentName, string propertyName)
+        => element.TryGetProperty(parentName, out JsonElement parent)
+            ? GetString(parent, propertyName)
+            : null;
+
+    private static int? GetInt32(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out JsonElement property) &&
+            property.ValueKind == JsonValueKind.Number &&
+            property.TryGetInt32(out int value)
+            ? value
+            : null;
+
+    private void WriteInventory(string fileName, string description, IEnumerable<string> reports)
+    {
+        using var inventory = _logs.Create(fileName, description, timestamp: false);
+        foreach (string report in reports.OrderBy(path => path, StringComparer.Ordinal))
+        {
+            inventory.WriteLine(report);
         }
     }
 

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/IResultFileHandler.cs
@@ -10,6 +10,8 @@ namespace Microsoft.DotNet.XHarness.iOS.Shared;
 
 public interface IResultFileHandler
 {
+    int LastCopyAttempts { get; }
+
     /// <summary>
     /// Determines whether the result file handler supports the given OS version and simulator status.
     /// </summary>
@@ -39,14 +41,4 @@ public interface IResultFileHandler
         string bundleIdentifier,
         string coverageFileName,
         string hostDestinationPath);
-
-    /// <summary>
-    /// Copy the latest crash report from the device and dumps its content to the log.
-    /// </summary>
-    Task CopyCrashReportAsync(
-        string deviceUdid,
-        string? deviceName,
-        AppBundleInformation appInformation,
-        Common.Logging.ILog outputLog,
-        bool isSimulator);
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
@@ -17,6 +17,7 @@ public interface ITestReporter : IDisposable
 {
     ILog CallbackLog { get; }
     bool? Success { get; }
+    bool TestExecutionStarted { get; }
     CancellationToken CancellationToken { get; }
 
     void LaunchCallback(Task<bool> launchResult);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ITestReporter.cs
@@ -17,7 +17,7 @@ public interface ITestReporter : IDisposable
 {
     ILog CallbackLog { get; }
     bool? Success { get; }
-    bool TestExecutionStarted { get; }
+    bool TestProtocolConnected { get; }
     CancellationToken CancellationToken { get; }
 
     void LaunchCallback(Task<bool> launchResult);

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/ResultFileHandler.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 
@@ -22,6 +21,8 @@ public class ResultFileHandler : IResultFileHandler
     private IMlaunchProcessManager _processManager;
     private IFileBackedLog _mainLog;
     private readonly int[] _retryDelaysMs;
+
+    public int LastCopyAttempts { get; private set; }
 
     public ResultFileHandler(IMlaunchProcessManager pm, IFileBackedLog fs, int[]? retryDelaysMs = null)
     {
@@ -118,7 +119,7 @@ public class ResultFileHandler : IResultFileHandler
     private bool ShouldCopyFromAppContainer(RunMode runMode, string osVersion, bool isSimulator)
         => runMode == RunMode.MacOS || IsVersionSupported(osVersion, isSimulator);
 
-    private static string GetAppContainerSourcePath(RunMode runMode, string fileName)
+    public static string GetAppContainerSourcePath(RunMode runMode, string fileName)
         => runMode is RunMode.iOS or RunMode.MacOS
             ? $"/Documents/{fileName}"
             : $"/Library/Caches/Documents/{fileName}";
@@ -132,6 +133,8 @@ public class ResultFileHandler : IResultFileHandler
         string hostDestinationPath,
         string fileDescription)
     {
+        LastCopyAttempts = 0;
+
         string copySourceDescription;
         string cmd;
         if (runMode == RunMode.MacOS)
@@ -160,6 +163,8 @@ public class ResultFileHandler : IResultFileHandler
         // (e.g., com.apple.Mercury.error 1000 or RSD error 0xE8000003 on tvOS devices).
         for (int attempt = 0; attempt <= _retryDelaysMs.Length; attempt++)
         {
+            LastCopyAttempts = attempt + 1;
+
             if (attempt > 0)
             {
                 int delayMs = _retryDelaysMs[attempt - 1];
@@ -191,99 +196,5 @@ public class ResultFileHandler : IResultFileHandler
         }
 
         return false;
-    }
-
-    public async Task CopyCrashReportAsync(
-        string deviceUdid,
-        string? deviceName,
-        AppBundleInformation appInformation,
-        ILog outputLog,
-        bool isSimulator)
-    {
-        _mainLog.WriteLine("Attempting to retrieve crash report from device...");
-
-        // List all crash reports on the device
-        string tempCrashListFile = Path.GetTempFileName();
-
-        MlaunchArguments listArgs = new MlaunchArguments(new ListCrashReportsArgument(tempCrashListFile));
-
-        if (!string.IsNullOrEmpty(deviceName))
-        {
-            listArgs.Add(new DeviceNameArgument(deviceName));
-        }
-
-        ProcessExecutionResult listResult = await _processManager.ExecuteCommandAsync(
-            listArgs,
-            _mainLog,
-            TimeSpan.FromMinutes(1));
-
-        if (!listResult.Succeeded || !File.Exists(tempCrashListFile))
-        {
-            _mainLog.WriteLine("Failed to list crash reports from device.");
-            return;
-        }
-
-        List<string> crashReports = File.ReadAllLines(tempCrashListFile)
-            .Where(line => !string.IsNullOrWhiteSpace(line))
-            .ToList();
-
-        if (crashReports.Count == 0)
-        {
-            _mainLog.WriteLine("No crash reports found on device.");
-            return;
-        }
-
-        // Filter for crash reports that might be related to our app
-        // .ips files typically follow the format: AppName-YYYY-MM-DD-HHMMSS.ips or similar
-        List<string> appRelatedCrashes = crashReports
-            .Where(crash => crash.Contains(appInformation.AppName, StringComparison.OrdinalIgnoreCase) ||
-                            crash.EndsWith(".ips", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        // Use the last crash report (most recent) from the filtered list
-        string latestCrashReport = (appRelatedCrashes.Count > 0 ? appRelatedCrashes : crashReports).Last();
-
-        _mainLog.WriteLine($"Found crash report: {latestCrashReport}");
-
-        // Download the crash report
-        string? uploadRoot = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
-        string crashReportContent;
-
-        if (!string.IsNullOrEmpty(uploadRoot) && Directory.Exists(uploadRoot))
-        {
-            string crashFileName = Path.GetFileName(latestCrashReport);
-            crashReportContent = Path.Combine(uploadRoot, crashFileName);
-        }
-        else
-        {
-            crashReportContent = Path.GetTempFileName();
-        }
-
-        MlaunchArguments downloadArgs = new MlaunchArguments(
-            new DownloadCrashReportArgument(latestCrashReport),
-            new DownloadCrashReportToArgument(crashReportContent));
-
-        if (!string.IsNullOrEmpty(deviceName))
-        {
-            downloadArgs.Add(new DeviceNameArgument(deviceName));
-        }
-
-        ProcessExecutionResult downloadResult = await _processManager.ExecuteCommandAsync(
-            downloadArgs,
-            _mainLog,
-            TimeSpan.FromMinutes(1));
-
-        if (!downloadResult.Succeeded || !File.Exists(crashReportContent))
-        {
-            _mainLog.WriteLine("Failed to download crash report from device.");
-            return;
-        }
-
-        // Dump the crash report content to the log
-        _mainLog.WriteLine($"==================== Crash report ====================");
-        _mainLog.WriteLine($"Crash report file: {crashReportContent}");
-        string crashContent = await File.ReadAllTextAsync(crashReportContent);
-        _mainLog.WriteLine(crashContent);
-        _mainLog.WriteLine($"==================== End of Crash report ====================");
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
@@ -39,4 +39,5 @@ public enum TestExecutingResult
     // Other results
     BuildSucceeded = 0x10000 | Succeeded,
     LaunchTimedOut = 0x20000 | LaunchFailure | TimedOut,
+    AppExitedBeforeTestStart = 0x40000 | Failed,
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestExecutingResult.cs
@@ -40,4 +40,5 @@ public enum TestExecutingResult
     BuildSucceeded = 0x10000 | Succeeded,
     LaunchTimedOut = 0x20000 | LaunchFailure | TimedOut,
     AppExitedBeforeTestStart = 0x40000 | Failed,
+    TestResultsMissing = 0x80000 | Failed,
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -6,11 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.Serialization.Json;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using Microsoft.DotNet.XHarness.Common;
 using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
@@ -36,7 +33,6 @@ public class TestReporter : ITestReporter
 
     private readonly ISimpleListener _listener;
     private readonly IFileBackedLog _mainLog;
-    private readonly ILogs _crashLogs;
     private readonly IReadableLog _runLog;
     private readonly ILogs _logs;
     private readonly ICrashSnapshotReporter _crashReporter;
@@ -60,8 +56,6 @@ public class TestReporter : ITestReporter
     /// <summary>
     /// Callback needed for the Xamarin.Xharness project that does extra logging in case of a crash.
     /// </summary>
-    private readonly ExceptionLogger? _exceptionLogger;
-
     private bool _waitedForExit = true;
     private bool _launchFailure;
     private bool _isSimulatorTest;
@@ -76,7 +70,7 @@ public class TestReporter : ITestReporter
 
     public bool ResultsUseXml => _xmlJargon != XmlResultJargon.Missing;
 
-    private bool TestExecutionStarted => _listener.ConnectedTask.IsCompletedSuccessfully && _listener.ConnectedTask.Result;
+    public bool TestExecutionStarted => _listener.ConnectedTask.IsCompletedSuccessfully && _listener.ConnectedTask.Result;
 
     public TestReporter(
         IMlaunchProcessManager processManager,
@@ -102,14 +96,12 @@ public class TestReporter : ITestReporter
         _runLog = runLog ?? throw new ArgumentNullException(nameof(runLog));
         _logs = logs ?? throw new ArgumentNullException(nameof(logs));
         _crashReporter = crashReporter ?? throw new ArgumentNullException(nameof(crashReporter));
-        _crashLogs = new Logs(logs.Directory);
         _resultParser = parser ?? throw new ArgumentNullException(nameof(parser));
         _appInfo = appInformation ?? throw new ArgumentNullException(nameof(appInformation));
         _runMode = runMode;
         _xmlJargon = xmlJargon;
         _timeout = timeout;
         _additionalLogsDirectory = additionalLogsDirectory;
-        _exceptionLogger = exceptionLogger;
         _timeoutWatch = Stopwatch.StartNew();
         _generateHtml = generateHtml;
 
@@ -132,7 +124,12 @@ public class TestReporter : ITestReporter
     {
         int pid = -1;
 
-        using var reader = _runLog.GetReader(); // diposed at the end of the method, which is what we want
+        using var reader = _runLog.GetReader();
+        if (reader is null)
+        {
+            return pid;
+        }
+
         if (reader.Peek() == -1)
         {
             // Empty file! If the app never connected to our listener, it probably never launched
@@ -170,55 +167,6 @@ public class TestReporter : ITestReporter
         }
 
         return pid;
-    }
-
-    /// <summary>
-    /// Parse the main log to get the pid
-    /// </summary>
-    private async Task<int> GetPidFromMainLog()
-    {
-        int pid = -1;
-        using var log_reader = _mainLog.GetReader(); // dispose when we leave the method, which is what we want
-        string? line;
-        while ((line = await log_reader.ReadLineAsync()) != null)
-        {
-            const string str = "was launched with pid '";
-            var idx = line.IndexOf(str, StringComparison.Ordinal);
-            if (idx > 0)
-            {
-                idx += str.Length;
-                var next_idx = line.IndexOf('\'', idx);
-                if (next_idx > idx)
-                {
-                    int.TryParse(line.Substring(idx, next_idx - idx), out pid);
-                }
-            }
-            if (pid != -1)
-            {
-                return pid;
-            }
-        }
-        return pid;
-    }
-
-    /// <summary>
-    /// Return the reason for a crash found in a log
-    /// </summary>
-    private void GetCrashReason(int pid, IReadableLog crashLog, out string? crashReason)
-    {
-        crashReason = null;
-        using var crashReader = crashLog.GetReader(); // dispose when we leave the method
-        var text = crashReader.ReadToEnd();
-
-        var reader = JsonReaderWriterFactory.CreateJsonReader(Encoding.UTF8.GetBytes(text), new XmlDictionaryReaderQuotas());
-        var doc = new XmlDocument();
-        doc.Load(reader);
-        foreach (XmlNode? node in doc.SelectNodes($"/root/processes/item[pid = '" + pid + "']"))
-        {
-            Console.WriteLine(node?.InnerXml);
-            Console.WriteLine(node?.SelectSingleNode("reason")?.InnerText);
-            crashReason = node?.SelectSingleNode("reason")?.InnerText;
-        }
     }
 
     /// <summary>
@@ -397,7 +345,7 @@ public class TestReporter : ITestReporter
                 {
                     var logFiles = new List<string>();
                     // add our logs AND the logs of the previous task, which is the build task
-                    logFiles.AddRange(Directory.GetFiles(_crashLogs.Directory));
+                    logFiles.AddRange(Directory.GetFiles(_logs.Directory));
                     if (_additionalLogsDirectory != null) // when using the run command, we do not have a build task, ergo, there are no logs to add.
                     {
                         logFiles.AddRange(Directory.GetFiles(_additionalLogsDirectory));
@@ -582,6 +530,8 @@ public class TestReporter : ITestReporter
     {
         (TestExecutingResult ExecutingResult, string? ResultMessage) result = (ExecutingResult: TestExecutingResult.Finished, ResultMessage: null);
         var crashed = false;
+        var missingResultFile = false;
+        var appExitedBeforeTestStart = false;
         if (File.Exists(_listener.TestLog.FullPath))
         {
             WrenchLog.WriteLine("AddFile: {0}", _listener.TestLog.FullPath);
@@ -614,10 +564,10 @@ public class TestReporter : ITestReporter
         }
         else
         {
-            WrenchLog.WriteLine("AddSummary: <b><i>{0} crashed at startup (no log)</i></b><br/>", _runMode);
-            _mainLog.WriteLine("Test run started but crashed and no test results were reported");
+            WrenchLog.WriteLine("AddSummary: <b><i>{0} exited without test results</i></b><br/>", _runMode);
+            _mainLog.WriteLine("The application exited without producing test results");
             result.ResultMessage = "No test log file was produced";
-            crashed = true;
+            missingResultFile = true;
             Success = false;
         }
 
@@ -632,12 +582,31 @@ public class TestReporter : ITestReporter
             crashLogWaitTime = 5;
         }
 
-        if (crashed)
+        if (crashed || missingResultFile)
         {
             crashLogWaitTime = 30;
         }
 
         await _crashReporter.EndCaptureAsync(TimeSpan.FromSeconds(crashLogWaitTime));
+
+        if (missingResultFile)
+        {
+            AppleCrashReportDiagnostics? crashDiagnostics = _crashReporter.CaptureDiagnostics;
+            if (!TestExecutionStarted && crashDiagnostics?.MatchedReport is null)
+            {
+                appExitedBeforeTestStart = true;
+                result.ResultMessage = "App exited before the test protocol started and no matching crash report was found";
+                _mainLog.WriteLine(result.ResultMessage);
+            }
+            else
+            {
+                crashed = true;
+                result.ResultMessage = crashDiagnostics?.MatchedReport is null
+                    ? "Test run started but no test results were reported"
+                    : $"Application crash matched report '{crashDiagnostics.MatchedReport.Name}'";
+                _mainLog.WriteLine(result.ResultMessage);
+            }
+        }
 
         if (_timedout)
         {
@@ -654,6 +623,10 @@ public class TestReporter : ITestReporter
         {
             result.ExecutingResult = TestExecutingResult.LaunchFailure;
         }
+        else if (appExitedBeforeTestStart)
+        {
+            result.ExecutingResult = TestExecutingResult.AppExitedBeforeTestStart;
+        }
         else if (crashed)
         {
             result.ExecutingResult = TestExecutingResult.Crashed;
@@ -667,55 +640,14 @@ public class TestReporter : ITestReporter
             result.ExecutingResult = TestExecutingResult.Failed;
         }
 
-        // Check crash reports to see if any of them explains why the test run crashed.
         if (!Success.Value)
         {
-            int pid = -1;
-            string? crashReason = null;
-            foreach (var crashLog in _crashLogs)
+            if (_launchFailure)
             {
-                try
-                {
-                    _logs.Add(crashLog);
-
-                    if (pid == -1)
-                    {
-                        // Find the pid
-                        pid = await GetPidFromMainLog();
-                    }
-
-                    GetCrashReason(pid, crashLog, out crashReason);
-                    if (crashReason != null)
-                    {
-                        break;
-                    }
-                }
-                catch (Exception e)
-                {
-                    var message = string.Format("Failed to process crash report '{1}': {0}", e.Message, crashLog.Description);
-                    _mainLog.WriteLine(message);
-                    _exceptionLogger?.Invoke(2, message);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(crashReason))
-            {
-                if (crashReason == "per-process-limit")
-                {
-                    result.ResultMessage = "Killed due to using too much memory (per-process-limit).";
-                }
-                else
-                {
-                    result.ResultMessage = $"Killed by the OS ({crashReason})";
-                }
-            }
-            else if (_launchFailure)
-            {
-                // same as with a crash
                 result.ResultMessage = $"Launch failure";
             }
 
-            await GenerateXmlFailures(result.ResultMessage, crashed, crashReason);
+            await GenerateXmlFailures(result.ResultMessage, crashed, crashReason: null);
         }
 
         return result;
@@ -723,7 +655,6 @@ public class TestReporter : ITestReporter
 
     public void Dispose()
     {
-        _crashLogs.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporter.cs
@@ -16,8 +16,6 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.XmlResults;
-using ExceptionLogger = System.Action<int, string>;
-
 #nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared;
 
@@ -53,9 +51,6 @@ public class TestReporter : ITestReporter
 
     private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-    /// <summary>
-    /// Callback needed for the Xamarin.Xharness project that does extra logging in case of a crash.
-    /// </summary>
     private bool _waitedForExit = true;
     private bool _launchFailure;
     private bool _isSimulatorTest;
@@ -70,7 +65,7 @@ public class TestReporter : ITestReporter
 
     public bool ResultsUseXml => _xmlJargon != XmlResultJargon.Missing;
 
-    public bool TestExecutionStarted => _listener.ConnectedTask.IsCompletedSuccessfully && _listener.ConnectedTask.Result;
+    public bool TestProtocolConnected => _listener.ConnectedTask.IsCompletedSuccessfully && _listener.ConnectedTask.Result;
 
     public TestReporter(
         IMlaunchProcessManager processManager,
@@ -86,7 +81,6 @@ public class TestReporter : ITestReporter
         string? device,
         TimeSpan timeout,
         string? additionalLogsDirectory = null,
-        ExceptionLogger? exceptionLogger = null,
         bool generateHtml = false)
     {
         _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
@@ -125,11 +119,6 @@ public class TestReporter : ITestReporter
         int pid = -1;
 
         using var reader = _runLog.GetReader();
-        if (reader is null)
-        {
-            return pid;
-        }
-
         if (reader.Peek() == -1)
         {
             // Empty file! If the app never connected to our listener, it probably never launched
@@ -247,7 +236,7 @@ public class TestReporter : ITestReporter
         _cancellationTokenSource.Cancel();
         _timedout = true;
 
-        if (TestExecutionStarted)
+        if (TestProtocolConnected)
         {
             _mainLog.WriteLine($"Test execution timed out after {_timeoutWatch.Elapsed.TotalMinutes:0.##} minutes");
             return;
@@ -455,27 +444,12 @@ public class TestReporter : ITestReporter
     }
 
     /// <summary>
-    /// Generate all the xml failures that will help the integration with the CI and return the failure reason
+    /// Generate XML failures for CI integration.
     /// </summary>
-    private async Task GenerateXmlFailures(string failure, bool crashed, string? crashReason)
+    private async Task GenerateXmlFailures(string failure, bool crashed)
     {
         if (!ResultsUseXml) // nothing to do
         {
-            return;
-        }
-
-        if (!string.IsNullOrEmpty(crashReason))
-        {
-            _resultParser.GenerateFailure(
-                _logs,
-                "crash",
-                _appInfo.AppName,
-                _appInfo.Variation,
-                $"App Crash {_appInfo.AppName} {_appInfo.Variation}",
-                $"App crashed: {failure}",
-                _mainLog.FullPath,
-                _xmlJargon);
-
             return;
         }
 
@@ -494,7 +468,7 @@ public class TestReporter : ITestReporter
             return;
         }
 
-        if (!_isSimulatorTest && crashed && string.IsNullOrEmpty(crashReason))
+        if (!_isSimulatorTest && crashed)
         {
             // this happens more that what we would like on devices, the main reason most of the time is that we have had netwoking problems and the
             // tcp connection could not be stablished. We are going to report it as an error since we have not parsed the logs, evne when the app might have
@@ -532,6 +506,7 @@ public class TestReporter : ITestReporter
         var crashed = false;
         var missingResultFile = false;
         var appExitedBeforeTestStart = false;
+        var testResultsMissing = false;
         if (File.Exists(_listener.TestLog.FullPath))
         {
             WrenchLog.WriteLine("AddFile: {0}", _listener.TestLog.FullPath);
@@ -592,25 +567,29 @@ public class TestReporter : ITestReporter
         if (missingResultFile)
         {
             AppleCrashReportDiagnostics? crashDiagnostics = _crashReporter.CaptureDiagnostics;
-            if (!TestExecutionStarted && crashDiagnostics?.MatchedReport is null)
+            if (crashDiagnostics?.MatchedReport is not null)
+            {
+                crashed = true;
+                result.ResultMessage = $"Application crash matched report '{crashDiagnostics.MatchedReport.Name}'";
+                _mainLog.WriteLine(result.ResultMessage);
+            }
+            else if (!TestProtocolConnected)
             {
                 appExitedBeforeTestStart = true;
-                result.ResultMessage = "App exited before the test protocol started and no matching crash report was found";
+                result.ResultMessage = "App exited without evidence that the test run started and no matching crash report was found";
                 _mainLog.WriteLine(result.ResultMessage);
             }
             else
             {
-                crashed = true;
-                result.ResultMessage = crashDiagnostics?.MatchedReport is null
-                    ? "Test run started but no test results were reported"
-                    : $"Application crash matched report '{crashDiagnostics.MatchedReport.Name}'";
+                testResultsMissing = true;
+                result.ResultMessage = "Test protocol connected but no test results were reported";
                 _mainLog.WriteLine(result.ResultMessage);
             }
         }
 
         if (_timedout)
         {
-            if (TestExecutionStarted)
+            if (TestProtocolConnected)
             {
                 result.ExecutingResult = TestExecutingResult.TimedOut;
             }
@@ -631,6 +610,10 @@ public class TestReporter : ITestReporter
         {
             result.ExecutingResult = TestExecutingResult.Crashed;
         }
+        else if (testResultsMissing)
+        {
+            result.ExecutingResult = TestExecutingResult.TestResultsMissing;
+        }
         else if (Success.Value)
         {
             result.ExecutingResult = TestExecutingResult.Succeeded;
@@ -647,7 +630,7 @@ public class TestReporter : ITestReporter
                 result.ResultMessage = $"Launch failure";
             }
 
-            await GenerateXmlFailures(result.ResultMessage, crashed, crashReason: null);
+            await GenerateXmlFailures(result.ResultMessage, crashed);
         }
 
         return result;

--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/TestReporterFactory.cs
@@ -9,8 +9,6 @@ using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 
-using ExceptionLogger = System.Action<int, string>;
-
 #nullable enable
 namespace Microsoft.DotNet.XHarness.iOS.Shared;
 
@@ -28,7 +26,6 @@ public interface ITestReporterFactory
         string? device,
         TimeSpan timeout,
         string? additionalLogsDirectory = null,
-        ExceptionLogger? exceptionLogger = null,
         bool generateHtml = false);
 }
 
@@ -53,7 +50,6 @@ public class TestReporterFactory : ITestReporterFactory
         string? device,
         TimeSpan timeout,
         string? additionalLogsDirectory = null,
-        ExceptionLogger? exceptionLogger = null,
         bool generateHtml = false) => new TestReporter(_processManager,
             mainLog,
             runLog,
@@ -67,7 +63,5 @@ public class TestReporterFactory : ITestReporterFactory
             device,
             timeout,
             additionalLogsDirectory,
-            exceptionLogger,
             generateHtml);
 }
-

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -195,7 +195,8 @@ public class InstrumentationRunnerSummaryTests
                 bundleId = "net.dot.Tests",
                 launcherExitCode = 1,
                 appExitCode = 1,
-                testProtocolStarted = false,
+                testProtocolExpected = false,
+                testProtocolConnected = false,
                 testResultFile = new
                 {
                     path = "/Documents/test-results.xml",
@@ -224,7 +225,8 @@ public class InstrumentationRunnerSummaryTests
         var appleLaunch = ExtractJsonFromLogs().GetProperty("appleLaunch");
         Assert.Equal("net.dot.Tests", appleLaunch.GetProperty("bundleId").GetString());
         Assert.Equal(1, appleLaunch.GetProperty("appExitCode").GetInt32());
-        Assert.False(appleLaunch.GetProperty("testProtocolStarted").GetBoolean());
+        Assert.False(appleLaunch.GetProperty("testProtocolExpected").GetBoolean());
+        Assert.False(appleLaunch.GetProperty("testProtocolConnected").GetBoolean());
         Assert.Equal(4, appleLaunch.GetProperty("testResultFile").GetProperty("copyAttempts").GetInt32());
         Assert.Equal(12, appleLaunch.GetProperty("crashReport").GetProperty("reportsBeforeLaunch").GetInt32());
         Assert.Equal("APP_EXITED_BEFORE_TEST_START", ExtractJsonFromLogs().GetProperty("exitCodeName").GetString());

--- a/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Android.Tests/InstrumentationRunnerSummaryTests.cs
@@ -185,6 +185,51 @@ public class InstrumentationRunnerSummaryTests
         Assert.Equal(35, environmentJson.GetProperty("target").GetProperty("apiLevel").GetInt32());
     }
 
+    [Fact]
+    public void EmitJsonResultBlock_ContainsAdditionalData()
+    {
+        var additionalData = new Dictionary<string, object?>
+        {
+            ["appleLaunch"] = new
+            {
+                bundleId = "net.dot.Tests",
+                launcherExitCode = 1,
+                appExitCode = 1,
+                testProtocolStarted = false,
+                testResultFile = new
+                {
+                    path = "/Documents/test-results.xml",
+                    copyAttempts = 4,
+                    exists = false,
+                },
+                crashReport = new
+                {
+                    reportsBeforeLaunch = 12,
+                    reportsCreatedDuringRun = 0,
+                },
+            },
+        };
+
+        RunSummaryEmitter.EmitRunSummary(
+            _mockLogger.Object,
+            ExitCode.APP_EXITED_BEFORE_TEST_START,
+            "apple",
+            "iPhone",
+            "iOS 18",
+            null,
+            null,
+            new List<DiagnosticsFile>(),
+            additionalData: additionalData);
+
+        var appleLaunch = ExtractJsonFromLogs().GetProperty("appleLaunch");
+        Assert.Equal("net.dot.Tests", appleLaunch.GetProperty("bundleId").GetString());
+        Assert.Equal(1, appleLaunch.GetProperty("appExitCode").GetInt32());
+        Assert.False(appleLaunch.GetProperty("testProtocolStarted").GetBoolean());
+        Assert.Equal(4, appleLaunch.GetProperty("testResultFile").GetProperty("copyAttempts").GetInt32());
+        Assert.Equal(12, appleLaunch.GetProperty("crashReport").GetProperty("reportsBeforeLaunch").GetInt32());
+        Assert.Equal("APP_EXITED_BEFORE_TEST_START", ExtractJsonFromLogs().GetProperty("exitCodeName").GetString());
+    }
+
     private JsonElement ExtractJsonFromLogs()
     {
         var jsonMessage = _loggedMessages.Find(m => m.Contains("<<XHARNESS_RESULT_START>>"));

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -253,6 +253,14 @@ public class AppTesterTests : AppRunTestBase
             .Setup(f => f.UseTunnel)
             .Returns(useTunnel);
 
+        string appOutputPath = _appLog.FullPath;
+        File.WriteAllText(
+            appOutputPath,
+            $"The app '{AppBundleIdentifier}' exited with exit code 7{Environment.NewLine}");
+        Mock.Get(_appLog)
+            .Setup(l => l.GetReader())
+            .Returns(() => new StreamReader(File.OpenRead(appOutputPath)));
+
         // Act
         var appTester = new AppTester(
             _processManager.Object,
@@ -280,6 +288,9 @@ public class AppTesterTests : AppRunTestBase
         // Verify
         Assert.Equal(TestExecutingResult.Succeeded, result);
         Assert.Equal("Tests run: 1194 Passed: 1191 Inconclusive: 0 Failed: 0 Ignored: 0", resultMessage);
+        Assert.NotNull(appTester.LaunchDiagnostics);
+        Assert.Equal(0, appTester.LaunchDiagnostics!.LauncherExitCode);
+        Assert.Equal(7, appTester.LaunchDiagnostics.AppExitCode);
 
         var expectedArgs = GetExpectedDeviceMlaunchArgs(
             useTunnel: useTunnel,
@@ -312,6 +323,7 @@ public class AppTesterTests : AppRunTestBase
         _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);
 
         deviceSystemLog.Verify(x => x.Dispose(), Times.AtLeastOnce);
+        File.Delete(appOutputPath);
     }
 
     [Theory]

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/AppOperations/AppTesterTests.cs
@@ -12,6 +12,7 @@ using Microsoft.DotNet.XHarness.Common.Execution;
 using Microsoft.DotNet.XHarness.Common.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared;
 using Microsoft.DotNet.XHarness.iOS.Shared.Execution;
+using Microsoft.DotNet.XHarness.iOS.Shared.Hardware;
 using Microsoft.DotNet.XHarness.iOS.Shared.Listeners;
 using Microsoft.DotNet.XHarness.iOS.Shared.Logging;
 using Microsoft.DotNet.XHarness.iOS.Shared.XmlResults;
@@ -217,10 +218,18 @@ public class AppTesterTests : AppRunTestBase
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public async Task TestOnDeviceTest(bool useTunnel)
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task TestOnDeviceTest(bool useTunnel, bool useContainerResultCopy)
     {
+        string osVersion = useContainerResultCopy ? "18.0" : "13.0";
+        IHardwareDevice device = Mock.Of<IHardwareDevice>(x =>
+            x.DeviceIdentifier == s_mockDevice.DeviceIdentifier &&
+            x.UDID == s_mockDevice.UDID &&
+            x.Name == s_mockDevice.Name &&
+            x.OSVersion == osVersion &&
+            x.InterfaceType == "Usb");
         var deviceSystemLog = new Mock<IFileBackedLog>();
         deviceSystemLog.SetupGet(x => x.FullPath).Returns(Path.GetTempFileName());
 
@@ -228,12 +237,13 @@ public class AppTesterTests : AppRunTestBase
 
         var deviceLogCapturerFactory = new Mock<IDeviceLogCapturerFactory>();
         deviceLogCapturerFactory
-            .Setup(x => x.Create(_mainLog.Object, deviceSystemLog.Object, s_mockDevice.UDID))
+            .Setup(x => x.Create(_mainLog.Object, deviceSystemLog.Object, device.UDID))
             .Returns(deviceLogCapturer.Object);
 
         var testResultFilePath = Path.GetTempFileName();
         var listenerLogFile = Mock.Of<IFileBackedLog>(x => x.FullPath == testResultFilePath);
         File.WriteAllLines(testResultFilePath, new[] { "Some result here", "Tests run: 124", "Some result there" });
+        _listener.SetupGet(x => x.TestLog).Returns(listenerLogFile);
 
         _logs
             .Setup(x => x.Create("test-ios-device-mocked_timestamp.log", "TestLog", It.IsAny<bool?>()))
@@ -277,7 +287,7 @@ public class AppTesterTests : AppRunTestBase
         var (result, resultMessage) = await appTester.TestApp(
             _appBundleInfo,
             new TestTargetOs(TestTarget.Device_iOS, null),
-            s_mockDevice,
+            device,
             null,
             timeout: TimeSpan.FromSeconds(30),
             testLaunchTimeout: TimeSpan.FromSeconds(30),
@@ -291,6 +301,10 @@ public class AppTesterTests : AppRunTestBase
         Assert.NotNull(appTester.LaunchDiagnostics);
         Assert.Equal(0, appTester.LaunchDiagnostics!.LauncherExitCode);
         Assert.Equal(7, appTester.LaunchDiagnostics.AppExitCode);
+        Assert.Equal(!useContainerResultCopy, appTester.LaunchDiagnostics.TestProtocolExpected);
+        Assert.False(appTester.LaunchDiagnostics.TestProtocolConnected);
+        Assert.Equal(useContainerResultCopy ? 1 : 0, appTester.LaunchDiagnostics.TestResultFile.CopyAttempts);
+        Assert.True(appTester.LaunchDiagnostics.TestResultFile.Exists);
 
         var expectedArgs = GetExpectedDeviceMlaunchArgs(
             useTunnel: useTunnel,
@@ -317,7 +331,7 @@ public class AppTesterTests : AppRunTestBase
         // we dont want to leak a process
         if (useTunnel)
         {
-            _tunnelBore.Verify(t => t.Close(s_mockDevice.DeviceIdentifier));
+            _tunnelBore.Verify(t => t.Close(device.DeviceIdentifier));
         }
 
         _snapshotReporter.Verify(x => x.StartCaptureAsync(), Times.AtLeastOnce);

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
@@ -185,6 +185,63 @@ public class TestOrchestratorTests : OrchestratorTestBase
     }
 
     [Fact]
+    public async Task OrchestrateAppExitedBeforeTestStartReturnsDistinctExitCode()
+    {
+        var testTarget = new TestTargetOs(TestTarget.Device_iOS, "14.2");
+        var launchDiagnostics = new AppleLaunchDiagnostics
+        {
+            BundleId = BundleIdentifier,
+            LauncherExitCode = 1,
+            AppExitCode = 1,
+            TestResultFile = new AppleTestResultFileDiagnostics
+            {
+                Path = "/Documents/test-results.xml",
+                CopyAttempts = 4,
+            },
+        };
+
+        _appTester.SetupGet(x => x.LaunchDiagnostics).Returns(launchDiagnostics);
+        _appTester
+            .Setup(x => x.TestApp(
+                _appBundleInformation,
+                testTarget,
+                _device.Object,
+                null,
+                TimeSpan.FromMinutes(30),
+                It.IsAny<TimeSpan>(),
+                false,
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<IEnumerable<(string, string?)>>(),
+                It.IsAny<XmlResultJargon>(),
+                It.IsAny<string[]?>(),
+                It.IsAny<string[]?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                TestExecutingResult.AppExitedBeforeTestStart,
+                "App exited before the test protocol started and no matching crash report was found"));
+
+        var result = await _testOrchestrator.OrchestrateTest(
+            AppPath,
+            testTarget,
+            DeviceName,
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(3),
+            CommunicationChannel.UsbTunnel,
+            XmlResultJargon.xUnit,
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            includeWirelessDevices: false,
+            resetSimulator: false,
+            enableLldb: false,
+            signalAppEnd: false,
+            Array.Empty<(string, string?)>(),
+            Array.Empty<string>(),
+            CancellationToken.None);
+
+        Assert.Equal(ExitCode.APP_EXITED_BEFORE_TEST_START, result);
+    }
+
+    [Fact]
     public async Task OrchestrateFailedSimulatorTestTest()
     {
         // Setup
@@ -474,8 +531,10 @@ public class TestOrchestratorTests : OrchestratorTestBase
         _appUninstaller.VerifyNoOtherCalls();
     }
 
-    [Fact]
-    public async Task OrchestrateDeviceTestWithFailingTcpTest()
+    [Theory]
+    [InlineData(TestExecutingResult.Crashed)]
+    [InlineData(TestExecutingResult.AppExitedBeforeTestStart)]
+    public async Task OrchestrateDeviceTestWithFailingTcpTest(TestExecutingResult testExecutingResult)
     {
         // Setup
         var testTarget = new TestTargetOs(TestTarget.Device_iOS, "14.2");
@@ -497,7 +556,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 It.IsAny<string[]?>(),
                 It.IsAny<string[]?>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((TestExecutingResult.Crashed, "Test execution timed out"))
+            .ReturnsAsync((testExecutingResult, "Test execution timed out"))
             .Verifiable();
 
         _appTester

--- a/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.Apple.Tests/Orchestration/TestOrchestratorTests.cs
@@ -184,8 +184,12 @@ public class TestOrchestratorTests : OrchestratorTestBase
         _appTester.VerifyAll();
     }
 
-    [Fact]
-    public async Task OrchestrateAppExitedBeforeTestStartReturnsDistinctExitCode()
+    [Theory]
+    [InlineData(TestExecutingResult.AppExitedBeforeTestStart, ExitCode.APP_EXITED_BEFORE_TEST_START)]
+    [InlineData(TestExecutingResult.TestResultsMissing, ExitCode.TEST_RESULTS_MISSING)]
+    public async Task OrchestrateMissingTestResultsReturnsSpecificExitCode(
+        TestExecutingResult testExecutingResult,
+        ExitCode expectedExitCode)
     {
         var testTarget = new TestTargetOs(TestTarget.Device_iOS, "14.2");
         var launchDiagnostics = new AppleLaunchDiagnostics
@@ -216,9 +220,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
                 It.IsAny<string[]?>(),
                 It.IsAny<string[]?>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((
-                TestExecutingResult.AppExitedBeforeTestStart,
-                "App exited before the test protocol started and no matching crash report was found"));
+            .ReturnsAsync((testExecutingResult, "No test results were reported"));
 
         var result = await _testOrchestrator.OrchestrateTest(
             AppPath,
@@ -238,7 +240,7 @@ public class TestOrchestratorTests : OrchestratorTestBase
             Array.Empty<string>(),
             CancellationToken.None);
 
-        Assert.Equal(ExitCode.APP_EXITED_BEFORE_TEST_START, result);
+        Assert.Equal(expectedExitCode, result);
     }
 
     [Fact]

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
@@ -51,17 +51,25 @@ public class CrashReportSnapshotTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    [Fact]
-    public async Task DeviceCaptureTest()
+    [Theory]
+    [InlineData("{\"captureTime\":\"2026-08-24 14:00:00.00 +0200\",\"pid\":42,\"procName\":\"Sample-iPhone\",\"bundleInfo\":{\"CFBundleIdentifier\":\"com.example.sample\"}}", 42)]
+    [InlineData("{", null)]
+    public async Task DeviceCaptureTest(string payload, int? expectedProcessId)
     {
         var tempFilePath = Path.GetTempFileName();
 
         const string deviceName = "Sample-iPhone";
-        const string crashLogPath = "/path/to/crash.log";
-        const string symbolicateLogPath = "/path/to/" + deviceName + ".symbolicated.log";
+        string crashLogPath = Path.Combine(_tempXcodeRoot, "crash.log");
+        string symbolicateLogPath = Path.Combine(_tempXcodeRoot, "crash.symbolicated.log");
 
         var crashReport = Mock.Of<IFileBackedLog>(x => x.FullPath == crashLogPath);
         var symbolicateReport = Mock.Of<IFileBackedLog>(x => x.FullPath == symbolicateLogPath);
+        var inventoryLog = Mock.Of<IFileBackedLog>();
+
+        _logs.Setup(x => x.Create("crash-reports-before.txt", "Crash reports before launch", false))
+            .Returns(inventoryLog);
+        _logs.Setup(x => x.Create("crash-reports-after.txt", "Crash reports after launch", false))
+            .Returns(inventoryLog);
 
         // Crash report is added
         _logs.Setup(x => x.Create(deviceName, "Crash report: " + deviceName, It.IsAny<bool>()))
@@ -79,6 +87,7 @@ public class CrashReportSnapshotTests : IDisposable
             _logs.Object,
             true,
             deviceName,
+            new AppBundleInformation(deviceName, "com.example.sample", "/tmp", "/tmp", supports32b: false),
             () => tempFilePath);
 
         File.WriteAllLines(tempFilePath, new[] { "crash 1", "crash 2" });
@@ -86,11 +95,21 @@ public class CrashReportSnapshotTests : IDisposable
         await snapshotReport.StartCaptureAsync();
 
         File.WriteAllLines(tempFilePath, new[] { "Sample-iPhone" });
+        File.WriteAllText(
+            crashLogPath,
+            "{\"app_name\":\"Sample-iPhone\",\"timestamp\":\"2026-08-24 14:00:00.00 +0200\",\"bundleID\":\"com.example.sample\",\"bug_type\":\"309\"}" +
+            Environment.NewLine +
+            payload);
 
         await snapshotReport.EndCaptureAsync(TimeSpan.FromSeconds(10));
 
         // Verify
         _logs.VerifyAll();
+        Assert.Equal(2, snapshotReport.CaptureDiagnostics.ReportsBeforeLaunch);
+        Assert.Equal(1, snapshotReport.CaptureDiagnostics.ReportsCreatedDuringRun);
+        Assert.Equal("Sample-iPhone", snapshotReport.CaptureDiagnostics.MatchedReport.Name);
+        Assert.Equal("com.example.sample", snapshotReport.CaptureDiagnostics.MatchedReport.BundleId);
+        Assert.Equal(expectedProcessId, snapshotReport.CaptureDiagnostics.MatchedReport.ProcessId);
 
         // List of crash reports is retrieved
         _processManager.Verify(

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/CrashSnapshotReporterTests.cs
@@ -52,9 +52,10 @@ public class CrashReportSnapshotTests : IDisposable
     }
 
     [Theory]
-    [InlineData("{\"captureTime\":\"2026-08-24 14:00:00.00 +0200\",\"pid\":42,\"procName\":\"Sample-iPhone\",\"bundleInfo\":{\"CFBundleIdentifier\":\"com.example.sample\"}}", 42)]
-    [InlineData("{", null)]
-    public async Task DeviceCaptureTest(string payload, int? expectedProcessId)
+    [InlineData("{\"captureTime\":\"2026-08-24 14:00:00.00 +0200\",\"pid\":42,\"procName\":\"Sample-iPhone\",\"bundleInfo\":{\"CFBundleIdentifier\":\"com.example.sample\"}}", 42, false)]
+    [InlineData("{\"captureTime\":\"2026-08-24 14:00:00.00 +0200\",\"pid\":42,\"procName\":\"Sample-iPhone\",\"bundleInfo\":{\"CFBundleIdentifier\":\"com.example.sample\"}}", 42, true)]
+    [InlineData("{", null, false)]
+    public async Task DeviceCaptureTest(string payload, int? expectedProcessId, bool headerHasBom)
     {
         var tempFilePath = Path.GetTempFileName();
 
@@ -95,9 +96,12 @@ public class CrashReportSnapshotTests : IDisposable
         await snapshotReport.StartCaptureAsync();
 
         File.WriteAllLines(tempFilePath, new[] { "Sample-iPhone" });
+        string header =
+            "{\"app_name\":\"Sample-iPhone\",\"timestamp\":\"2026-08-24 14:00:00.00 +0200\",\"bundleID\":\"com.example.sample\",\"bug_type\":\"309\"}";
         File.WriteAllText(
             crashLogPath,
-            "{\"app_name\":\"Sample-iPhone\",\"timestamp\":\"2026-08-24 14:00:00.00 +0200\",\"bundleID\":\"com.example.sample\",\"bug_type\":\"309\"}" +
+            (headerHasBom ? "\uFEFF" : string.Empty) +
+            header +
             Environment.NewLine +
             payload);
 

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/ResultFileHandlerTests.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.DotNet.XHarness.Common.Execution;
@@ -177,83 +175,6 @@ public class ResultFileHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task CopyCrashReportUsesHelixUploadRootWhenAvailable()
-    {
-        // Skip on Windows as mlaunch is not available
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return;
-        }
-
-        string originalUploadRoot = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
-        string uploadRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        Directory.CreateDirectory(uploadRoot);
-
-        try
-        {
-            Environment.SetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT", uploadRoot);
-
-            Mock<IMlaunchProcessManager> pm = new Mock<IMlaunchProcessManager>();
-            Mock<IFileBackedLog> log = new Mock<IFileBackedLog>();
-            ResultFileHandler handler = CreateHandler(pm, log);
-
-            string crashReportName = "MyApp-2025-11-25-223847.ips";
-            string expectedDownloadPath = Path.Combine(uploadRoot, crashReportName);
-            string crashContent = "Dummy crash content";
-            string actualDownloadPath = null;
-
-            int callCount = 0;
-
-            pm.Setup(m => m.ExecuteCommandAsync(
-                    It.IsAny<MlaunchArguments>(),
-                    It.IsAny<ILog>(),
-                    It.IsAny<TimeSpan>(),
-                    It.IsAny<Dictionary<string, string>>(),
-                    It.IsAny<int>(),
-                    It.IsAny<CancellationToken?>()))
-                .Returns((MlaunchArguments args, ILog _, TimeSpan _, Dictionary<string, string> _, int _, CancellationToken? _) =>
-                {
-                    callCount++;
-                    if (callCount == 1)
-                    {
-                        string listFilePath = GetArgumentValue(args, "list-crash-reports");
-                        File.WriteAllLines(listFilePath, new[] { crashReportName });
-                    }
-                    else if (callCount == 2)
-                    {
-                        actualDownloadPath = GetArgumentValue(args, "download-crash-report-to");
-                        File.WriteAllText(actualDownloadPath, crashContent);
-                    }
-
-                    return Task.FromResult(new ProcessExecutionResult { ExitCode = 0 });
-                });
-
-            var appInfo = new AppBundleInformation("MyApp", "com.example.myapp", "/tmp", "/tmp", supports32b: false);
-
-            await handler.CopyCrashReportAsync("device-udid", null, appInfo, log.Object, isSimulator: false);
-
-            Assert.Equal(expectedDownloadPath, actualDownloadPath);
-            Assert.True(File.Exists(expectedDownloadPath));
-
-            log.Verify(l => l.WriteLine("Attempting to retrieve crash report from device..."), Times.Once);
-            log.Verify(l => l.WriteLine($"Found crash report: {crashReportName}"), Times.Once);
-            log.Verify(l => l.WriteLine("==================== Crash report ===================="), Times.Once);
-            log.Verify(l => l.WriteLine($"Crash report file: {expectedDownloadPath}"), Times.Once);
-            log.Verify(l => l.WriteLine(crashContent), Times.Once);
-            log.Verify(l => l.WriteLine("==================== End of Crash report ===================="), Times.Once);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT", originalUploadRoot);
-
-            if (Directory.Exists(uploadRoot))
-            {
-                Directory.Delete(uploadRoot, true);
-            }
-        }
-    }
-
-    [Fact]
     public async Task CopyResultsAsync_WhenFirstAttemptFailsAndSecondSucceeds_ReturnsTrue()
     {
         Mock<IMlaunchProcessManager> pm = new Mock<IMlaunchProcessManager>();
@@ -290,6 +211,7 @@ public class ResultFileHandlerTests : IDisposable
 
         Assert.True(result);
         Assert.Equal(2, callCount);
+        Assert.Equal(2, handler.LastCopyAttempts);
         log.Verify(l => l.WriteLine(It.Is<string>(s => s.Contains("Retrying results file copy (attempt 2)"))), Times.Once);
     }
 
@@ -326,6 +248,7 @@ public class ResultFileHandlerTests : IDisposable
         Assert.False(result);
         // 1 initial attempt + 2 retries = 3 total
         Assert.Equal(3, callCount);
+        Assert.Equal(3, handler.LastCopyAttempts);
         log.Verify(l => l.WriteLine(It.Is<string>(s => s.Contains("Retrying results file copy (attempt 2)"))), Times.Once);
         log.Verify(l => l.WriteLine(It.Is<string>(s => s.Contains("Retrying results file copy (attempt 3)"))), Times.Once);
     }
@@ -403,12 +326,4 @@ public class ResultFileHandlerTests : IDisposable
         Assert.Contains("coverage.cobertura.xml", command);
     }
 
-    private static string GetArgumentValue(MlaunchArguments args, string argumentName)
-    {
-        string prefix = $"--{argumentName}=";
-        string argument = args.Select(a => a.AsCommandLineArgument())
-            .First(a => a.StartsWith(prefix, StringComparison.Ordinal));
-
-        return argument.Substring(prefix.Length).Trim('"');
-    }
 }

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
@@ -20,6 +20,7 @@ public class TestExecutingResultTests
             TestExecutingResult.LaunchFailure,
             TestExecutingResult.BuildFailure,
             TestExecutingResult.LaunchTimedOut,
+            TestExecutingResult.AppExitedBeforeTestStart,
             TestExecutingResult.Failed,
         },
         TestExecutingResult.Failed

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestExecutingResultTests.cs
@@ -21,6 +21,7 @@ public class TestExecutingResultTests
             TestExecutingResult.BuildFailure,
             TestExecutingResult.LaunchTimedOut,
             TestExecutingResult.AppExitedBeforeTestStart,
+            TestExecutingResult.TestResultsMissing,
             TestExecutingResult.Failed,
         },
         TestExecutingResult.Failed

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -509,7 +509,7 @@ public class TestReporterTests : IDisposable
     }
 
     [Fact]
-    public async Task ParseResult_WhenAppExitsBeforeProtocolWithoutCrashReport_ReturnsEarlyExit()
+    public async Task ParseResult_WhenAppExitsWithoutTestStart_ReturnsEarlyExit()
     {
         var listenerLog = Mock.Of<IFileBackedLog>(l => l.FullPath == "/this/path/does/not/exist");
         _listener.Setup(l => l.TestLog).Returns(listenerLog);
@@ -525,10 +525,27 @@ public class TestReporterTests : IDisposable
     }
 
     [Fact]
+    public async Task ParseResult_WhenProtocolConnectsButResultsAreMissing_ReturnsResultsMissing()
+    {
+        var listenerLog = Mock.Of<IFileBackedLog>(l => l.FullPath == "/this/path/does/not/exist");
+        _listener.Setup(l => l.TestLog).Returns(listenerLog);
+        _listener.Setup(l => l.ConnectedTask).Returns(Task.FromResult(true));
+
+        var testReporter = BuildTestReporter();
+        await testReporter.CollectDeviceResult(new ProcessExecutionResult { ExitCode = 1 });
+
+        var (result, resultMessage) = await testReporter.ParseResult();
+
+        Assert.Equal(TestExecutingResult.TestResultsMissing, result);
+        Assert.Contains("no test results were reported", resultMessage);
+    }
+
+    [Fact]
     public async Task ParseResult_WhenAppExitsWithMatchingCrashReport_ReturnsCrashed()
     {
         var listenerLog = Mock.Of<IFileBackedLog>(l => l.FullPath == "/this/path/does/not/exist");
         _listener.Setup(l => l.TestLog).Returns(listenerLog);
+        _listener.Setup(l => l.ConnectedTask).Returns(Task.FromResult(true));
         string mainLogPath = Path.Combine(_logsDirectory, "main.log");
         File.WriteAllText(mainLogPath, string.Empty);
         _mainLog.SetupGet(l => l.FullPath).Returns(mainLogPath);

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/TestReporterTests.cs
@@ -35,12 +35,14 @@ public class TestReporterTests : IDisposable
     public TestReporterTests()
     {
         _crashReporter = new Mock<ICrashSnapshotReporter>();
+        _crashReporter.SetupGet(r => r.CaptureDiagnostics).Returns(new AppleCrashReportDiagnostics());
         _processManager = new Mock<IMlaunchProcessManager>();
         _parser = new XmlResultParser();
         _runLog = new Mock<IReadableLog>();
         _mainLog = new Mock<IFileBackedLog>();
         _logs = new Mock<ILogs>();
         _listener = new Mock<ISimpleListener>();
+        _listener.Setup(l => l.ConnectedTask).Returns(Task.FromResult(false));
         _appInformation = new AppBundleInformation(
             appName: "test app",
             bundleIdentifier: "my.id.com",
@@ -504,5 +506,49 @@ public class TestReporterTests : IDisposable
         _mainLog.Verify(l => l.WriteLine(It.Is<string>(s => s.Contains("Test run completed but results file was not available"))), Times.Once);
         // Crash reporter should be called with 0 delay since tests succeeded
         _crashReporter.Verify(c => c.EndCaptureAsync(It.Is<TimeSpan>(t => t.TotalSeconds == 0)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ParseResult_WhenAppExitsBeforeProtocolWithoutCrashReport_ReturnsEarlyExit()
+    {
+        var listenerLog = Mock.Of<IFileBackedLog>(l => l.FullPath == "/this/path/does/not/exist");
+        _listener.Setup(l => l.TestLog).Returns(listenerLog);
+
+        var testReporter = BuildTestReporter();
+        await testReporter.CollectDeviceResult(new ProcessExecutionResult { ExitCode = 1 });
+
+        var (result, resultMessage) = await testReporter.ParseResult();
+
+        Assert.Equal(TestExecutingResult.AppExitedBeforeTestStart, result);
+        Assert.Contains("no matching crash report", resultMessage);
+        _crashReporter.Verify(c => c.EndCaptureAsync(TimeSpan.FromSeconds(30)), Times.Once);
+    }
+
+    [Fact]
+    public async Task ParseResult_WhenAppExitsWithMatchingCrashReport_ReturnsCrashed()
+    {
+        var listenerLog = Mock.Of<IFileBackedLog>(l => l.FullPath == "/this/path/does/not/exist");
+        _listener.Setup(l => l.TestLog).Returns(listenerLog);
+        string mainLogPath = Path.Combine(_logsDirectory, "main.log");
+        File.WriteAllText(mainLogPath, string.Empty);
+        _mainLog.SetupGet(l => l.FullPath).Returns(mainLogPath);
+        _crashReporter
+            .SetupGet(r => r.CaptureDiagnostics)
+            .Returns(new AppleCrashReportDiagnostics
+            {
+                MatchedReport = new AppleCrashReportMetadata
+                {
+                    Name = "test-app.ips",
+                    MatchReason = "bundle identifier",
+                },
+            });
+
+        var testReporter = BuildTestReporter();
+        await testReporter.CollectDeviceResult(new ProcessExecutionResult { ExitCode = 1 });
+
+        var (result, resultMessage) = await testReporter.ParseResult();
+
+        Assert.Equal(TestExecutingResult.Crashed, result);
+        Assert.Contains("test-app.ips", resultMessage);
     }
 }


### PR DESCRIPTION
Fixes #1685

## Why

Apple test runs could report `APP_CRASH` even when there was no evidence that the launched app crashed. XHarness selected the latest available `.ips` report, which could be stale, belong to another application, or predate the current run.

This made CI failures misleading and obscured the more actionable condition: the app launched and exited before producing test results, with no matching crash report.

## What changed

- Snapshot crash reports before launch and compare them after exit.
- Consider only reports created during the current run.
- Match reports using the bundle identifier or executable/process name.
- Parse both modern `.ips` JSON and legacy Apple crash reports.
- Remove the unsafe fallback that selected the latest report.
- Preserve crash-report inventories and matched reports as diagnostics.
- Record launcher and application exit codes separately.
- Record whether a test protocol was expected and whether it connected, avoiding the previous ambiguity between listener connectivity and actual test execution.
- Record result-file copy attempts, expected path, end-signal state, and crash-report evidence.
- Add an `appleLaunch` section to `xharness-result.json`.
- Add `APP_EXITED_BEFORE_TEST_START` with exit code `93`; known TCP failures retain `TCP_CONNECTION_FAILED` (`92`).
- Add `TEST_RESULTS_MISSING` with exit code `94` for runs where the protocol connected but no results were produced.
- Reserve `APP_CRASH` for runs with a matching crash report.

The Apple diagnostics model remains in the Apple-specific assembly. Common only exposes a generic mechanism for platforms to append structured result sections, allowing Android and other targets to add their own diagnostics without depending on Apple concepts.

## Why removing `GetCrashReason` is not a loss of functionality

The previous crash-reason path looked as though it extracted an OS termination reason, but it was not connected to the reports collected during a test run:

- `TestReporter` enumerated a private `_crashLogs` collection that was never populated by `CrashSnapshotReporter`; the reporter wrote to a different `Logs` instance.
- Consequently, the `GetCrashReason` loop and its exception callback were not reached for downloaded crash reports.
- `GetCrashReason` expected an older JSON process-list shape (`processes/item/reason`), not the modern `.ips` or legacy crash-report formats handled by the crash reporter.

Removing this plumbing therefore does not remove diagnostics that were working in practice. The new path still inventories, downloads, preserves, matches, and symbolicates reports produced during the run. Extracting termination or exception reasons from actual modern and legacy crash-report fields can be added separately without reviving the disconnected parser.

## Result

Failures now distinguish between:

- a matching Apple crash report;
- a known TCP connection failure;
- an app that exits without test-startup evidence or matching crash evidence; and
- a connected test protocol that never produces a results file.

This prevents stale reports from being attributed to the current run and gives CI triage enough structured evidence to identify the appropriate investigation path.

## Testing

- Apple orchestration and app-launch diagnostics
- Modern and legacy crash-report matching
- Missing, stale, unrelated, and BOM-prefixed crash reports
- Early-exit, missing-results, and confirmed-crash classification
- Protocol-connected crash-report precedence
- TCP failure precedence
- Pre-iOS 18 protocol and iOS 18 container-copy diagnostics
- Android summary compatibility

Repository build completed with 0 warnings and 0 errors. All 64 focused tests pass.