### PR TITLE
Retry timed out Apple device listing

### DIFF
--- a/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
+++ b/src/Microsoft.DotNet.XHarness.iOS.Shared/Hardware/HardwareDeviceLoader.cs
@@ -39,7 +39,10 @@ public interface IHardwareDeviceLoader : IDeviceLoader
 
 public class HardwareDeviceLoader : IHardwareDeviceLoader
 {
+    private static readonly int[] DefaultDeviceListingRetryDelaysMs = { 5_000, 10_000 };
+
     private readonly IMlaunchProcessManager _processManager;
+    private readonly int[] _deviceListingRetryDelaysMs;
     private bool _loaded;
     private readonly BlockingEnumerableCollection<IHardwareDevice> _connectedDevices = new();
     private readonly SemaphoreSlim _semaphore = new(1);
@@ -53,8 +56,15 @@ public class HardwareDeviceLoader : IHardwareDeviceLoader
     public IEnumerable<IHardwareDevice> ConnectedxrOS => _connectedDevices.Where(x => x.DevicePlatform == DevicePlatform.xrOS);
 
     public HardwareDeviceLoader(IMlaunchProcessManager processManager)
+        : this(processManager, DefaultDeviceListingRetryDelaysMs)
+    {
+    }
+
+    internal HardwareDeviceLoader(IMlaunchProcessManager processManager, int[] deviceListingRetryDelaysMs)
     {
         _processManager = processManager ?? throw new ArgumentNullException(nameof(processManager));
+        _deviceListingRetryDelaysMs = deviceListingRetryDelaysMs?.ToArray()
+            ?? throw new ArgumentNullException(nameof(deviceListingRetryDelaysMs));
     }
 
     public async Task LoadDevices(
@@ -81,8 +91,9 @@ public class HardwareDeviceLoader : IHardwareDeviceLoader
         var tmpfile = Path.GetTempFileName();
         try
         {
-            using (var process = new Process())
+            for (int attempt = 0; ; attempt++)
             {
+                using var process = new Process();
                 var arguments = new MlaunchArguments(
                     new ListDevicesArgument(tmpfile),
                     new ListWirelessDevicesArgument(includeWirelessDevices),
@@ -94,45 +105,57 @@ public class HardwareDeviceLoader : IHardwareDeviceLoader
                     arguments.Add(new ListExtraDataArgument());
                 }
 
+                File.WriteAllText(tmpfile, string.Empty);
                 var task = _processManager.RunAsync(process, arguments, log, timeout: TimeSpan.FromSeconds(120), cancellationToken: cancellationToken);
                 log.WriteLine("Launching {0} {1}", process.StartInfo.FileName, process.StartInfo.Arguments);
 
                 var result = await task;
 
-                if (!result.Succeeded)
+                if (result.Succeeded)
+                {
+                    break;
+                }
+
+                if (!result.TimedOut || attempt == _deviceListingRetryDelaysMs.Length)
                 {
                     var reason = result.TimedOut ? "mlaunch timed out" : $"mlaunch exited with code {result.ExitCode}";
                     throw new Exception($"Failed to list devices: {reason}.");
                 }
 
-                var doc = new XmlDocument();
-                doc.LoadWithoutNetworkAccess(tmpfile);
+                int delayMs = _deviceListingRetryDelaysMs[attempt];
+                log.WriteLine(
+                    $"Device listing timed out. Retrying in {delayMs / 1000}s " +
+                    $"(attempt {attempt + 2}/{_deviceListingRetryDelaysMs.Length + 1})...");
+                await Task.Delay(delayMs, cancellationToken);
+            }
 
-                var devices = doc.SelectNodes("/MTouch/Device");
+            var doc = new XmlDocument();
+            doc.LoadWithoutNetworkAccess(tmpfile);
 
-                log.WriteLine($"Found {devices.Count} devices");
-                log.Flush();
+            var devices = doc.SelectNodes("/MTouch/Device");
 
-                foreach (XmlNode dev in devices)
+            log.WriteLine($"Found {devices.Count} devices");
+            log.Flush();
+
+            foreach (XmlNode dev in devices)
+            {
+                Device d = GetDevice(dev);
+                if (d == null)
                 {
-                    Device d = GetDevice(dev);
-                    if (d == null)
-                    {
-                        continue;
-                    }
-
-                    if (!includeLocked && d.IsLocked)
-                    {
-                        log.WriteLine($"Skipping device {d.Name} ({d.DeviceIdentifier}) because it's locked.");
-                        continue;
-                    }
-                    if (d.IsUsableForDebugging.HasValue && !d.IsUsableForDebugging.Value)
-                    {
-                        log.WriteLine($"Skipping device {d.Name} ({d.DeviceIdentifier}) because it's not usable for debugging.");
-                        continue;
-                    }
-                    _connectedDevices.Add(d);
+                    continue;
                 }
+
+                if (!includeLocked && d.IsLocked)
+                {
+                    log.WriteLine($"Skipping device {d.Name} ({d.DeviceIdentifier}) because it's locked.");
+                    continue;
+                }
+                if (d.IsUsableForDebugging.HasValue && !d.IsUsableForDebugging.Value)
+                {
+                    log.WriteLine($"Skipping device {d.Name} ({d.DeviceIdentifier}) because it's not usable for debugging.");
+                    continue;
+                }
+                _connectedDevices.Add(d);
             }
 
             _loaded = true;

--- a/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
+++ b/tests/Microsoft.DotNet.XHarness.iOS.Shared.Tests/Hardware/HardwareDeviceLoaderTests.cs
@@ -27,7 +27,7 @@ public class HardwareDeviceLoaderTests
     public HardwareDeviceLoaderTests()
     {
         _processManager = new Mock<IMlaunchProcessManager>();
-        _devices = new HardwareDeviceLoader(_processManager.Object);
+        _devices = new HardwareDeviceLoader(_processManager.Object, Array.Empty<int>());
         _executionLog = new Mock<ILog>();
     }
 
@@ -92,20 +92,7 @@ public class HardwareDeviceLoaderTests
                 processPath = p.StartInfo.FileName;
                 passedArguments = args;
 
-                // we get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
-                var tempPath = args.Where(a => a is ListDevicesArgument).First().AsCommandLineArgument();
-                tempPath = tempPath.Substring(tempPath.IndexOf('=') + 1).Replace("\"", string.Empty);
-
-                var name = GetType().Assembly.GetManifestResourceNames().Where(a => a.EndsWith("devices.xml", StringComparison.Ordinal)).FirstOrDefault();
-                using (var outputStream = new StreamWriter(tempPath))
-                using (var sampleStream = new StreamReader(GetType().Assembly.GetManifestResourceStream(name)))
-                {
-                    string line;
-                    while ((line = sampleStream.ReadLine()) != null)
-                    {
-                        outputStream.WriteLine(line);
-                    }
-                }
+                WriteSampleDeviceList(args);
                 return Task.FromResult(new ProcessExecutionResult { ExitCode = 0, TimedOut = false });
             });
 
@@ -137,6 +124,47 @@ public class HardwareDeviceLoaderTests
     }
 
     [Fact]
+    public async Task LoadDevicesRetriesTimedOutMlaunch()
+    {
+        var calls = 0;
+        var devices = new HardwareDeviceLoader(_processManager.Object, new[] { 0, 0 });
+
+        _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
+            .Returns<Process, MlaunchArguments, ILog, TimeSpan?, Dictionary<string, string>, int, CancellationToken?, bool?>((p, args, log, t, env, verbosity, token, d) =>
+            {
+                calls++;
+                if (calls < 3)
+                {
+                    return Task.FromResult(new ProcessExecutionResult { ExitCode = 137, TimedOut = true });
+                }
+
+                WriteSampleDeviceList(args);
+                return Task.FromResult(new ProcessExecutionResult { ExitCode = 0, TimedOut = false });
+            });
+
+        await devices.LoadDevices(_executionLog.Object);
+
+        Assert.Equal(3, calls);
+        Assert.NotEmpty(devices.ConnectedDevices);
+    }
+
+    [Fact]
+    public async Task LoadDevicesDoesNotRetryMlaunchExitFailure()
+    {
+        var devices = new HardwareDeviceLoader(_processManager.Object, new[] { 0, 0 });
+
+        _processManager.Setup(p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()))
+            .ReturnsAsync(new ProcessExecutionResult { ExitCode = 1, TimedOut = false });
+
+        var ex = await Assert.ThrowsAsync<Exception>(() => devices.LoadDevices(_executionLog.Object));
+
+        Assert.Contains("mlaunch exited with code 1", ex.Message);
+        _processManager.Verify(
+            p => p.RunAsync(It.IsAny<Process>(), It.IsAny<MlaunchArguments>(), It.IsAny<ILog>(), It.IsAny<TimeSpan?>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<int>(), It.IsAny<CancellationToken?>(), It.IsAny<bool?>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task FindAndCacheDevicesWithFailingMlaunchTest()
     {
         string processPath = null;
@@ -160,18 +188,7 @@ public class HardwareDeviceLoaderTests
                 processPath = p.StartInfo.FileName;
                 passedArguments = args;
 
-                // we get the temp file that was passed as the args, and write our sample xml, which will be parsed to get the devices :)
-                var tempPath = args.Where(a => a is ListDevicesArgument).First().AsCommandLineArgument();
-                tempPath = tempPath.Substring(tempPath.IndexOf('=') + 1).Replace("\"", string.Empty);
-
-                var name = GetType().Assembly.GetManifestResourceNames().Where(a => a.EndsWith("devices.xml", StringComparison.Ordinal)).FirstOrDefault();
-                using (var outputStream = new StreamWriter(tempPath))
-                using (var sampleStream = new StreamReader(GetType().Assembly.GetManifestResourceStream(name)))
-                {
-                    string line;
-                    while ((line = sampleStream.ReadLine()) != null)
-                        outputStream.WriteLine(line);
-                }
+                WriteSampleDeviceList(args);
                 return Task.FromResult(new ProcessExecutionResult { ExitCode = 0, TimedOut = false });
             });
 
@@ -186,5 +203,18 @@ public class HardwareDeviceLoaderTests
         Assert.Equal(2, calls);
         await _devices.LoadDevices(_executionLog.Object);
         Assert.Equal(2, calls);
+    }
+
+    private static void WriteSampleDeviceList(MlaunchArguments args)
+    {
+        var tempPath = args.OfType<ListDevicesArgument>().Single().AsCommandLineArgument();
+        tempPath = tempPath.Substring(tempPath.IndexOf('=') + 1).Replace("\"", string.Empty);
+
+        var resourceName = typeof(HardwareDeviceLoaderTests).Assembly
+            .GetManifestResourceNames()
+            .Single(name => name.EndsWith("devices.xml", StringComparison.Ordinal));
+        using var outputStream = new StreamWriter(tempPath);
+        using var sampleStream = new StreamReader(typeof(HardwareDeviceLoaderTests).Assembly.GetManifestResourceStream(resourceName));
+        outputStream.Write(sampleStream.ReadToEnd());
     }
 }


### PR DESCRIPTION
Retry physical Apple device enumeration when `mlaunch --listdev` reaches the existing 120-second timeout. Use two retries with 5-second and 10-second backoff, while preserving immediate failures for non-timeout exit codes.

This mitigates the transient device-listing hangs tracked by dotnet/runtime#125135.

Tests cover recovery after repeated timeouts and verify that non-timeout failures are not retried.