### PR TITLE
Temporarily disable Helix JobMonitor

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -1,6 +1,8 @@
 variables:
 - template: /eng/common-variables.yml
 - template: /eng/common/templates/variables/pool-providers.yml
+- name: enableHelixJobMonitor
+  value: false
 
 # CI and PR triggers
 trigger:
@@ -120,7 +122,8 @@ stages:
   displayName: E2E
   dependsOn: Build_OSX
   jobs:
-  - template: /eng/common/core-templates/job/helix-job-monitor.yml
+  - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
+    - template: /eng/common/core-templates/job/helix-job-monitor.yml
 
   - template: eng/e2e-test.yml
     parameters:

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
           --projects ${{ parameters.testProject }}
           --warnAsError false
           /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/${{ parameters.name }}.binlog
-          /p:EnableHelixJobMonitor=true
+          /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
           /p:RestoreUsingNuGetTargets=false
         displayName: Run tests in Helix
         env:


### PR DESCRIPTION
Temporarily disable JobMonitor to reduce ADO load while investigating Helix test result publishing failures.

The new `enableHelixJobMonitor` pipeline variable defaults to `false`. Setting it to `true` restores the existing behavior: the monitor job is scheduled and Helix submissions opt into JobMonitor.

ADO work item: [dnceng/internal#12380](https://dev.azure.com/dnceng/internal/_workitems/edit/12380)