### PR TITLE
Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26421.2",
+      "version": "11.0.0-beta.26427.10",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -1,8 +1,6 @@
 variables:
 - template: /eng/common-variables.yml
 - template: /eng/common/templates/variables/pool-providers.yml
-- name: enableHelixJobMonitor
-  value: false
 
 # CI and PR triggers
 trigger:
@@ -122,8 +120,7 @@ stages:
   displayName: E2E
   dependsOn: Build_OSX
   jobs:
-  - ${{ if eq(variables['enableHelixJobMonitor'], true) }}:
-    - template: /eng/common/core-templates/job/helix-job-monitor.yml
+  - template: /eng/common/core-templates/job/helix-job-monitor.yml
 
   - template: eng/e2e-test.yml
     parameters:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,9 +11,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>51abc19095ae366ecb773826993966dc8a1063eb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26421.2">
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>51abc19095ae366ecb773826993966dc8a1063eb</Sha>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/e2e-test.yml
+++ b/eng/e2e-test.yml
@@ -39,7 +39,7 @@ jobs:
           --projects ${{ parameters.testProject }}
           --warnAsError false
           /bl:$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/${{ parameters.name }}.binlog
-          /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+          /p:EnableHelixJobMonitor=true
           /p:RestoreUsingNuGetTargets=false
         displayName: Run tests in Helix
         env:


### PR DESCRIPTION
Updates Microsoft.DotNet.Helix.JobMonitor to the fixed `11.0.0-beta.26427.10` build and refreshes its dependency metadata.

Also restores the monitor behavior temporarily disabled by #1703.

Published by: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358