### PR TITLE
Use GPT-5.6 Luna for PAT validation

### DIFF
--- a/.github/workflows/validate-pat-pool.yml
+++ b/.github/workflows/validate-pat-pool.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       VALIDATE_PAT: |
         if [ -z "$COPILOT_GITHUB_TOKEN" ]; then echo "status=empty" >> "$GITHUB_OUTPUT"; exit 0; fi
-        set +e; timeout 30 copilot --prompt "Say OK" --available-tools="" --silent --effort=low; rc=$?; set -e
+        set +e; timeout 30 copilot --model gpt-5.6-luna --prompt "Say OK" --available-tools="" --silent --effort=low; rc=$?; set -e
         if [ $rc -eq 0 ]; then echo "status=valid" >> "$GITHUB_OUTPUT"
         elif [ $rc -eq 124 ]; then echo "status=unknown" >> "$GITHUB_OUTPUT"
         else echo "status=invalid" >> "$GITHUB_OUTPUT"; fi


### PR DESCRIPTION
## Summary

- Pin PAT validation to `gpt-5.6-luna` with low reasoning effort.
- Keep the validation prompt lightweight while using a model that supports the configured effort level.

## Validation

- `git diff --check`
- YAML parse check passed.
- Live PAT validation was not run locally because the workflow's Actions credentials are not available in the local environment.